### PR TITLE
fix(intake): stop believing bot-authored lifecycle labels

### DIFF
--- a/plugins/lisa-agy/scripts/lifecycle-label-trust.mjs
+++ b/plugins/lisa-agy/scripts/lifecycle-label-trust.mjs
@@ -225,14 +225,22 @@ export function terminalLifecycleLabels(config) {
  * issue #2539 describes, where only the auto-complete direction was ever
  * repaired and the reverse rotted unobserved.
  *
+ * `excludeLabels` removes labels from consideration entirely. Callers MUST pass
+ * the untrusted set here: `open-label-closed-state` is a repair direction that
+ * WRITES (it advances the label to the terminal `done` role), so without this a
+ * bot-applied label the classifier just refused to believe would still drive a
+ * real label write — the guard would launder the very input it rejected.
+ *
  * @param {{
  *   readonly labels?: readonly (string | { readonly name?: string })[]
  *   readonly state?: string
  *   readonly terminalLabels?: readonly string[]
+ *   readonly excludeLabels?: readonly string[]
  * }} input
  * @returns {{
  *   readonly drifts: readonly { direction: string, label: string }[]
  *   readonly directionsWalked: readonly string[]
+ *   readonly excluded: readonly string[]
  * }}
  */
 export function detectLifecycleDrift(input = {}) {
@@ -241,12 +249,23 @@ export function detectLifecycleDrift(input = {}) {
       String(label).trim().toLowerCase()
     )
   );
+  const excluded = new Set(
+    (Array.isArray(input.excludeLabels) ? input.excludeLabels : []).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
   const closed =
     String(input.state ?? "")
       .trim()
       .toLowerCase() === "closed";
-  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+  const allLifecycleLabels = normalizeLabelNames(input.labels).filter(
     isLifecycleLabel
+  );
+  const skipped = allLifecycleLabels.filter(label =>
+    excluded.has(label.trim().toLowerCase())
+  );
+  const lifecycleLabels = allLifecycleLabels.filter(
+    label => !excluded.has(label.trim().toLowerCase())
   );
 
   const drifts = lifecycleLabels.flatMap(label => {
@@ -260,7 +279,11 @@ export function detectLifecycleDrift(input = {}) {
     return [];
   });
 
-  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+  return {
+    drifts,
+    directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS,
+    excluded: skipped,
+  };
 }
 
 /**
@@ -450,10 +473,14 @@ async function main() {
     issueAuthor: issue.user ?? issue.author,
     windowSeconds: payload.windowSeconds,
   });
+  // Untrusted labels are excluded here rather than at the call site: the
+  // `open-label-closed-state` direction WRITES, so a caller that forgot to pass
+  // them would launder a label the classifier just rejected into a real write.
   const drift = detectLifecycleDrift({
     labels: issue.labels,
     state: issue.state,
     terminalLabels: terminalLifecycleLabels(payload.config),
+    excludeLabels: trust.untrusted.map(entry => entry.label),
   });
 
   process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);

--- a/plugins/lisa-agy/scripts/lifecycle-label-trust.mjs
+++ b/plugins/lisa-agy/scripts/lifecycle-label-trust.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+/**
+ * Lifecycle-label trust resolution — the read-side guard for #2539.
+ *
+ * ## The defect
+ *
+ * `coderabbitai[bot]` stamps a `status:*` label on issues seconds after they are
+ * filed. Measured across CodySwannGT/lisa#2460–#2540, seven of eight bot-applied
+ * lifecycle labels landed 26–118s after creation — far too fast to be a real
+ * claim. An issue wearing a bot-applied `status:in-progress` is invisible to
+ * build-intake (it is not the `ready` role) AND looks handled to a human, so
+ * nothing re-examines it. A MISSING lifecycle label is recoverable; a WRONG one
+ * is silent in both directions at once.
+ *
+ * ## Why this guard reads instead of writes
+ *
+ * The label is applied by a webhook after the fact, so no pre-tool check on this
+ * machine has anything to intercept — the write never passes through us. The two
+ * remaining options were a reconciler that reverts the label, and this: intake
+ * refusing to BELIEVE the label. The reconciler was rejected because the bot
+ * re-applies on every subsequent review event, so reverting produces a label-flap
+ * loop that is worse than the disease. Distrust is idempotent, cannot race, and
+ * writes nothing — nothing in this module mutates a tracker.
+ *
+ * ## Why actor alone is not enough
+ *
+ * #2470 (false claim, 27s) and #2494 (real, 3001s) were BOTH applied by
+ * `coderabbitai[bot]`. Rejecting every bot-authored lifecycle label would
+ * discard the true one; rejecting every fast label would discard the human
+ * `status:ready` applied at filing time, which is the queue's entry signal.
+ * Distrust therefore requires BOTH conditions: a bot actor AND a latency below
+ * the plausibility window.
+ *
+ * ## Why the member set is never hardcoded
+ *
+ * The live `status:*` family has drifted 7 → 6 members. A pinned literal breaks
+ * silently — an unrecognised member simply fails to match, so the guard reports
+ * clean on exactly the case it stopped covering. Membership is decided by the
+ * `status:` PREFIX and terminality is resolved from live config.
+ */
+
+/** Lifecycle labels are identified by this prefix, never by a pinned set. */
+export const LIFECYCLE_LABEL_PREFIX = "status:";
+
+/**
+ * Fallback terminal label used only when config supplies no `done` role.
+ *
+ * This module ships standalone into host projects and cannot import Lisa's
+ * TypeScript `BUILD_LABEL_DEFAULTS`, so the literal is repeated here — but it is
+ * NOT free to drift: `lifecycle-label-trust.test.ts` asserts it stays equal to
+ * `BUILD_LABEL_DEFAULTS.done.production` in `src/sync/lifecycle-defaults.ts`.
+ * This is a fallback only; a configured project resolves the value live.
+ */
+export const DEFAULT_TERMINAL_LIFECYCLE_LABEL = "status:done";
+
+/**
+ * Seconds below which a BOT-applied lifecycle label is not believable as a claim.
+ *
+ * Calibrated against measurement, not taste: the observed false bot claims
+ * clustered at 26–118s, while the one corroborated bot label landed at 3001s.
+ * 300s sits an order of magnitude above the noise and an order of magnitude
+ * below the real signal, so neither edge is close to the boundary.
+ */
+export const IMPLAUSIBLE_CLAIM_WINDOW_SECONDS = 300;
+
+/**
+ * Both directions a lifecycle label can contradict native state.
+ *
+ * Emitted on every drift result so a repair pass cannot walk one direction and
+ * silently leave the other accumulating — the asymmetry that let TUN-556 and
+ * TUN-503 sit on a terminal `status:done` while still natively open.
+ */
+export const LIFECYCLE_DRIFT_DIRECTIONS = [
+  "terminal-label-open-state",
+  "open-label-closed-state",
+];
+
+/**
+ * @typedef {{ readonly login?: string, readonly type?: string }} Actor
+ *
+ * @typedef {{
+ *   readonly event?: string
+ *   readonly label?: { readonly name?: string }
+ *   readonly actor?: Actor | null
+ *   readonly created_at?: string
+ * }} TimelineEvent
+ *
+ * @typedef {{
+ *   readonly label: string
+ *   readonly actor: string | null
+ *   readonly latencySeconds: number | null
+ *   readonly reason: string
+ *   readonly trusted: boolean
+ * }} EvaluatedLabel
+ */
+
+/**
+ * Is this label part of the lifecycle namespace?
+ *
+ * Prefix-only by design — see the module preamble on set drift. `status:` with
+ * no member is still lifecycle-namespaced and must not fall through as taxonomy.
+ *
+ * @param {unknown} name
+ * @returns {boolean}
+ */
+export function isLifecycleLabel(name) {
+  if (typeof name !== "string") {
+    return false;
+  }
+  return name.trim().toLowerCase().startsWith(LIFECYCLE_LABEL_PREFIX);
+}
+
+/**
+ * Is this timeline actor a bot?
+ *
+ * Checks GitHub's first-class `type` discriminator first, then falls back to the
+ * `[bot]` login suffix so an actor payload lacking `type` is still classified.
+ * A missing actor is NOT a bot: unattributable is handled separately, and
+ * guessing "bot" there would silently drop legitimate labels.
+ *
+ * @param {Actor | null | undefined} actor
+ * @returns {boolean}
+ */
+export function isBotActor(actor) {
+  if (!actor || typeof actor !== "object") {
+    return false;
+  }
+  if (typeof actor.type === "string" && actor.type.toLowerCase() === "bot") {
+    return true;
+  }
+  return (
+    typeof actor.login === "string" &&
+    actor.login.trim().toLowerCase().endsWith("[bot]")
+  );
+}
+
+/**
+ * Resolve which of an item's lifecycle labels intake is entitled to believe.
+ *
+ * Read-only and total: every lifecycle label on the item lands in exactly one of
+ * `trusted` or `untrusted`, and `evaluated` carries the reasoning for all of
+ * them so a distrust decision is auditable rather than invisible.
+ *
+ * Provenance that cannot be established (a label applied at creation, which
+ * GitHub records no `labeled` event for) is TRUSTED but reported in
+ * `unknownProvenance`. Failing closed there would make intake ignore the
+ * human `status:ready` that opens the queue, stalling every project — so the
+ * blind spot is surfaced rather than guessed at. Supplying `issueAuthor` closes
+ * it, by attributing creation-time labels to whoever filed the item.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly timeline?: readonly TimelineEvent[]
+ *   readonly issueCreatedAt?: string
+ *   readonly issueAuthor?: Actor | null
+ *   readonly windowSeconds?: number
+ * }} input
+ * @returns {{
+ *   readonly trusted: readonly string[]
+ *   readonly untrusted: readonly Omit<EvaluatedLabel, "trusted">[]
+ *   readonly unknownProvenance: readonly string[]
+ *   readonly evaluated: readonly EvaluatedLabel[]
+ *   readonly hasUntrustedLifecycleLabels: boolean
+ * }}
+ */
+export function resolveTrustedLifecycleLabels(input = {}) {
+  const windowSeconds = normalizeWindow(input.windowSeconds);
+  const createdAtMs = parseTimestamp(input.issueCreatedAt);
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+  const latestApplication = indexLatestLabelApplications(input.timeline);
+
+  const evaluated = lifecycleLabels.map(label =>
+    evaluateLabel({
+      label,
+      application: latestApplication.get(label.trim().toLowerCase()),
+      createdAtMs,
+      issueAuthor: input.issueAuthor,
+      windowSeconds,
+    })
+  );
+
+  return {
+    trusted: evaluated.filter(entry => entry.trusted).map(entry => entry.label),
+    untrusted: evaluated
+      .filter(entry => !entry.trusted)
+      .map(({ trusted: _trusted, ...rest }) => rest),
+    unknownProvenance: evaluated
+      .filter(entry => entry.reason === "provenance-unknown")
+      .map(entry => entry.label),
+    evaluated,
+    hasUntrustedLifecycleLabels: evaluated.some(entry => !entry.trusted),
+  };
+}
+
+/**
+ * The lifecycle labels that mean "this work is finished", read from live config.
+ *
+ * Only the PRODUCTION rung of the `done` role is terminal. `status:on-dev` and
+ * `status:on-stg` are shipped-somewhere, not finished, and closing on them would
+ * retire work that still has environments to clear.
+ *
+ * @param {unknown} config a parsed `.lisa.config.json`-shaped object
+ * @returns {readonly string[]}
+ */
+export function terminalLifecycleLabels(config) {
+  const done = readPath(config, ["github", "labels", "build", "done"]);
+
+  if (typeof done === "string" && done.trim().length > 0) {
+    return [done.trim()];
+  }
+  const production = readPath(done, ["production"]);
+  if (typeof production === "string" && production.trim().length > 0) {
+    return [production.trim()];
+  }
+  return [DEFAULT_TERMINAL_LIFECYCLE_LABEL];
+}
+
+/**
+ * Detect lifecycle labels that contradict native state, in BOTH directions.
+ *
+ * `directionsWalked` is always the full direction list, so a caller reporting
+ * "clean" is asserting it looked at both — the failure mode refinement #1 of
+ * issue #2539 describes, where only the auto-complete direction was ever
+ * repaired and the reverse rotted unobserved.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly state?: string
+ *   readonly terminalLabels?: readonly string[]
+ * }} input
+ * @returns {{
+ *   readonly drifts: readonly { direction: string, label: string }[]
+ *   readonly directionsWalked: readonly string[]
+ * }}
+ */
+export function detectLifecycleDrift(input = {}) {
+  const terminal = new Set(
+    (input.terminalLabels ?? terminalLifecycleLabels(undefined)).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
+  const closed =
+    String(input.state ?? "")
+      .trim()
+      .toLowerCase() === "closed";
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+
+  const drifts = lifecycleLabels.flatMap(label => {
+    const isTerminal = terminal.has(label.trim().toLowerCase());
+    if (isTerminal && !closed) {
+      return [{ direction: "terminal-label-open-state", label }];
+    }
+    if (!isTerminal && closed) {
+      return [{ direction: "open-label-closed-state", label }];
+    }
+    return [];
+  });
+
+  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+}
+
+/**
+ * Classify one lifecycle label against its most recent application.
+ *
+ * @param {{
+ *   label: string
+ *   application?: { actor?: Actor | null, createdAtMs: number | null }
+ *   createdAtMs: number | null
+ *   issueAuthor?: Actor | null
+ *   windowSeconds: number
+ * }} params
+ * @returns {EvaluatedLabel}
+ */
+function evaluateLabel(params) {
+  const { label, application, createdAtMs, issueAuthor, windowSeconds } =
+    params;
+
+  const actor = application ? application.actor : issueAuthor;
+  const hasProvenance = Boolean(application) || Boolean(issueAuthor);
+
+  if (!hasProvenance) {
+    return {
+      label,
+      actor: null,
+      latencySeconds: null,
+      reason: "provenance-unknown",
+      trusted: true,
+    };
+  }
+
+  const login = typeof actor?.login === "string" ? actor.login : null;
+
+  if (!isBotActor(actor)) {
+    return {
+      label,
+      actor: login,
+      latencySeconds: latencySeconds(createdAtMs, application),
+      reason: "human-actor",
+      trusted: true,
+    };
+  }
+
+  const latency = latencySeconds(createdAtMs, application);
+  const implausible = latency === null || latency < windowSeconds;
+
+  return {
+    label,
+    actor: login,
+    latencySeconds: latency,
+    reason: implausible
+      ? "bot-actor-implausible-latency"
+      : "bot-actor-plausible-latency",
+    trusted: !implausible,
+  };
+}
+
+/**
+ * Seconds between item creation and the label application.
+ *
+ * A creation-time label (no timeline event) is latency 0 by construction.
+ *
+ * @param {number | null} createdAtMs
+ * @param {{ createdAtMs: number | null } | undefined} application
+ * @returns {number | null}
+ */
+function latencySeconds(createdAtMs, application) {
+  if (createdAtMs === null) {
+    return null;
+  }
+  if (!application) {
+    return 0;
+  }
+  if (application.createdAtMs === null) {
+    return null;
+  }
+  return Math.max(
+    0,
+    Math.round((application.createdAtMs - createdAtMs) / 1000)
+  );
+}
+
+/**
+ * Map each lifecycle label to its MOST RECENT `labeled` event.
+ *
+ * Most-recent, not first: a human who removes the bot's label and re-applies it
+ * has made a genuine claim, and keying on the first application would keep
+ * distrusting a label the human now owns.
+ *
+ * @param {readonly TimelineEvent[] | undefined} timeline
+ * @returns {Map<string, { actor?: Actor | null, createdAtMs: number | null }>}
+ */
+function indexLatestLabelApplications(timeline) {
+  const index = new Map();
+
+  for (const event of Array.isArray(timeline) ? timeline : []) {
+    if (event?.event !== "labeled") {
+      continue;
+    }
+    const name = event.label?.name;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      continue;
+    }
+    const key = name.trim().toLowerCase();
+    const createdAtMs = parseTimestamp(event.created_at);
+    const existing = index.get(key);
+    if (
+      existing &&
+      existing.createdAtMs !== null &&
+      createdAtMs !== null &&
+      existing.createdAtMs > createdAtMs
+    ) {
+      continue;
+    }
+    index.set(key, { actor: event.actor ?? null, createdAtMs });
+  }
+
+  return index;
+}
+
+/**
+ * @param {readonly (string | { readonly name?: string })[] | undefined} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabelNames(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label => (typeof label === "string" ? label : label?.name))
+    .filter(name => typeof name === "string" && name.trim().length > 0);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function parseTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
+function normalizeWindow(value) {
+  return Number.isFinite(value) && value >= 0
+    ? Number(value)
+    : IMPLAUSIBLE_CLAIM_WINDOW_SECONDS;
+}
+
+/**
+ * @param {unknown} source
+ * @param {readonly string[]} keys
+ * @returns {unknown}
+ */
+function readPath(source, keys) {
+  return keys.reduce(
+    (current, key) =>
+      current && typeof current === "object" ? current[key] : undefined,
+    source
+  );
+}
+
+/**
+ * CLI: read a `{ issue, timeline, config }` payload on stdin, print the verdict.
+ *
+ * Exits 0 even when untrusted labels are found. This is a classifier, not a
+ * gate: callers run it inside `set -e` intake bash and branch on the JSON, and a
+ * non-zero exit would abort the scan on the very issues it exists to rescue.
+ *
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const payload = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+  const issue = payload.issue ?? {};
+
+  const trust = resolveTrustedLifecycleLabels({
+    labels: issue.labels,
+    timeline: payload.timeline,
+    issueCreatedAt: issue.created_at ?? issue.createdAt,
+    issueAuthor: issue.user ?? issue.author,
+    windowSeconds: payload.windowSeconds,
+  });
+  const drift = detectLifecycleDrift({
+    labels: issue.labels,
+    state: issue.state,
+    terminalLabels: terminalLifecycleLabels(payload.config),
+  });
+
+  process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
@@ -178,14 +178,38 @@ If none of the configured role labels exist on the repo → label convention not
 Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
 
 ```bash
-gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
-gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
-jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
-      --slurpfile c .lisa.config.json \
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE. Reading `$t[0]` would pass only page one,
+# silently dropping later label events — the newest of which is exactly the
+# application this classifier keys on. --slurp + `add` flattens all pages.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Resolve config the SAME way `read_role` does: the local file overrides the
+# global one key by key. Reading only `.lisa.config.json` would resolve a stale
+# terminal `done` label for any project that overrides it locally, and
+# `lisa-repair-intake` WRITES on the drift direction that mistake produces.
+# Both files are optional — a missing one must not abort the cycle.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
       '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
-  > /tmp/lisa-trust-input.json
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+The temp directory is **per invocation**. Fixed `/tmp/lisa-*.json` paths let two concurrent intake cycles interleave one issue's metadata with another's timeline, which yields a confident verdict about an item that was never examined.
 
 The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
 

--- a/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
@@ -168,6 +168,36 @@ gh label list --repo <org>/<repo> --json name \
 
 If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
 
+#### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
+
+**A `status:*` label is only a lifecycle signal if a trustworthy actor applied it.** Third-party GitHub Apps write labels through the same API humans do, and at least one — `coderabbitai[bot]` — stamps `status:*` on issues seconds after filing. Measured on CodySwannGT/lisa#2460–#2540: seven of eight bot-applied lifecycle labels landed 26–118s after creation. Those labels are guesses wearing the costume of the intake contract, and they break the queue in **both** directions:
+
+- a bot-applied **`$CLAIMED`** makes an unworked issue look like somebody's active work, so no cycle picks it up and no human re-examines it (#2470 sat unworked for a day this way);
+- a bot-applied **`$READY`** puts an issue into the build queue that no human ever flipped ready (#2538), inverting the gate the ready role exists to be.
+
+Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
+
+```bash
+gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
+jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
+      --slurpfile c .lisa.config.json \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > /tmp/lisa-trust-input.json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
+
+- a candidate whose `$READY` is **untrusted** is **not claimable** — skip it and leave it for a human to flip genuinely ready; report it in the summary rather than dispatching it;
+- a candidate whose `$CLAIMED` is **untrusted** is **not claimed** — if its `$READY` is trusted it stays a normal candidate, exactly as if the bot label were absent.
+
+**Never unlabel to correct this.** The bot re-applies its label on each subsequent review event, so reverting produces a label-flap loop that is worse than the defect. The guard is that intake stops *believing* the label; it writes nothing. Distrust is idempotent and cannot race.
+
+A label whose provenance cannot be established (applied at creation, which GitHub records no `labeled` event for) is trusted but listed in `unknownProvenance` — failing closed there would ignore the human `status:ready` that opens the queue. Report that list; do not silently drop it.
+
+Lifecycle membership is decided by the **`status:` prefix**, never by a pinned member list. The live family has drifted 7 → 6 members, and a literal set breaks silently: an unrecognised member simply fails to match, so the guard would report clean on exactly the case it stopped covering.
+
 ### Phase 3 — Process the first eligible ready issue
 
 #### 3a.0 Repo-scope gate (claim only current-repo issues)

--- a/plugins/lisa-agy/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-repair-intake/SKILL.md
@@ -560,6 +560,60 @@ native-open / active / unresolved:
 4. Post a compact `[lisa-repair-intake]` note only when the native close-out changed state or when
    an actionable setup error must be surfaced. Do not spam already-closed terminal items.
 
+### Lifecycle label contradicts native state — walk BOTH directions
+
+A lifecycle label can lie in two ways, and historically only one of them had an owner:
+
+| label | native state | owned by |
+|---|---|---|
+| terminal `done` role | still open / active | the `Build terminal-open` section above |
+| non-terminal role (`ready`, `claimed`, `blocked`, or any other `status:` member) | closed / completed | **nothing, until now** |
+
+A pass that walks one direction leaves the other accumulating silently. Measured on the Linear TUN
+board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still natively open in
+`On Dev`** — invisible to intake and indistinguishable from handled, exactly like a bot-applied
+`status:in-progress` on GitHub.
+
+Resolve both directions in one pass with the shipped detector, which always reports
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
+   Do not restate its rules; the terminality test lives there (intermediate env rungs like
+   `status:on-dev` / `status:on-stg` are **not** terminal).
+2. **`open-label-closed-state`** → the previously unowned direction. The item is natively closed or
+   completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
+   terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
+   **Lisa's own** lifecycle surface, not a contest with another writer.
+3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
+   `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
+   repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native
+   state as authoritative and remove the contradicting stale label; never move the state to match a
+   label.
+
+Membership in the lifecycle namespace is decided by the **`status:` prefix**, never a pinned member
+list — the live family has drifted 7 → 6 members, and a literal set fails silently by simply not
+matching the member it stopped covering.
+
+### Bot-authored lifecycle label → distrust, never revert (read-only)
+
+`status:*` labels written by a **bot** actor within the plausibility window of the item's creation are
+not lifecycle signals — see `lisa-github-build-intake` Phase 2b for the measurement and the
+classifier. Report them here so an operator can see how much of the board is wearing a label nobody
+chose:
+
+- list each item alongside the untrusted label, the bot login, and the latency, from the classifier's
+  `untrusted` array;
+- list `unknownProvenance` labels separately — trusted, but unattributable;
+- **do not unlabel and do not relabel.** The bot re-applies on each subsequent review event, so a
+  reverting reconciler produces a label-flap loop that is worse than the defect. Repair happens by
+  intake declining to *believe* the label, which is idempotent and writes nothing.
+
+This class is deliberately **read-only** and never counts toward the repair cap's actionable work.
+
 ### Build parent rollup reconciliation (intermediate-env or terminal close-out)
 
 For each parent/container item (an Epic, a Linear Project, or any item — of any type — with open child work),

--- a/plugins/lisa-agy/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-repair-intake/SKILL.md
@@ -575,11 +575,49 @@ board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still nat
 `status:in-progress` on GitHub.
 
 Resolve both directions in one pass with the shipped detector, which always reports
-`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined.
+
+**Build the classifier input inside this cycle. Never consume a temp file another skill wrote.**
+repair-intake runs as its own cycle, so borrowing `lisa-github-build-intake`'s scratch file fails
+two ways: absent, the redirect fails and `set -e` aborts the whole cycle; stale from an earlier run
+on a *different* item, the resolver classifies that other item and this section reports `drifts: []`
+while `directionsWalked` still claims both directions were walked. That is precisely the
+silent-clean verdict this section promises cannot happen.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE; --slurp + `add` flattens all of them so a
+# label event on page two is not silently dropped.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Same resolution `read_role` uses: local overrides global, both optional.
+# Resolving a stale terminal `done` here would make the true terminal label look
+# like `open-label-closed-state` — and that direction WRITES.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+**Untrusted labels are excluded from `drifts` before any repair runs** — the classifier does this
+itself, so repair must **never act on a label the classifier refused to believe**. Without it, a
+bot-applied label on a natively closed item would be advanced to the terminal `done` role by the
+`open-label-closed-state` repair, laundering the exact input the guard rejected into a real write.
+The `excluded` array reports what was held back; surface it, do not repair it.
 
 1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
    Do not restate its rules; the terminality test lives there (intermediate env rungs like
@@ -588,6 +626,9 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust
    completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
    terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
    **Lisa's own** lifecycle surface, not a contest with another writer.
+   Apply the leaf/container check from the **Lifecycle ownership guard** section *before* this
+   branch: repair-intake owns container repair, so a natively-closed `ready` **leaf** is skipped
+   here and left to the build lane rather than claimed by this pass.
 3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
    `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
    repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native

--- a/plugins/lisa-copilot/scripts/lifecycle-label-trust.mjs
+++ b/plugins/lisa-copilot/scripts/lifecycle-label-trust.mjs
@@ -225,14 +225,22 @@ export function terminalLifecycleLabels(config) {
  * issue #2539 describes, where only the auto-complete direction was ever
  * repaired and the reverse rotted unobserved.
  *
+ * `excludeLabels` removes labels from consideration entirely. Callers MUST pass
+ * the untrusted set here: `open-label-closed-state` is a repair direction that
+ * WRITES (it advances the label to the terminal `done` role), so without this a
+ * bot-applied label the classifier just refused to believe would still drive a
+ * real label write — the guard would launder the very input it rejected.
+ *
  * @param {{
  *   readonly labels?: readonly (string | { readonly name?: string })[]
  *   readonly state?: string
  *   readonly terminalLabels?: readonly string[]
+ *   readonly excludeLabels?: readonly string[]
  * }} input
  * @returns {{
  *   readonly drifts: readonly { direction: string, label: string }[]
  *   readonly directionsWalked: readonly string[]
+ *   readonly excluded: readonly string[]
  * }}
  */
 export function detectLifecycleDrift(input = {}) {
@@ -241,12 +249,23 @@ export function detectLifecycleDrift(input = {}) {
       String(label).trim().toLowerCase()
     )
   );
+  const excluded = new Set(
+    (Array.isArray(input.excludeLabels) ? input.excludeLabels : []).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
   const closed =
     String(input.state ?? "")
       .trim()
       .toLowerCase() === "closed";
-  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+  const allLifecycleLabels = normalizeLabelNames(input.labels).filter(
     isLifecycleLabel
+  );
+  const skipped = allLifecycleLabels.filter(label =>
+    excluded.has(label.trim().toLowerCase())
+  );
+  const lifecycleLabels = allLifecycleLabels.filter(
+    label => !excluded.has(label.trim().toLowerCase())
   );
 
   const drifts = lifecycleLabels.flatMap(label => {
@@ -260,7 +279,11 @@ export function detectLifecycleDrift(input = {}) {
     return [];
   });
 
-  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+  return {
+    drifts,
+    directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS,
+    excluded: skipped,
+  };
 }
 
 /**
@@ -450,10 +473,14 @@ async function main() {
     issueAuthor: issue.user ?? issue.author,
     windowSeconds: payload.windowSeconds,
   });
+  // Untrusted labels are excluded here rather than at the call site: the
+  // `open-label-closed-state` direction WRITES, so a caller that forgot to pass
+  // them would launder a label the classifier just rejected into a real write.
   const drift = detectLifecycleDrift({
     labels: issue.labels,
     state: issue.state,
     terminalLabels: terminalLifecycleLabels(payload.config),
+    excludeLabels: trust.untrusted.map(entry => entry.label),
   });
 
   process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);

--- a/plugins/lisa-copilot/scripts/lifecycle-label-trust.mjs
+++ b/plugins/lisa-copilot/scripts/lifecycle-label-trust.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+/**
+ * Lifecycle-label trust resolution — the read-side guard for #2539.
+ *
+ * ## The defect
+ *
+ * `coderabbitai[bot]` stamps a `status:*` label on issues seconds after they are
+ * filed. Measured across CodySwannGT/lisa#2460–#2540, seven of eight bot-applied
+ * lifecycle labels landed 26–118s after creation — far too fast to be a real
+ * claim. An issue wearing a bot-applied `status:in-progress` is invisible to
+ * build-intake (it is not the `ready` role) AND looks handled to a human, so
+ * nothing re-examines it. A MISSING lifecycle label is recoverable; a WRONG one
+ * is silent in both directions at once.
+ *
+ * ## Why this guard reads instead of writes
+ *
+ * The label is applied by a webhook after the fact, so no pre-tool check on this
+ * machine has anything to intercept — the write never passes through us. The two
+ * remaining options were a reconciler that reverts the label, and this: intake
+ * refusing to BELIEVE the label. The reconciler was rejected because the bot
+ * re-applies on every subsequent review event, so reverting produces a label-flap
+ * loop that is worse than the disease. Distrust is idempotent, cannot race, and
+ * writes nothing — nothing in this module mutates a tracker.
+ *
+ * ## Why actor alone is not enough
+ *
+ * #2470 (false claim, 27s) and #2494 (real, 3001s) were BOTH applied by
+ * `coderabbitai[bot]`. Rejecting every bot-authored lifecycle label would
+ * discard the true one; rejecting every fast label would discard the human
+ * `status:ready` applied at filing time, which is the queue's entry signal.
+ * Distrust therefore requires BOTH conditions: a bot actor AND a latency below
+ * the plausibility window.
+ *
+ * ## Why the member set is never hardcoded
+ *
+ * The live `status:*` family has drifted 7 → 6 members. A pinned literal breaks
+ * silently — an unrecognised member simply fails to match, so the guard reports
+ * clean on exactly the case it stopped covering. Membership is decided by the
+ * `status:` PREFIX and terminality is resolved from live config.
+ */
+
+/** Lifecycle labels are identified by this prefix, never by a pinned set. */
+export const LIFECYCLE_LABEL_PREFIX = "status:";
+
+/**
+ * Fallback terminal label used only when config supplies no `done` role.
+ *
+ * This module ships standalone into host projects and cannot import Lisa's
+ * TypeScript `BUILD_LABEL_DEFAULTS`, so the literal is repeated here — but it is
+ * NOT free to drift: `lifecycle-label-trust.test.ts` asserts it stays equal to
+ * `BUILD_LABEL_DEFAULTS.done.production` in `src/sync/lifecycle-defaults.ts`.
+ * This is a fallback only; a configured project resolves the value live.
+ */
+export const DEFAULT_TERMINAL_LIFECYCLE_LABEL = "status:done";
+
+/**
+ * Seconds below which a BOT-applied lifecycle label is not believable as a claim.
+ *
+ * Calibrated against measurement, not taste: the observed false bot claims
+ * clustered at 26–118s, while the one corroborated bot label landed at 3001s.
+ * 300s sits an order of magnitude above the noise and an order of magnitude
+ * below the real signal, so neither edge is close to the boundary.
+ */
+export const IMPLAUSIBLE_CLAIM_WINDOW_SECONDS = 300;
+
+/**
+ * Both directions a lifecycle label can contradict native state.
+ *
+ * Emitted on every drift result so a repair pass cannot walk one direction and
+ * silently leave the other accumulating — the asymmetry that let TUN-556 and
+ * TUN-503 sit on a terminal `status:done` while still natively open.
+ */
+export const LIFECYCLE_DRIFT_DIRECTIONS = [
+  "terminal-label-open-state",
+  "open-label-closed-state",
+];
+
+/**
+ * @typedef {{ readonly login?: string, readonly type?: string }} Actor
+ *
+ * @typedef {{
+ *   readonly event?: string
+ *   readonly label?: { readonly name?: string }
+ *   readonly actor?: Actor | null
+ *   readonly created_at?: string
+ * }} TimelineEvent
+ *
+ * @typedef {{
+ *   readonly label: string
+ *   readonly actor: string | null
+ *   readonly latencySeconds: number | null
+ *   readonly reason: string
+ *   readonly trusted: boolean
+ * }} EvaluatedLabel
+ */
+
+/**
+ * Is this label part of the lifecycle namespace?
+ *
+ * Prefix-only by design — see the module preamble on set drift. `status:` with
+ * no member is still lifecycle-namespaced and must not fall through as taxonomy.
+ *
+ * @param {unknown} name
+ * @returns {boolean}
+ */
+export function isLifecycleLabel(name) {
+  if (typeof name !== "string") {
+    return false;
+  }
+  return name.trim().toLowerCase().startsWith(LIFECYCLE_LABEL_PREFIX);
+}
+
+/**
+ * Is this timeline actor a bot?
+ *
+ * Checks GitHub's first-class `type` discriminator first, then falls back to the
+ * `[bot]` login suffix so an actor payload lacking `type` is still classified.
+ * A missing actor is NOT a bot: unattributable is handled separately, and
+ * guessing "bot" there would silently drop legitimate labels.
+ *
+ * @param {Actor | null | undefined} actor
+ * @returns {boolean}
+ */
+export function isBotActor(actor) {
+  if (!actor || typeof actor !== "object") {
+    return false;
+  }
+  if (typeof actor.type === "string" && actor.type.toLowerCase() === "bot") {
+    return true;
+  }
+  return (
+    typeof actor.login === "string" &&
+    actor.login.trim().toLowerCase().endsWith("[bot]")
+  );
+}
+
+/**
+ * Resolve which of an item's lifecycle labels intake is entitled to believe.
+ *
+ * Read-only and total: every lifecycle label on the item lands in exactly one of
+ * `trusted` or `untrusted`, and `evaluated` carries the reasoning for all of
+ * them so a distrust decision is auditable rather than invisible.
+ *
+ * Provenance that cannot be established (a label applied at creation, which
+ * GitHub records no `labeled` event for) is TRUSTED but reported in
+ * `unknownProvenance`. Failing closed there would make intake ignore the
+ * human `status:ready` that opens the queue, stalling every project — so the
+ * blind spot is surfaced rather than guessed at. Supplying `issueAuthor` closes
+ * it, by attributing creation-time labels to whoever filed the item.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly timeline?: readonly TimelineEvent[]
+ *   readonly issueCreatedAt?: string
+ *   readonly issueAuthor?: Actor | null
+ *   readonly windowSeconds?: number
+ * }} input
+ * @returns {{
+ *   readonly trusted: readonly string[]
+ *   readonly untrusted: readonly Omit<EvaluatedLabel, "trusted">[]
+ *   readonly unknownProvenance: readonly string[]
+ *   readonly evaluated: readonly EvaluatedLabel[]
+ *   readonly hasUntrustedLifecycleLabels: boolean
+ * }}
+ */
+export function resolveTrustedLifecycleLabels(input = {}) {
+  const windowSeconds = normalizeWindow(input.windowSeconds);
+  const createdAtMs = parseTimestamp(input.issueCreatedAt);
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+  const latestApplication = indexLatestLabelApplications(input.timeline);
+
+  const evaluated = lifecycleLabels.map(label =>
+    evaluateLabel({
+      label,
+      application: latestApplication.get(label.trim().toLowerCase()),
+      createdAtMs,
+      issueAuthor: input.issueAuthor,
+      windowSeconds,
+    })
+  );
+
+  return {
+    trusted: evaluated.filter(entry => entry.trusted).map(entry => entry.label),
+    untrusted: evaluated
+      .filter(entry => !entry.trusted)
+      .map(({ trusted: _trusted, ...rest }) => rest),
+    unknownProvenance: evaluated
+      .filter(entry => entry.reason === "provenance-unknown")
+      .map(entry => entry.label),
+    evaluated,
+    hasUntrustedLifecycleLabels: evaluated.some(entry => !entry.trusted),
+  };
+}
+
+/**
+ * The lifecycle labels that mean "this work is finished", read from live config.
+ *
+ * Only the PRODUCTION rung of the `done` role is terminal. `status:on-dev` and
+ * `status:on-stg` are shipped-somewhere, not finished, and closing on them would
+ * retire work that still has environments to clear.
+ *
+ * @param {unknown} config a parsed `.lisa.config.json`-shaped object
+ * @returns {readonly string[]}
+ */
+export function terminalLifecycleLabels(config) {
+  const done = readPath(config, ["github", "labels", "build", "done"]);
+
+  if (typeof done === "string" && done.trim().length > 0) {
+    return [done.trim()];
+  }
+  const production = readPath(done, ["production"]);
+  if (typeof production === "string" && production.trim().length > 0) {
+    return [production.trim()];
+  }
+  return [DEFAULT_TERMINAL_LIFECYCLE_LABEL];
+}
+
+/**
+ * Detect lifecycle labels that contradict native state, in BOTH directions.
+ *
+ * `directionsWalked` is always the full direction list, so a caller reporting
+ * "clean" is asserting it looked at both — the failure mode refinement #1 of
+ * issue #2539 describes, where only the auto-complete direction was ever
+ * repaired and the reverse rotted unobserved.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly state?: string
+ *   readonly terminalLabels?: readonly string[]
+ * }} input
+ * @returns {{
+ *   readonly drifts: readonly { direction: string, label: string }[]
+ *   readonly directionsWalked: readonly string[]
+ * }}
+ */
+export function detectLifecycleDrift(input = {}) {
+  const terminal = new Set(
+    (input.terminalLabels ?? terminalLifecycleLabels(undefined)).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
+  const closed =
+    String(input.state ?? "")
+      .trim()
+      .toLowerCase() === "closed";
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+
+  const drifts = lifecycleLabels.flatMap(label => {
+    const isTerminal = terminal.has(label.trim().toLowerCase());
+    if (isTerminal && !closed) {
+      return [{ direction: "terminal-label-open-state", label }];
+    }
+    if (!isTerminal && closed) {
+      return [{ direction: "open-label-closed-state", label }];
+    }
+    return [];
+  });
+
+  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+}
+
+/**
+ * Classify one lifecycle label against its most recent application.
+ *
+ * @param {{
+ *   label: string
+ *   application?: { actor?: Actor | null, createdAtMs: number | null }
+ *   createdAtMs: number | null
+ *   issueAuthor?: Actor | null
+ *   windowSeconds: number
+ * }} params
+ * @returns {EvaluatedLabel}
+ */
+function evaluateLabel(params) {
+  const { label, application, createdAtMs, issueAuthor, windowSeconds } =
+    params;
+
+  const actor = application ? application.actor : issueAuthor;
+  const hasProvenance = Boolean(application) || Boolean(issueAuthor);
+
+  if (!hasProvenance) {
+    return {
+      label,
+      actor: null,
+      latencySeconds: null,
+      reason: "provenance-unknown",
+      trusted: true,
+    };
+  }
+
+  const login = typeof actor?.login === "string" ? actor.login : null;
+
+  if (!isBotActor(actor)) {
+    return {
+      label,
+      actor: login,
+      latencySeconds: latencySeconds(createdAtMs, application),
+      reason: "human-actor",
+      trusted: true,
+    };
+  }
+
+  const latency = latencySeconds(createdAtMs, application);
+  const implausible = latency === null || latency < windowSeconds;
+
+  return {
+    label,
+    actor: login,
+    latencySeconds: latency,
+    reason: implausible
+      ? "bot-actor-implausible-latency"
+      : "bot-actor-plausible-latency",
+    trusted: !implausible,
+  };
+}
+
+/**
+ * Seconds between item creation and the label application.
+ *
+ * A creation-time label (no timeline event) is latency 0 by construction.
+ *
+ * @param {number | null} createdAtMs
+ * @param {{ createdAtMs: number | null } | undefined} application
+ * @returns {number | null}
+ */
+function latencySeconds(createdAtMs, application) {
+  if (createdAtMs === null) {
+    return null;
+  }
+  if (!application) {
+    return 0;
+  }
+  if (application.createdAtMs === null) {
+    return null;
+  }
+  return Math.max(
+    0,
+    Math.round((application.createdAtMs - createdAtMs) / 1000)
+  );
+}
+
+/**
+ * Map each lifecycle label to its MOST RECENT `labeled` event.
+ *
+ * Most-recent, not first: a human who removes the bot's label and re-applies it
+ * has made a genuine claim, and keying on the first application would keep
+ * distrusting a label the human now owns.
+ *
+ * @param {readonly TimelineEvent[] | undefined} timeline
+ * @returns {Map<string, { actor?: Actor | null, createdAtMs: number | null }>}
+ */
+function indexLatestLabelApplications(timeline) {
+  const index = new Map();
+
+  for (const event of Array.isArray(timeline) ? timeline : []) {
+    if (event?.event !== "labeled") {
+      continue;
+    }
+    const name = event.label?.name;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      continue;
+    }
+    const key = name.trim().toLowerCase();
+    const createdAtMs = parseTimestamp(event.created_at);
+    const existing = index.get(key);
+    if (
+      existing &&
+      existing.createdAtMs !== null &&
+      createdAtMs !== null &&
+      existing.createdAtMs > createdAtMs
+    ) {
+      continue;
+    }
+    index.set(key, { actor: event.actor ?? null, createdAtMs });
+  }
+
+  return index;
+}
+
+/**
+ * @param {readonly (string | { readonly name?: string })[] | undefined} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabelNames(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label => (typeof label === "string" ? label : label?.name))
+    .filter(name => typeof name === "string" && name.trim().length > 0);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function parseTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
+function normalizeWindow(value) {
+  return Number.isFinite(value) && value >= 0
+    ? Number(value)
+    : IMPLAUSIBLE_CLAIM_WINDOW_SECONDS;
+}
+
+/**
+ * @param {unknown} source
+ * @param {readonly string[]} keys
+ * @returns {unknown}
+ */
+function readPath(source, keys) {
+  return keys.reduce(
+    (current, key) =>
+      current && typeof current === "object" ? current[key] : undefined,
+    source
+  );
+}
+
+/**
+ * CLI: read a `{ issue, timeline, config }` payload on stdin, print the verdict.
+ *
+ * Exits 0 even when untrusted labels are found. This is a classifier, not a
+ * gate: callers run it inside `set -e` intake bash and branch on the JSON, and a
+ * non-zero exit would abort the scan on the very issues it exists to rescue.
+ *
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const payload = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+  const issue = payload.issue ?? {};
+
+  const trust = resolveTrustedLifecycleLabels({
+    labels: issue.labels,
+    timeline: payload.timeline,
+    issueCreatedAt: issue.created_at ?? issue.createdAt,
+    issueAuthor: issue.user ?? issue.author,
+    windowSeconds: payload.windowSeconds,
+  });
+  const drift = detectLifecycleDrift({
+    labels: issue.labels,
+    state: issue.state,
+    terminalLabels: terminalLifecycleLabels(payload.config),
+  });
+
+  process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
@@ -178,14 +178,38 @@ If none of the configured role labels exist on the repo → label convention not
 Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
 
 ```bash
-gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
-gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
-jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
-      --slurpfile c .lisa.config.json \
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE. Reading `$t[0]` would pass only page one,
+# silently dropping later label events — the newest of which is exactly the
+# application this classifier keys on. --slurp + `add` flattens all pages.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Resolve config the SAME way `read_role` does: the local file overrides the
+# global one key by key. Reading only `.lisa.config.json` would resolve a stale
+# terminal `done` label for any project that overrides it locally, and
+# `lisa-repair-intake` WRITES on the drift direction that mistake produces.
+# Both files are optional — a missing one must not abort the cycle.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
       '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
-  > /tmp/lisa-trust-input.json
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+The temp directory is **per invocation**. Fixed `/tmp/lisa-*.json` paths let two concurrent intake cycles interleave one issue's metadata with another's timeline, which yields a confident verdict about an item that was never examined.
 
 The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
 

--- a/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
@@ -168,6 +168,36 @@ gh label list --repo <org>/<repo> --json name \
 
 If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
 
+#### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
+
+**A `status:*` label is only a lifecycle signal if a trustworthy actor applied it.** Third-party GitHub Apps write labels through the same API humans do, and at least one — `coderabbitai[bot]` — stamps `status:*` on issues seconds after filing. Measured on CodySwannGT/lisa#2460–#2540: seven of eight bot-applied lifecycle labels landed 26–118s after creation. Those labels are guesses wearing the costume of the intake contract, and they break the queue in **both** directions:
+
+- a bot-applied **`$CLAIMED`** makes an unworked issue look like somebody's active work, so no cycle picks it up and no human re-examines it (#2470 sat unworked for a day this way);
+- a bot-applied **`$READY`** puts an issue into the build queue that no human ever flipped ready (#2538), inverting the gate the ready role exists to be.
+
+Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
+
+```bash
+gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
+jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
+      --slurpfile c .lisa.config.json \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > /tmp/lisa-trust-input.json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
+
+- a candidate whose `$READY` is **untrusted** is **not claimable** — skip it and leave it for a human to flip genuinely ready; report it in the summary rather than dispatching it;
+- a candidate whose `$CLAIMED` is **untrusted** is **not claimed** — if its `$READY` is trusted it stays a normal candidate, exactly as if the bot label were absent.
+
+**Never unlabel to correct this.** The bot re-applies its label on each subsequent review event, so reverting produces a label-flap loop that is worse than the defect. The guard is that intake stops *believing* the label; it writes nothing. Distrust is idempotent and cannot race.
+
+A label whose provenance cannot be established (applied at creation, which GitHub records no `labeled` event for) is trusted but listed in `unknownProvenance` — failing closed there would ignore the human `status:ready` that opens the queue. Report that list; do not silently drop it.
+
+Lifecycle membership is decided by the **`status:` prefix**, never by a pinned member list. The live family has drifted 7 → 6 members, and a literal set breaks silently: an unrecognised member simply fails to match, so the guard would report clean on exactly the case it stopped covering.
+
 ### Phase 3 — Process the first eligible ready issue
 
 #### 3a.0 Repo-scope gate (claim only current-repo issues)

--- a/plugins/lisa-copilot/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-repair-intake/SKILL.md
@@ -560,6 +560,60 @@ native-open / active / unresolved:
 4. Post a compact `[lisa-repair-intake]` note only when the native close-out changed state or when
    an actionable setup error must be surfaced. Do not spam already-closed terminal items.
 
+### Lifecycle label contradicts native state — walk BOTH directions
+
+A lifecycle label can lie in two ways, and historically only one of them had an owner:
+
+| label | native state | owned by |
+|---|---|---|
+| terminal `done` role | still open / active | the `Build terminal-open` section above |
+| non-terminal role (`ready`, `claimed`, `blocked`, or any other `status:` member) | closed / completed | **nothing, until now** |
+
+A pass that walks one direction leaves the other accumulating silently. Measured on the Linear TUN
+board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still natively open in
+`On Dev`** — invisible to intake and indistinguishable from handled, exactly like a bot-applied
+`status:in-progress` on GitHub.
+
+Resolve both directions in one pass with the shipped detector, which always reports
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
+   Do not restate its rules; the terminality test lives there (intermediate env rungs like
+   `status:on-dev` / `status:on-stg` are **not** terminal).
+2. **`open-label-closed-state`** → the previously unowned direction. The item is natively closed or
+   completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
+   terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
+   **Lisa's own** lifecycle surface, not a contest with another writer.
+3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
+   `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
+   repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native
+   state as authoritative and remove the contradicting stale label; never move the state to match a
+   label.
+
+Membership in the lifecycle namespace is decided by the **`status:` prefix**, never a pinned member
+list — the live family has drifted 7 → 6 members, and a literal set fails silently by simply not
+matching the member it stopped covering.
+
+### Bot-authored lifecycle label → distrust, never revert (read-only)
+
+`status:*` labels written by a **bot** actor within the plausibility window of the item's creation are
+not lifecycle signals — see `lisa-github-build-intake` Phase 2b for the measurement and the
+classifier. Report them here so an operator can see how much of the board is wearing a label nobody
+chose:
+
+- list each item alongside the untrusted label, the bot login, and the latency, from the classifier's
+  `untrusted` array;
+- list `unknownProvenance` labels separately — trusted, but unattributable;
+- **do not unlabel and do not relabel.** The bot re-applies on each subsequent review event, so a
+  reverting reconciler produces a label-flap loop that is worse than the defect. Repair happens by
+  intake declining to *believe* the label, which is idempotent and writes nothing.
+
+This class is deliberately **read-only** and never counts toward the repair cap's actionable work.
+
 ### Build parent rollup reconciliation (intermediate-env or terminal close-out)
 
 For each parent/container item (an Epic, a Linear Project, or any item — of any type — with open child work),

--- a/plugins/lisa-copilot/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-repair-intake/SKILL.md
@@ -575,11 +575,49 @@ board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still nat
 `status:in-progress` on GitHub.
 
 Resolve both directions in one pass with the shipped detector, which always reports
-`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined.
+
+**Build the classifier input inside this cycle. Never consume a temp file another skill wrote.**
+repair-intake runs as its own cycle, so borrowing `lisa-github-build-intake`'s scratch file fails
+two ways: absent, the redirect fails and `set -e` aborts the whole cycle; stale from an earlier run
+on a *different* item, the resolver classifies that other item and this section reports `drifts: []`
+while `directionsWalked` still claims both directions were walked. That is precisely the
+silent-clean verdict this section promises cannot happen.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE; --slurp + `add` flattens all of them so a
+# label event on page two is not silently dropped.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Same resolution `read_role` uses: local overrides global, both optional.
+# Resolving a stale terminal `done` here would make the true terminal label look
+# like `open-label-closed-state` — and that direction WRITES.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+**Untrusted labels are excluded from `drifts` before any repair runs** — the classifier does this
+itself, so repair must **never act on a label the classifier refused to believe**. Without it, a
+bot-applied label on a natively closed item would be advanced to the terminal `done` role by the
+`open-label-closed-state` repair, laundering the exact input the guard rejected into a real write.
+The `excluded` array reports what was held back; surface it, do not repair it.
 
 1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
    Do not restate its rules; the terminality test lives there (intermediate env rungs like
@@ -588,6 +626,9 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust
    completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
    terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
    **Lisa's own** lifecycle surface, not a contest with another writer.
+   Apply the leaf/container check from the **Lifecycle ownership guard** section *before* this
+   branch: repair-intake owns container repair, so a natively-closed `ready` **leaf** is skipped
+   here and left to the build lane rather than claimed by this pass.
 3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
    `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
    repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native

--- a/plugins/lisa-cursor/scripts/lifecycle-label-trust.mjs
+++ b/plugins/lisa-cursor/scripts/lifecycle-label-trust.mjs
@@ -225,14 +225,22 @@ export function terminalLifecycleLabels(config) {
  * issue #2539 describes, where only the auto-complete direction was ever
  * repaired and the reverse rotted unobserved.
  *
+ * `excludeLabels` removes labels from consideration entirely. Callers MUST pass
+ * the untrusted set here: `open-label-closed-state` is a repair direction that
+ * WRITES (it advances the label to the terminal `done` role), so without this a
+ * bot-applied label the classifier just refused to believe would still drive a
+ * real label write — the guard would launder the very input it rejected.
+ *
  * @param {{
  *   readonly labels?: readonly (string | { readonly name?: string })[]
  *   readonly state?: string
  *   readonly terminalLabels?: readonly string[]
+ *   readonly excludeLabels?: readonly string[]
  * }} input
  * @returns {{
  *   readonly drifts: readonly { direction: string, label: string }[]
  *   readonly directionsWalked: readonly string[]
+ *   readonly excluded: readonly string[]
  * }}
  */
 export function detectLifecycleDrift(input = {}) {
@@ -241,12 +249,23 @@ export function detectLifecycleDrift(input = {}) {
       String(label).trim().toLowerCase()
     )
   );
+  const excluded = new Set(
+    (Array.isArray(input.excludeLabels) ? input.excludeLabels : []).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
   const closed =
     String(input.state ?? "")
       .trim()
       .toLowerCase() === "closed";
-  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+  const allLifecycleLabels = normalizeLabelNames(input.labels).filter(
     isLifecycleLabel
+  );
+  const skipped = allLifecycleLabels.filter(label =>
+    excluded.has(label.trim().toLowerCase())
+  );
+  const lifecycleLabels = allLifecycleLabels.filter(
+    label => !excluded.has(label.trim().toLowerCase())
   );
 
   const drifts = lifecycleLabels.flatMap(label => {
@@ -260,7 +279,11 @@ export function detectLifecycleDrift(input = {}) {
     return [];
   });
 
-  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+  return {
+    drifts,
+    directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS,
+    excluded: skipped,
+  };
 }
 
 /**
@@ -450,10 +473,14 @@ async function main() {
     issueAuthor: issue.user ?? issue.author,
     windowSeconds: payload.windowSeconds,
   });
+  // Untrusted labels are excluded here rather than at the call site: the
+  // `open-label-closed-state` direction WRITES, so a caller that forgot to pass
+  // them would launder a label the classifier just rejected into a real write.
   const drift = detectLifecycleDrift({
     labels: issue.labels,
     state: issue.state,
     terminalLabels: terminalLifecycleLabels(payload.config),
+    excludeLabels: trust.untrusted.map(entry => entry.label),
   });
 
   process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);

--- a/plugins/lisa-cursor/scripts/lifecycle-label-trust.mjs
+++ b/plugins/lisa-cursor/scripts/lifecycle-label-trust.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+/**
+ * Lifecycle-label trust resolution — the read-side guard for #2539.
+ *
+ * ## The defect
+ *
+ * `coderabbitai[bot]` stamps a `status:*` label on issues seconds after they are
+ * filed. Measured across CodySwannGT/lisa#2460–#2540, seven of eight bot-applied
+ * lifecycle labels landed 26–118s after creation — far too fast to be a real
+ * claim. An issue wearing a bot-applied `status:in-progress` is invisible to
+ * build-intake (it is not the `ready` role) AND looks handled to a human, so
+ * nothing re-examines it. A MISSING lifecycle label is recoverable; a WRONG one
+ * is silent in both directions at once.
+ *
+ * ## Why this guard reads instead of writes
+ *
+ * The label is applied by a webhook after the fact, so no pre-tool check on this
+ * machine has anything to intercept — the write never passes through us. The two
+ * remaining options were a reconciler that reverts the label, and this: intake
+ * refusing to BELIEVE the label. The reconciler was rejected because the bot
+ * re-applies on every subsequent review event, so reverting produces a label-flap
+ * loop that is worse than the disease. Distrust is idempotent, cannot race, and
+ * writes nothing — nothing in this module mutates a tracker.
+ *
+ * ## Why actor alone is not enough
+ *
+ * #2470 (false claim, 27s) and #2494 (real, 3001s) were BOTH applied by
+ * `coderabbitai[bot]`. Rejecting every bot-authored lifecycle label would
+ * discard the true one; rejecting every fast label would discard the human
+ * `status:ready` applied at filing time, which is the queue's entry signal.
+ * Distrust therefore requires BOTH conditions: a bot actor AND a latency below
+ * the plausibility window.
+ *
+ * ## Why the member set is never hardcoded
+ *
+ * The live `status:*` family has drifted 7 → 6 members. A pinned literal breaks
+ * silently — an unrecognised member simply fails to match, so the guard reports
+ * clean on exactly the case it stopped covering. Membership is decided by the
+ * `status:` PREFIX and terminality is resolved from live config.
+ */
+
+/** Lifecycle labels are identified by this prefix, never by a pinned set. */
+export const LIFECYCLE_LABEL_PREFIX = "status:";
+
+/**
+ * Fallback terminal label used only when config supplies no `done` role.
+ *
+ * This module ships standalone into host projects and cannot import Lisa's
+ * TypeScript `BUILD_LABEL_DEFAULTS`, so the literal is repeated here — but it is
+ * NOT free to drift: `lifecycle-label-trust.test.ts` asserts it stays equal to
+ * `BUILD_LABEL_DEFAULTS.done.production` in `src/sync/lifecycle-defaults.ts`.
+ * This is a fallback only; a configured project resolves the value live.
+ */
+export const DEFAULT_TERMINAL_LIFECYCLE_LABEL = "status:done";
+
+/**
+ * Seconds below which a BOT-applied lifecycle label is not believable as a claim.
+ *
+ * Calibrated against measurement, not taste: the observed false bot claims
+ * clustered at 26–118s, while the one corroborated bot label landed at 3001s.
+ * 300s sits an order of magnitude above the noise and an order of magnitude
+ * below the real signal, so neither edge is close to the boundary.
+ */
+export const IMPLAUSIBLE_CLAIM_WINDOW_SECONDS = 300;
+
+/**
+ * Both directions a lifecycle label can contradict native state.
+ *
+ * Emitted on every drift result so a repair pass cannot walk one direction and
+ * silently leave the other accumulating — the asymmetry that let TUN-556 and
+ * TUN-503 sit on a terminal `status:done` while still natively open.
+ */
+export const LIFECYCLE_DRIFT_DIRECTIONS = [
+  "terminal-label-open-state",
+  "open-label-closed-state",
+];
+
+/**
+ * @typedef {{ readonly login?: string, readonly type?: string }} Actor
+ *
+ * @typedef {{
+ *   readonly event?: string
+ *   readonly label?: { readonly name?: string }
+ *   readonly actor?: Actor | null
+ *   readonly created_at?: string
+ * }} TimelineEvent
+ *
+ * @typedef {{
+ *   readonly label: string
+ *   readonly actor: string | null
+ *   readonly latencySeconds: number | null
+ *   readonly reason: string
+ *   readonly trusted: boolean
+ * }} EvaluatedLabel
+ */
+
+/**
+ * Is this label part of the lifecycle namespace?
+ *
+ * Prefix-only by design — see the module preamble on set drift. `status:` with
+ * no member is still lifecycle-namespaced and must not fall through as taxonomy.
+ *
+ * @param {unknown} name
+ * @returns {boolean}
+ */
+export function isLifecycleLabel(name) {
+  if (typeof name !== "string") {
+    return false;
+  }
+  return name.trim().toLowerCase().startsWith(LIFECYCLE_LABEL_PREFIX);
+}
+
+/**
+ * Is this timeline actor a bot?
+ *
+ * Checks GitHub's first-class `type` discriminator first, then falls back to the
+ * `[bot]` login suffix so an actor payload lacking `type` is still classified.
+ * A missing actor is NOT a bot: unattributable is handled separately, and
+ * guessing "bot" there would silently drop legitimate labels.
+ *
+ * @param {Actor | null | undefined} actor
+ * @returns {boolean}
+ */
+export function isBotActor(actor) {
+  if (!actor || typeof actor !== "object") {
+    return false;
+  }
+  if (typeof actor.type === "string" && actor.type.toLowerCase() === "bot") {
+    return true;
+  }
+  return (
+    typeof actor.login === "string" &&
+    actor.login.trim().toLowerCase().endsWith("[bot]")
+  );
+}
+
+/**
+ * Resolve which of an item's lifecycle labels intake is entitled to believe.
+ *
+ * Read-only and total: every lifecycle label on the item lands in exactly one of
+ * `trusted` or `untrusted`, and `evaluated` carries the reasoning for all of
+ * them so a distrust decision is auditable rather than invisible.
+ *
+ * Provenance that cannot be established (a label applied at creation, which
+ * GitHub records no `labeled` event for) is TRUSTED but reported in
+ * `unknownProvenance`. Failing closed there would make intake ignore the
+ * human `status:ready` that opens the queue, stalling every project — so the
+ * blind spot is surfaced rather than guessed at. Supplying `issueAuthor` closes
+ * it, by attributing creation-time labels to whoever filed the item.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly timeline?: readonly TimelineEvent[]
+ *   readonly issueCreatedAt?: string
+ *   readonly issueAuthor?: Actor | null
+ *   readonly windowSeconds?: number
+ * }} input
+ * @returns {{
+ *   readonly trusted: readonly string[]
+ *   readonly untrusted: readonly Omit<EvaluatedLabel, "trusted">[]
+ *   readonly unknownProvenance: readonly string[]
+ *   readonly evaluated: readonly EvaluatedLabel[]
+ *   readonly hasUntrustedLifecycleLabels: boolean
+ * }}
+ */
+export function resolveTrustedLifecycleLabels(input = {}) {
+  const windowSeconds = normalizeWindow(input.windowSeconds);
+  const createdAtMs = parseTimestamp(input.issueCreatedAt);
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+  const latestApplication = indexLatestLabelApplications(input.timeline);
+
+  const evaluated = lifecycleLabels.map(label =>
+    evaluateLabel({
+      label,
+      application: latestApplication.get(label.trim().toLowerCase()),
+      createdAtMs,
+      issueAuthor: input.issueAuthor,
+      windowSeconds,
+    })
+  );
+
+  return {
+    trusted: evaluated.filter(entry => entry.trusted).map(entry => entry.label),
+    untrusted: evaluated
+      .filter(entry => !entry.trusted)
+      .map(({ trusted: _trusted, ...rest }) => rest),
+    unknownProvenance: evaluated
+      .filter(entry => entry.reason === "provenance-unknown")
+      .map(entry => entry.label),
+    evaluated,
+    hasUntrustedLifecycleLabels: evaluated.some(entry => !entry.trusted),
+  };
+}
+
+/**
+ * The lifecycle labels that mean "this work is finished", read from live config.
+ *
+ * Only the PRODUCTION rung of the `done` role is terminal. `status:on-dev` and
+ * `status:on-stg` are shipped-somewhere, not finished, and closing on them would
+ * retire work that still has environments to clear.
+ *
+ * @param {unknown} config a parsed `.lisa.config.json`-shaped object
+ * @returns {readonly string[]}
+ */
+export function terminalLifecycleLabels(config) {
+  const done = readPath(config, ["github", "labels", "build", "done"]);
+
+  if (typeof done === "string" && done.trim().length > 0) {
+    return [done.trim()];
+  }
+  const production = readPath(done, ["production"]);
+  if (typeof production === "string" && production.trim().length > 0) {
+    return [production.trim()];
+  }
+  return [DEFAULT_TERMINAL_LIFECYCLE_LABEL];
+}
+
+/**
+ * Detect lifecycle labels that contradict native state, in BOTH directions.
+ *
+ * `directionsWalked` is always the full direction list, so a caller reporting
+ * "clean" is asserting it looked at both — the failure mode refinement #1 of
+ * issue #2539 describes, where only the auto-complete direction was ever
+ * repaired and the reverse rotted unobserved.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly state?: string
+ *   readonly terminalLabels?: readonly string[]
+ * }} input
+ * @returns {{
+ *   readonly drifts: readonly { direction: string, label: string }[]
+ *   readonly directionsWalked: readonly string[]
+ * }}
+ */
+export function detectLifecycleDrift(input = {}) {
+  const terminal = new Set(
+    (input.terminalLabels ?? terminalLifecycleLabels(undefined)).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
+  const closed =
+    String(input.state ?? "")
+      .trim()
+      .toLowerCase() === "closed";
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+
+  const drifts = lifecycleLabels.flatMap(label => {
+    const isTerminal = terminal.has(label.trim().toLowerCase());
+    if (isTerminal && !closed) {
+      return [{ direction: "terminal-label-open-state", label }];
+    }
+    if (!isTerminal && closed) {
+      return [{ direction: "open-label-closed-state", label }];
+    }
+    return [];
+  });
+
+  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+}
+
+/**
+ * Classify one lifecycle label against its most recent application.
+ *
+ * @param {{
+ *   label: string
+ *   application?: { actor?: Actor | null, createdAtMs: number | null }
+ *   createdAtMs: number | null
+ *   issueAuthor?: Actor | null
+ *   windowSeconds: number
+ * }} params
+ * @returns {EvaluatedLabel}
+ */
+function evaluateLabel(params) {
+  const { label, application, createdAtMs, issueAuthor, windowSeconds } =
+    params;
+
+  const actor = application ? application.actor : issueAuthor;
+  const hasProvenance = Boolean(application) || Boolean(issueAuthor);
+
+  if (!hasProvenance) {
+    return {
+      label,
+      actor: null,
+      latencySeconds: null,
+      reason: "provenance-unknown",
+      trusted: true,
+    };
+  }
+
+  const login = typeof actor?.login === "string" ? actor.login : null;
+
+  if (!isBotActor(actor)) {
+    return {
+      label,
+      actor: login,
+      latencySeconds: latencySeconds(createdAtMs, application),
+      reason: "human-actor",
+      trusted: true,
+    };
+  }
+
+  const latency = latencySeconds(createdAtMs, application);
+  const implausible = latency === null || latency < windowSeconds;
+
+  return {
+    label,
+    actor: login,
+    latencySeconds: latency,
+    reason: implausible
+      ? "bot-actor-implausible-latency"
+      : "bot-actor-plausible-latency",
+    trusted: !implausible,
+  };
+}
+
+/**
+ * Seconds between item creation and the label application.
+ *
+ * A creation-time label (no timeline event) is latency 0 by construction.
+ *
+ * @param {number | null} createdAtMs
+ * @param {{ createdAtMs: number | null } | undefined} application
+ * @returns {number | null}
+ */
+function latencySeconds(createdAtMs, application) {
+  if (createdAtMs === null) {
+    return null;
+  }
+  if (!application) {
+    return 0;
+  }
+  if (application.createdAtMs === null) {
+    return null;
+  }
+  return Math.max(
+    0,
+    Math.round((application.createdAtMs - createdAtMs) / 1000)
+  );
+}
+
+/**
+ * Map each lifecycle label to its MOST RECENT `labeled` event.
+ *
+ * Most-recent, not first: a human who removes the bot's label and re-applies it
+ * has made a genuine claim, and keying on the first application would keep
+ * distrusting a label the human now owns.
+ *
+ * @param {readonly TimelineEvent[] | undefined} timeline
+ * @returns {Map<string, { actor?: Actor | null, createdAtMs: number | null }>}
+ */
+function indexLatestLabelApplications(timeline) {
+  const index = new Map();
+
+  for (const event of Array.isArray(timeline) ? timeline : []) {
+    if (event?.event !== "labeled") {
+      continue;
+    }
+    const name = event.label?.name;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      continue;
+    }
+    const key = name.trim().toLowerCase();
+    const createdAtMs = parseTimestamp(event.created_at);
+    const existing = index.get(key);
+    if (
+      existing &&
+      existing.createdAtMs !== null &&
+      createdAtMs !== null &&
+      existing.createdAtMs > createdAtMs
+    ) {
+      continue;
+    }
+    index.set(key, { actor: event.actor ?? null, createdAtMs });
+  }
+
+  return index;
+}
+
+/**
+ * @param {readonly (string | { readonly name?: string })[] | undefined} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabelNames(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label => (typeof label === "string" ? label : label?.name))
+    .filter(name => typeof name === "string" && name.trim().length > 0);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function parseTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
+function normalizeWindow(value) {
+  return Number.isFinite(value) && value >= 0
+    ? Number(value)
+    : IMPLAUSIBLE_CLAIM_WINDOW_SECONDS;
+}
+
+/**
+ * @param {unknown} source
+ * @param {readonly string[]} keys
+ * @returns {unknown}
+ */
+function readPath(source, keys) {
+  return keys.reduce(
+    (current, key) =>
+      current && typeof current === "object" ? current[key] : undefined,
+    source
+  );
+}
+
+/**
+ * CLI: read a `{ issue, timeline, config }` payload on stdin, print the verdict.
+ *
+ * Exits 0 even when untrusted labels are found. This is a classifier, not a
+ * gate: callers run it inside `set -e` intake bash and branch on the JSON, and a
+ * non-zero exit would abort the scan on the very issues it exists to rescue.
+ *
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const payload = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+  const issue = payload.issue ?? {};
+
+  const trust = resolveTrustedLifecycleLabels({
+    labels: issue.labels,
+    timeline: payload.timeline,
+    issueCreatedAt: issue.created_at ?? issue.createdAt,
+    issueAuthor: issue.user ?? issue.author,
+    windowSeconds: payload.windowSeconds,
+  });
+  const drift = detectLifecycleDrift({
+    labels: issue.labels,
+    state: issue.state,
+    terminalLabels: terminalLifecycleLabels(payload.config),
+  });
+
+  process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
@@ -178,14 +178,38 @@ If none of the configured role labels exist on the repo → label convention not
 Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
 
 ```bash
-gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
-gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
-jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
-      --slurpfile c .lisa.config.json \
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE. Reading `$t[0]` would pass only page one,
+# silently dropping later label events — the newest of which is exactly the
+# application this classifier keys on. --slurp + `add` flattens all pages.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Resolve config the SAME way `read_role` does: the local file overrides the
+# global one key by key. Reading only `.lisa.config.json` would resolve a stale
+# terminal `done` label for any project that overrides it locally, and
+# `lisa-repair-intake` WRITES on the drift direction that mistake produces.
+# Both files are optional — a missing one must not abort the cycle.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
       '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
-  > /tmp/lisa-trust-input.json
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+The temp directory is **per invocation**. Fixed `/tmp/lisa-*.json` paths let two concurrent intake cycles interleave one issue's metadata with another's timeline, which yields a confident verdict about an item that was never examined.
 
 The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
 

--- a/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
@@ -168,6 +168,36 @@ gh label list --repo <org>/<repo> --json name \
 
 If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
 
+#### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
+
+**A `status:*` label is only a lifecycle signal if a trustworthy actor applied it.** Third-party GitHub Apps write labels through the same API humans do, and at least one — `coderabbitai[bot]` — stamps `status:*` on issues seconds after filing. Measured on CodySwannGT/lisa#2460–#2540: seven of eight bot-applied lifecycle labels landed 26–118s after creation. Those labels are guesses wearing the costume of the intake contract, and they break the queue in **both** directions:
+
+- a bot-applied **`$CLAIMED`** makes an unworked issue look like somebody's active work, so no cycle picks it up and no human re-examines it (#2470 sat unworked for a day this way);
+- a bot-applied **`$READY`** puts an issue into the build queue that no human ever flipped ready (#2538), inverting the gate the ready role exists to be.
+
+Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
+
+```bash
+gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
+jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
+      --slurpfile c .lisa.config.json \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > /tmp/lisa-trust-input.json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
+
+- a candidate whose `$READY` is **untrusted** is **not claimable** — skip it and leave it for a human to flip genuinely ready; report it in the summary rather than dispatching it;
+- a candidate whose `$CLAIMED` is **untrusted** is **not claimed** — if its `$READY` is trusted it stays a normal candidate, exactly as if the bot label were absent.
+
+**Never unlabel to correct this.** The bot re-applies its label on each subsequent review event, so reverting produces a label-flap loop that is worse than the defect. The guard is that intake stops *believing* the label; it writes nothing. Distrust is idempotent and cannot race.
+
+A label whose provenance cannot be established (applied at creation, which GitHub records no `labeled` event for) is trusted but listed in `unknownProvenance` — failing closed there would ignore the human `status:ready` that opens the queue. Report that list; do not silently drop it.
+
+Lifecycle membership is decided by the **`status:` prefix**, never by a pinned member list. The live family has drifted 7 → 6 members, and a literal set breaks silently: an unrecognised member simply fails to match, so the guard would report clean on exactly the case it stopped covering.
+
 ### Phase 3 — Process the first eligible ready issue
 
 #### 3a.0 Repo-scope gate (claim only current-repo issues)

--- a/plugins/lisa-cursor/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-repair-intake/SKILL.md
@@ -560,6 +560,60 @@ native-open / active / unresolved:
 4. Post a compact `[lisa-repair-intake]` note only when the native close-out changed state or when
    an actionable setup error must be surfaced. Do not spam already-closed terminal items.
 
+### Lifecycle label contradicts native state — walk BOTH directions
+
+A lifecycle label can lie in two ways, and historically only one of them had an owner:
+
+| label | native state | owned by |
+|---|---|---|
+| terminal `done` role | still open / active | the `Build terminal-open` section above |
+| non-terminal role (`ready`, `claimed`, `blocked`, or any other `status:` member) | closed / completed | **nothing, until now** |
+
+A pass that walks one direction leaves the other accumulating silently. Measured on the Linear TUN
+board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still natively open in
+`On Dev`** — invisible to intake and indistinguishable from handled, exactly like a bot-applied
+`status:in-progress` on GitHub.
+
+Resolve both directions in one pass with the shipped detector, which always reports
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
+   Do not restate its rules; the terminality test lives there (intermediate env rungs like
+   `status:on-dev` / `status:on-stg` are **not** terminal).
+2. **`open-label-closed-state`** → the previously unowned direction. The item is natively closed or
+   completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
+   terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
+   **Lisa's own** lifecycle surface, not a contest with another writer.
+3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
+   `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
+   repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native
+   state as authoritative and remove the contradicting stale label; never move the state to match a
+   label.
+
+Membership in the lifecycle namespace is decided by the **`status:` prefix**, never a pinned member
+list — the live family has drifted 7 → 6 members, and a literal set fails silently by simply not
+matching the member it stopped covering.
+
+### Bot-authored lifecycle label → distrust, never revert (read-only)
+
+`status:*` labels written by a **bot** actor within the plausibility window of the item's creation are
+not lifecycle signals — see `lisa-github-build-intake` Phase 2b for the measurement and the
+classifier. Report them here so an operator can see how much of the board is wearing a label nobody
+chose:
+
+- list each item alongside the untrusted label, the bot login, and the latency, from the classifier's
+  `untrusted` array;
+- list `unknownProvenance` labels separately — trusted, but unattributable;
+- **do not unlabel and do not relabel.** The bot re-applies on each subsequent review event, so a
+  reverting reconciler produces a label-flap loop that is worse than the defect. Repair happens by
+  intake declining to *believe* the label, which is idempotent and writes nothing.
+
+This class is deliberately **read-only** and never counts toward the repair cap's actionable work.
+
 ### Build parent rollup reconciliation (intermediate-env or terminal close-out)
 
 For each parent/container item (an Epic, a Linear Project, or any item — of any type — with open child work),

--- a/plugins/lisa-cursor/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-repair-intake/SKILL.md
@@ -575,11 +575,49 @@ board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still nat
 `status:in-progress` on GitHub.
 
 Resolve both directions in one pass with the shipped detector, which always reports
-`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined.
+
+**Build the classifier input inside this cycle. Never consume a temp file another skill wrote.**
+repair-intake runs as its own cycle, so borrowing `lisa-github-build-intake`'s scratch file fails
+two ways: absent, the redirect fails and `set -e` aborts the whole cycle; stale from an earlier run
+on a *different* item, the resolver classifies that other item and this section reports `drifts: []`
+while `directionsWalked` still claims both directions were walked. That is precisely the
+silent-clean verdict this section promises cannot happen.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE; --slurp + `add` flattens all of them so a
+# label event on page two is not silently dropped.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Same resolution `read_role` uses: local overrides global, both optional.
+# Resolving a stale terminal `done` here would make the true terminal label look
+# like `open-label-closed-state` — and that direction WRITES.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+**Untrusted labels are excluded from `drifts` before any repair runs** — the classifier does this
+itself, so repair must **never act on a label the classifier refused to believe**. Without it, a
+bot-applied label on a natively closed item would be advanced to the terminal `done` role by the
+`open-label-closed-state` repair, laundering the exact input the guard rejected into a real write.
+The `excluded` array reports what was held back; surface it, do not repair it.
 
 1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
    Do not restate its rules; the terminality test lives there (intermediate env rungs like
@@ -588,6 +626,9 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust
    completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
    terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
    **Lisa's own** lifecycle surface, not a contest with another writer.
+   Apply the leaf/container check from the **Lifecycle ownership guard** section *before* this
+   branch: repair-intake owns container repair, so a natively-closed `ready` **leaf** is skipped
+   here and left to the build lane rather than claimed by this pass.
 3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
    `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
    repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
@@ -178,14 +178,38 @@ If none of the configured role labels exist on the repo → label convention not
 Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
 
 ```bash
-gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
-gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
-jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
-      --slurpfile c .lisa.config.json \
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE. Reading `$t[0]` would pass only page one,
+# silently dropping later label events — the newest of which is exactly the
+# application this classifier keys on. --slurp + `add` flattens all pages.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Resolve config the SAME way `read_role` does: the local file overrides the
+# global one key by key. Reading only `.lisa.config.json` would resolve a stale
+# terminal `done` label for any project that overrides it locally, and
+# `lisa-repair-intake` WRITES on the drift direction that mistake produces.
+# Both files are optional — a missing one must not abort the cycle.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
       '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
-  > /tmp/lisa-trust-input.json
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+The temp directory is **per invocation**. Fixed `/tmp/lisa-*.json` paths let two concurrent intake cycles interleave one issue's metadata with another's timeline, which yields a confident verdict about an item that was never examined.
 
 The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
@@ -168,6 +168,36 @@ gh label list --repo <org>/<repo> --json name \
 
 If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
 
+#### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
+
+**A `status:*` label is only a lifecycle signal if a trustworthy actor applied it.** Third-party GitHub Apps write labels through the same API humans do, and at least one — `coderabbitai[bot]` — stamps `status:*` on issues seconds after filing. Measured on CodySwannGT/lisa#2460–#2540: seven of eight bot-applied lifecycle labels landed 26–118s after creation. Those labels are guesses wearing the costume of the intake contract, and they break the queue in **both** directions:
+
+- a bot-applied **`$CLAIMED`** makes an unworked issue look like somebody's active work, so no cycle picks it up and no human re-examines it (#2470 sat unworked for a day this way);
+- a bot-applied **`$READY`** puts an issue into the build queue that no human ever flipped ready (#2538), inverting the gate the ready role exists to be.
+
+Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
+
+```bash
+gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
+jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
+      --slurpfile c .lisa.config.json \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > /tmp/lisa-trust-input.json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
+
+- a candidate whose `$READY` is **untrusted** is **not claimable** — skip it and leave it for a human to flip genuinely ready; report it in the summary rather than dispatching it;
+- a candidate whose `$CLAIMED` is **untrusted** is **not claimed** — if its `$READY` is trusted it stays a normal candidate, exactly as if the bot label were absent.
+
+**Never unlabel to correct this.** The bot re-applies its label on each subsequent review event, so reverting produces a label-flap loop that is worse than the defect. The guard is that intake stops *believing* the label; it writes nothing. Distrust is idempotent and cannot race.
+
+A label whose provenance cannot be established (applied at creation, which GitHub records no `labeled` event for) is trusted but listed in `unknownProvenance` — failing closed there would ignore the human `status:ready` that opens the queue. Report that list; do not silently drop it.
+
+Lifecycle membership is decided by the **`status:` prefix**, never by a pinned member list. The live family has drifted 7 → 6 members, and a literal set breaks silently: an unrecognised member simply fails to match, so the guard would report clean on exactly the case it stopped covering.
+
 ### Phase 3 — Process the first eligible ready issue
 
 #### 3a.0 Repo-scope gate (claim only current-repo issues)

--- a/plugins/lisa/.codex-plugin/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-repair-intake/SKILL.md
@@ -560,6 +560,60 @@ native-open / active / unresolved:
 4. Post a compact `[lisa-repair-intake]` note only when the native close-out changed state or when
    an actionable setup error must be surfaced. Do not spam already-closed terminal items.
 
+### Lifecycle label contradicts native state — walk BOTH directions
+
+A lifecycle label can lie in two ways, and historically only one of them had an owner:
+
+| label | native state | owned by |
+|---|---|---|
+| terminal `done` role | still open / active | the `Build terminal-open` section above |
+| non-terminal role (`ready`, `claimed`, `blocked`, or any other `status:` member) | closed / completed | **nothing, until now** |
+
+A pass that walks one direction leaves the other accumulating silently. Measured on the Linear TUN
+board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still natively open in
+`On Dev`** — invisible to intake and indistinguishable from handled, exactly like a bot-applied
+`status:in-progress` on GitHub.
+
+Resolve both directions in one pass with the shipped detector, which always reports
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
+   Do not restate its rules; the terminality test lives there (intermediate env rungs like
+   `status:on-dev` / `status:on-stg` are **not** terminal).
+2. **`open-label-closed-state`** → the previously unowned direction. The item is natively closed or
+   completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
+   terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
+   **Lisa's own** lifecycle surface, not a contest with another writer.
+3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
+   `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
+   repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native
+   state as authoritative and remove the contradicting stale label; never move the state to match a
+   label.
+
+Membership in the lifecycle namespace is decided by the **`status:` prefix**, never a pinned member
+list — the live family has drifted 7 → 6 members, and a literal set fails silently by simply not
+matching the member it stopped covering.
+
+### Bot-authored lifecycle label → distrust, never revert (read-only)
+
+`status:*` labels written by a **bot** actor within the plausibility window of the item's creation are
+not lifecycle signals — see `lisa-github-build-intake` Phase 2b for the measurement and the
+classifier. Report them here so an operator can see how much of the board is wearing a label nobody
+chose:
+
+- list each item alongside the untrusted label, the bot login, and the latency, from the classifier's
+  `untrusted` array;
+- list `unknownProvenance` labels separately — trusted, but unattributable;
+- **do not unlabel and do not relabel.** The bot re-applies on each subsequent review event, so a
+  reverting reconciler produces a label-flap loop that is worse than the defect. Repair happens by
+  intake declining to *believe* the label, which is idempotent and writes nothing.
+
+This class is deliberately **read-only** and never counts toward the repair cap's actionable work.
+
 ### Build parent rollup reconciliation (intermediate-env or terminal close-out)
 
 For each parent/container item (an Epic, a Linear Project, or any item — of any type — with open child work),

--- a/plugins/lisa/.codex-plugin/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-repair-intake/SKILL.md
@@ -575,11 +575,49 @@ board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still nat
 `status:in-progress` on GitHub.
 
 Resolve both directions in one pass with the shipped detector, which always reports
-`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined.
+
+**Build the classifier input inside this cycle. Never consume a temp file another skill wrote.**
+repair-intake runs as its own cycle, so borrowing `lisa-github-build-intake`'s scratch file fails
+two ways: absent, the redirect fails and `set -e` aborts the whole cycle; stale from an earlier run
+on a *different* item, the resolver classifies that other item and this section reports `drifts: []`
+while `directionsWalked` still claims both directions were walked. That is precisely the
+silent-clean verdict this section promises cannot happen.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE; --slurp + `add` flattens all of them so a
+# label event on page two is not silently dropped.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Same resolution `read_role` uses: local overrides global, both optional.
+# Resolving a stale terminal `done` here would make the true terminal label look
+# like `open-label-closed-state` — and that direction WRITES.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+**Untrusted labels are excluded from `drifts` before any repair runs** — the classifier does this
+itself, so repair must **never act on a label the classifier refused to believe**. Without it, a
+bot-applied label on a natively closed item would be advanced to the terminal `done` role by the
+`open-label-closed-state` repair, laundering the exact input the guard rejected into a real write.
+The `excluded` array reports what was held back; surface it, do not repair it.
 
 1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
    Do not restate its rules; the terminality test lives there (intermediate env rungs like
@@ -588,6 +626,9 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust
    completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
    terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
    **Lisa's own** lifecycle surface, not a contest with another writer.
+   Apply the leaf/container check from the **Lifecycle ownership guard** section *before* this
+   branch: repair-intake owns container repair, so a natively-closed `ready` **leaf** is skipped
+   here and left to the build lane rather than claimed by this pass.
 3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
    `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
    repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native

--- a/plugins/lisa/scripts/lifecycle-label-trust.mjs
+++ b/plugins/lisa/scripts/lifecycle-label-trust.mjs
@@ -225,14 +225,22 @@ export function terminalLifecycleLabels(config) {
  * issue #2539 describes, where only the auto-complete direction was ever
  * repaired and the reverse rotted unobserved.
  *
+ * `excludeLabels` removes labels from consideration entirely. Callers MUST pass
+ * the untrusted set here: `open-label-closed-state` is a repair direction that
+ * WRITES (it advances the label to the terminal `done` role), so without this a
+ * bot-applied label the classifier just refused to believe would still drive a
+ * real label write — the guard would launder the very input it rejected.
+ *
  * @param {{
  *   readonly labels?: readonly (string | { readonly name?: string })[]
  *   readonly state?: string
  *   readonly terminalLabels?: readonly string[]
+ *   readonly excludeLabels?: readonly string[]
  * }} input
  * @returns {{
  *   readonly drifts: readonly { direction: string, label: string }[]
  *   readonly directionsWalked: readonly string[]
+ *   readonly excluded: readonly string[]
  * }}
  */
 export function detectLifecycleDrift(input = {}) {
@@ -241,12 +249,23 @@ export function detectLifecycleDrift(input = {}) {
       String(label).trim().toLowerCase()
     )
   );
+  const excluded = new Set(
+    (Array.isArray(input.excludeLabels) ? input.excludeLabels : []).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
   const closed =
     String(input.state ?? "")
       .trim()
       .toLowerCase() === "closed";
-  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+  const allLifecycleLabels = normalizeLabelNames(input.labels).filter(
     isLifecycleLabel
+  );
+  const skipped = allLifecycleLabels.filter(label =>
+    excluded.has(label.trim().toLowerCase())
+  );
+  const lifecycleLabels = allLifecycleLabels.filter(
+    label => !excluded.has(label.trim().toLowerCase())
   );
 
   const drifts = lifecycleLabels.flatMap(label => {
@@ -260,7 +279,11 @@ export function detectLifecycleDrift(input = {}) {
     return [];
   });
 
-  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+  return {
+    drifts,
+    directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS,
+    excluded: skipped,
+  };
 }
 
 /**
@@ -450,10 +473,14 @@ async function main() {
     issueAuthor: issue.user ?? issue.author,
     windowSeconds: payload.windowSeconds,
   });
+  // Untrusted labels are excluded here rather than at the call site: the
+  // `open-label-closed-state` direction WRITES, so a caller that forgot to pass
+  // them would launder a label the classifier just rejected into a real write.
   const drift = detectLifecycleDrift({
     labels: issue.labels,
     state: issue.state,
     terminalLabels: terminalLifecycleLabels(payload.config),
+    excludeLabels: trust.untrusted.map(entry => entry.label),
   });
 
   process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);

--- a/plugins/lisa/scripts/lifecycle-label-trust.mjs
+++ b/plugins/lisa/scripts/lifecycle-label-trust.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+/**
+ * Lifecycle-label trust resolution — the read-side guard for #2539.
+ *
+ * ## The defect
+ *
+ * `coderabbitai[bot]` stamps a `status:*` label on issues seconds after they are
+ * filed. Measured across CodySwannGT/lisa#2460–#2540, seven of eight bot-applied
+ * lifecycle labels landed 26–118s after creation — far too fast to be a real
+ * claim. An issue wearing a bot-applied `status:in-progress` is invisible to
+ * build-intake (it is not the `ready` role) AND looks handled to a human, so
+ * nothing re-examines it. A MISSING lifecycle label is recoverable; a WRONG one
+ * is silent in both directions at once.
+ *
+ * ## Why this guard reads instead of writes
+ *
+ * The label is applied by a webhook after the fact, so no pre-tool check on this
+ * machine has anything to intercept — the write never passes through us. The two
+ * remaining options were a reconciler that reverts the label, and this: intake
+ * refusing to BELIEVE the label. The reconciler was rejected because the bot
+ * re-applies on every subsequent review event, so reverting produces a label-flap
+ * loop that is worse than the disease. Distrust is idempotent, cannot race, and
+ * writes nothing — nothing in this module mutates a tracker.
+ *
+ * ## Why actor alone is not enough
+ *
+ * #2470 (false claim, 27s) and #2494 (real, 3001s) were BOTH applied by
+ * `coderabbitai[bot]`. Rejecting every bot-authored lifecycle label would
+ * discard the true one; rejecting every fast label would discard the human
+ * `status:ready` applied at filing time, which is the queue's entry signal.
+ * Distrust therefore requires BOTH conditions: a bot actor AND a latency below
+ * the plausibility window.
+ *
+ * ## Why the member set is never hardcoded
+ *
+ * The live `status:*` family has drifted 7 → 6 members. A pinned literal breaks
+ * silently — an unrecognised member simply fails to match, so the guard reports
+ * clean on exactly the case it stopped covering. Membership is decided by the
+ * `status:` PREFIX and terminality is resolved from live config.
+ */
+
+/** Lifecycle labels are identified by this prefix, never by a pinned set. */
+export const LIFECYCLE_LABEL_PREFIX = "status:";
+
+/**
+ * Fallback terminal label used only when config supplies no `done` role.
+ *
+ * This module ships standalone into host projects and cannot import Lisa's
+ * TypeScript `BUILD_LABEL_DEFAULTS`, so the literal is repeated here — but it is
+ * NOT free to drift: `lifecycle-label-trust.test.ts` asserts it stays equal to
+ * `BUILD_LABEL_DEFAULTS.done.production` in `src/sync/lifecycle-defaults.ts`.
+ * This is a fallback only; a configured project resolves the value live.
+ */
+export const DEFAULT_TERMINAL_LIFECYCLE_LABEL = "status:done";
+
+/**
+ * Seconds below which a BOT-applied lifecycle label is not believable as a claim.
+ *
+ * Calibrated against measurement, not taste: the observed false bot claims
+ * clustered at 26–118s, while the one corroborated bot label landed at 3001s.
+ * 300s sits an order of magnitude above the noise and an order of magnitude
+ * below the real signal, so neither edge is close to the boundary.
+ */
+export const IMPLAUSIBLE_CLAIM_WINDOW_SECONDS = 300;
+
+/**
+ * Both directions a lifecycle label can contradict native state.
+ *
+ * Emitted on every drift result so a repair pass cannot walk one direction and
+ * silently leave the other accumulating — the asymmetry that let TUN-556 and
+ * TUN-503 sit on a terminal `status:done` while still natively open.
+ */
+export const LIFECYCLE_DRIFT_DIRECTIONS = [
+  "terminal-label-open-state",
+  "open-label-closed-state",
+];
+
+/**
+ * @typedef {{ readonly login?: string, readonly type?: string }} Actor
+ *
+ * @typedef {{
+ *   readonly event?: string
+ *   readonly label?: { readonly name?: string }
+ *   readonly actor?: Actor | null
+ *   readonly created_at?: string
+ * }} TimelineEvent
+ *
+ * @typedef {{
+ *   readonly label: string
+ *   readonly actor: string | null
+ *   readonly latencySeconds: number | null
+ *   readonly reason: string
+ *   readonly trusted: boolean
+ * }} EvaluatedLabel
+ */
+
+/**
+ * Is this label part of the lifecycle namespace?
+ *
+ * Prefix-only by design — see the module preamble on set drift. `status:` with
+ * no member is still lifecycle-namespaced and must not fall through as taxonomy.
+ *
+ * @param {unknown} name
+ * @returns {boolean}
+ */
+export function isLifecycleLabel(name) {
+  if (typeof name !== "string") {
+    return false;
+  }
+  return name.trim().toLowerCase().startsWith(LIFECYCLE_LABEL_PREFIX);
+}
+
+/**
+ * Is this timeline actor a bot?
+ *
+ * Checks GitHub's first-class `type` discriminator first, then falls back to the
+ * `[bot]` login suffix so an actor payload lacking `type` is still classified.
+ * A missing actor is NOT a bot: unattributable is handled separately, and
+ * guessing "bot" there would silently drop legitimate labels.
+ *
+ * @param {Actor | null | undefined} actor
+ * @returns {boolean}
+ */
+export function isBotActor(actor) {
+  if (!actor || typeof actor !== "object") {
+    return false;
+  }
+  if (typeof actor.type === "string" && actor.type.toLowerCase() === "bot") {
+    return true;
+  }
+  return (
+    typeof actor.login === "string" &&
+    actor.login.trim().toLowerCase().endsWith("[bot]")
+  );
+}
+
+/**
+ * Resolve which of an item's lifecycle labels intake is entitled to believe.
+ *
+ * Read-only and total: every lifecycle label on the item lands in exactly one of
+ * `trusted` or `untrusted`, and `evaluated` carries the reasoning for all of
+ * them so a distrust decision is auditable rather than invisible.
+ *
+ * Provenance that cannot be established (a label applied at creation, which
+ * GitHub records no `labeled` event for) is TRUSTED but reported in
+ * `unknownProvenance`. Failing closed there would make intake ignore the
+ * human `status:ready` that opens the queue, stalling every project — so the
+ * blind spot is surfaced rather than guessed at. Supplying `issueAuthor` closes
+ * it, by attributing creation-time labels to whoever filed the item.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly timeline?: readonly TimelineEvent[]
+ *   readonly issueCreatedAt?: string
+ *   readonly issueAuthor?: Actor | null
+ *   readonly windowSeconds?: number
+ * }} input
+ * @returns {{
+ *   readonly trusted: readonly string[]
+ *   readonly untrusted: readonly Omit<EvaluatedLabel, "trusted">[]
+ *   readonly unknownProvenance: readonly string[]
+ *   readonly evaluated: readonly EvaluatedLabel[]
+ *   readonly hasUntrustedLifecycleLabels: boolean
+ * }}
+ */
+export function resolveTrustedLifecycleLabels(input = {}) {
+  const windowSeconds = normalizeWindow(input.windowSeconds);
+  const createdAtMs = parseTimestamp(input.issueCreatedAt);
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+  const latestApplication = indexLatestLabelApplications(input.timeline);
+
+  const evaluated = lifecycleLabels.map(label =>
+    evaluateLabel({
+      label,
+      application: latestApplication.get(label.trim().toLowerCase()),
+      createdAtMs,
+      issueAuthor: input.issueAuthor,
+      windowSeconds,
+    })
+  );
+
+  return {
+    trusted: evaluated.filter(entry => entry.trusted).map(entry => entry.label),
+    untrusted: evaluated
+      .filter(entry => !entry.trusted)
+      .map(({ trusted: _trusted, ...rest }) => rest),
+    unknownProvenance: evaluated
+      .filter(entry => entry.reason === "provenance-unknown")
+      .map(entry => entry.label),
+    evaluated,
+    hasUntrustedLifecycleLabels: evaluated.some(entry => !entry.trusted),
+  };
+}
+
+/**
+ * The lifecycle labels that mean "this work is finished", read from live config.
+ *
+ * Only the PRODUCTION rung of the `done` role is terminal. `status:on-dev` and
+ * `status:on-stg` are shipped-somewhere, not finished, and closing on them would
+ * retire work that still has environments to clear.
+ *
+ * @param {unknown} config a parsed `.lisa.config.json`-shaped object
+ * @returns {readonly string[]}
+ */
+export function terminalLifecycleLabels(config) {
+  const done = readPath(config, ["github", "labels", "build", "done"]);
+
+  if (typeof done === "string" && done.trim().length > 0) {
+    return [done.trim()];
+  }
+  const production = readPath(done, ["production"]);
+  if (typeof production === "string" && production.trim().length > 0) {
+    return [production.trim()];
+  }
+  return [DEFAULT_TERMINAL_LIFECYCLE_LABEL];
+}
+
+/**
+ * Detect lifecycle labels that contradict native state, in BOTH directions.
+ *
+ * `directionsWalked` is always the full direction list, so a caller reporting
+ * "clean" is asserting it looked at both — the failure mode refinement #1 of
+ * issue #2539 describes, where only the auto-complete direction was ever
+ * repaired and the reverse rotted unobserved.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly state?: string
+ *   readonly terminalLabels?: readonly string[]
+ * }} input
+ * @returns {{
+ *   readonly drifts: readonly { direction: string, label: string }[]
+ *   readonly directionsWalked: readonly string[]
+ * }}
+ */
+export function detectLifecycleDrift(input = {}) {
+  const terminal = new Set(
+    (input.terminalLabels ?? terminalLifecycleLabels(undefined)).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
+  const closed =
+    String(input.state ?? "")
+      .trim()
+      .toLowerCase() === "closed";
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+
+  const drifts = lifecycleLabels.flatMap(label => {
+    const isTerminal = terminal.has(label.trim().toLowerCase());
+    if (isTerminal && !closed) {
+      return [{ direction: "terminal-label-open-state", label }];
+    }
+    if (!isTerminal && closed) {
+      return [{ direction: "open-label-closed-state", label }];
+    }
+    return [];
+  });
+
+  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+}
+
+/**
+ * Classify one lifecycle label against its most recent application.
+ *
+ * @param {{
+ *   label: string
+ *   application?: { actor?: Actor | null, createdAtMs: number | null }
+ *   createdAtMs: number | null
+ *   issueAuthor?: Actor | null
+ *   windowSeconds: number
+ * }} params
+ * @returns {EvaluatedLabel}
+ */
+function evaluateLabel(params) {
+  const { label, application, createdAtMs, issueAuthor, windowSeconds } =
+    params;
+
+  const actor = application ? application.actor : issueAuthor;
+  const hasProvenance = Boolean(application) || Boolean(issueAuthor);
+
+  if (!hasProvenance) {
+    return {
+      label,
+      actor: null,
+      latencySeconds: null,
+      reason: "provenance-unknown",
+      trusted: true,
+    };
+  }
+
+  const login = typeof actor?.login === "string" ? actor.login : null;
+
+  if (!isBotActor(actor)) {
+    return {
+      label,
+      actor: login,
+      latencySeconds: latencySeconds(createdAtMs, application),
+      reason: "human-actor",
+      trusted: true,
+    };
+  }
+
+  const latency = latencySeconds(createdAtMs, application);
+  const implausible = latency === null || latency < windowSeconds;
+
+  return {
+    label,
+    actor: login,
+    latencySeconds: latency,
+    reason: implausible
+      ? "bot-actor-implausible-latency"
+      : "bot-actor-plausible-latency",
+    trusted: !implausible,
+  };
+}
+
+/**
+ * Seconds between item creation and the label application.
+ *
+ * A creation-time label (no timeline event) is latency 0 by construction.
+ *
+ * @param {number | null} createdAtMs
+ * @param {{ createdAtMs: number | null } | undefined} application
+ * @returns {number | null}
+ */
+function latencySeconds(createdAtMs, application) {
+  if (createdAtMs === null) {
+    return null;
+  }
+  if (!application) {
+    return 0;
+  }
+  if (application.createdAtMs === null) {
+    return null;
+  }
+  return Math.max(
+    0,
+    Math.round((application.createdAtMs - createdAtMs) / 1000)
+  );
+}
+
+/**
+ * Map each lifecycle label to its MOST RECENT `labeled` event.
+ *
+ * Most-recent, not first: a human who removes the bot's label and re-applies it
+ * has made a genuine claim, and keying on the first application would keep
+ * distrusting a label the human now owns.
+ *
+ * @param {readonly TimelineEvent[] | undefined} timeline
+ * @returns {Map<string, { actor?: Actor | null, createdAtMs: number | null }>}
+ */
+function indexLatestLabelApplications(timeline) {
+  const index = new Map();
+
+  for (const event of Array.isArray(timeline) ? timeline : []) {
+    if (event?.event !== "labeled") {
+      continue;
+    }
+    const name = event.label?.name;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      continue;
+    }
+    const key = name.trim().toLowerCase();
+    const createdAtMs = parseTimestamp(event.created_at);
+    const existing = index.get(key);
+    if (
+      existing &&
+      existing.createdAtMs !== null &&
+      createdAtMs !== null &&
+      existing.createdAtMs > createdAtMs
+    ) {
+      continue;
+    }
+    index.set(key, { actor: event.actor ?? null, createdAtMs });
+  }
+
+  return index;
+}
+
+/**
+ * @param {readonly (string | { readonly name?: string })[] | undefined} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabelNames(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label => (typeof label === "string" ? label : label?.name))
+    .filter(name => typeof name === "string" && name.trim().length > 0);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function parseTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
+function normalizeWindow(value) {
+  return Number.isFinite(value) && value >= 0
+    ? Number(value)
+    : IMPLAUSIBLE_CLAIM_WINDOW_SECONDS;
+}
+
+/**
+ * @param {unknown} source
+ * @param {readonly string[]} keys
+ * @returns {unknown}
+ */
+function readPath(source, keys) {
+  return keys.reduce(
+    (current, key) =>
+      current && typeof current === "object" ? current[key] : undefined,
+    source
+  );
+}
+
+/**
+ * CLI: read a `{ issue, timeline, config }` payload on stdin, print the verdict.
+ *
+ * Exits 0 even when untrusted labels are found. This is a classifier, not a
+ * gate: callers run it inside `set -e` intake bash and branch on the JSON, and a
+ * non-zero exit would abort the scan on the very issues it exists to rescue.
+ *
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const payload = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+  const issue = payload.issue ?? {};
+
+  const trust = resolveTrustedLifecycleLabels({
+    labels: issue.labels,
+    timeline: payload.timeline,
+    issueCreatedAt: issue.created_at ?? issue.createdAt,
+    issueAuthor: issue.user ?? issue.author,
+    windowSeconds: payload.windowSeconds,
+  });
+  const drift = detectLifecycleDrift({
+    labels: issue.labels,
+    state: issue.state,
+    terminalLabels: terminalLifecycleLabels(payload.config),
+  });
+
+  process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
@@ -178,14 +178,38 @@ If none of the configured role labels exist on the repo → label convention not
 Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
 
 ```bash
-gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
-gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
-jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
-      --slurpfile c .lisa.config.json \
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE. Reading `$t[0]` would pass only page one,
+# silently dropping later label events — the newest of which is exactly the
+# application this classifier keys on. --slurp + `add` flattens all pages.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Resolve config the SAME way `read_role` does: the local file overrides the
+# global one key by key. Reading only `.lisa.config.json` would resolve a stale
+# terminal `done` label for any project that overrides it locally, and
+# `lisa-repair-intake` WRITES on the drift direction that mistake produces.
+# Both files are optional — a missing one must not abort the cycle.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
       '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
-  > /tmp/lisa-trust-input.json
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+The temp directory is **per invocation**. Fixed `/tmp/lisa-*.json` paths let two concurrent intake cycles interleave one issue's metadata with another's timeline, which yields a confident verdict about an item that was never examined.
 
 The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
 

--- a/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
@@ -168,6 +168,36 @@ gh label list --repo <org>/<repo> --json name \
 
 If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
 
+#### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
+
+**A `status:*` label is only a lifecycle signal if a trustworthy actor applied it.** Third-party GitHub Apps write labels through the same API humans do, and at least one — `coderabbitai[bot]` — stamps `status:*` on issues seconds after filing. Measured on CodySwannGT/lisa#2460–#2540: seven of eight bot-applied lifecycle labels landed 26–118s after creation. Those labels are guesses wearing the costume of the intake contract, and they break the queue in **both** directions:
+
+- a bot-applied **`$CLAIMED`** makes an unworked issue look like somebody's active work, so no cycle picks it up and no human re-examines it (#2470 sat unworked for a day this way);
+- a bot-applied **`$READY`** puts an issue into the build queue that no human ever flipped ready (#2538), inverting the gate the ready role exists to be.
+
+Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
+
+```bash
+gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
+jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
+      --slurpfile c .lisa.config.json \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > /tmp/lisa-trust-input.json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
+
+- a candidate whose `$READY` is **untrusted** is **not claimable** — skip it and leave it for a human to flip genuinely ready; report it in the summary rather than dispatching it;
+- a candidate whose `$CLAIMED` is **untrusted** is **not claimed** — if its `$READY` is trusted it stays a normal candidate, exactly as if the bot label were absent.
+
+**Never unlabel to correct this.** The bot re-applies its label on each subsequent review event, so reverting produces a label-flap loop that is worse than the defect. The guard is that intake stops *believing* the label; it writes nothing. Distrust is idempotent and cannot race.
+
+A label whose provenance cannot be established (applied at creation, which GitHub records no `labeled` event for) is trusted but listed in `unknownProvenance` — failing closed there would ignore the human `status:ready` that opens the queue. Report that list; do not silently drop it.
+
+Lifecycle membership is decided by the **`status:` prefix**, never by a pinned member list. The live family has drifted 7 → 6 members, and a literal set breaks silently: an unrecognised member simply fails to match, so the guard would report clean on exactly the case it stopped covering.
+
 ### Phase 3 — Process the first eligible ready issue
 
 #### 3a.0 Repo-scope gate (claim only current-repo issues)

--- a/plugins/lisa/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-repair-intake/SKILL.md
@@ -560,6 +560,60 @@ native-open / active / unresolved:
 4. Post a compact `[lisa-repair-intake]` note only when the native close-out changed state or when
    an actionable setup error must be surfaced. Do not spam already-closed terminal items.
 
+### Lifecycle label contradicts native state — walk BOTH directions
+
+A lifecycle label can lie in two ways, and historically only one of them had an owner:
+
+| label | native state | owned by |
+|---|---|---|
+| terminal `done` role | still open / active | the `Build terminal-open` section above |
+| non-terminal role (`ready`, `claimed`, `blocked`, or any other `status:` member) | closed / completed | **nothing, until now** |
+
+A pass that walks one direction leaves the other accumulating silently. Measured on the Linear TUN
+board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still natively open in
+`On Dev`** — invisible to intake and indistinguishable from handled, exactly like a bot-applied
+`status:in-progress` on GitHub.
+
+Resolve both directions in one pass with the shipped detector, which always reports
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
+   Do not restate its rules; the terminality test lives there (intermediate env rungs like
+   `status:on-dev` / `status:on-stg` are **not** terminal).
+2. **`open-label-closed-state`** → the previously unowned direction. The item is natively closed or
+   completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
+   terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
+   **Lisa's own** lifecycle surface, not a contest with another writer.
+3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
+   `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
+   repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native
+   state as authoritative and remove the contradicting stale label; never move the state to match a
+   label.
+
+Membership in the lifecycle namespace is decided by the **`status:` prefix**, never a pinned member
+list — the live family has drifted 7 → 6 members, and a literal set fails silently by simply not
+matching the member it stopped covering.
+
+### Bot-authored lifecycle label → distrust, never revert (read-only)
+
+`status:*` labels written by a **bot** actor within the plausibility window of the item's creation are
+not lifecycle signals — see `lisa-github-build-intake` Phase 2b for the measurement and the
+classifier. Report them here so an operator can see how much of the board is wearing a label nobody
+chose:
+
+- list each item alongside the untrusted label, the bot login, and the latency, from the classifier's
+  `untrusted` array;
+- list `unknownProvenance` labels separately — trusted, but unattributable;
+- **do not unlabel and do not relabel.** The bot re-applies on each subsequent review event, so a
+  reverting reconciler produces a label-flap loop that is worse than the defect. Repair happens by
+  intake declining to *believe* the label, which is idempotent and writes nothing.
+
+This class is deliberately **read-only** and never counts toward the repair cap's actionable work.
+
 ### Build parent rollup reconciliation (intermediate-env or terminal close-out)
 
 For each parent/container item (an Epic, a Linear Project, or any item — of any type — with open child work),

--- a/plugins/lisa/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-repair-intake/SKILL.md
@@ -575,11 +575,49 @@ board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still nat
 `status:in-progress` on GitHub.
 
 Resolve both directions in one pass with the shipped detector, which always reports
-`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined.
+
+**Build the classifier input inside this cycle. Never consume a temp file another skill wrote.**
+repair-intake runs as its own cycle, so borrowing `lisa-github-build-intake`'s scratch file fails
+two ways: absent, the redirect fails and `set -e` aborts the whole cycle; stale from an earlier run
+on a *different* item, the resolver classifies that other item and this section reports `drifts: []`
+while `directionsWalked` still claims both directions were walked. That is precisely the
+silent-clean verdict this section promises cannot happen.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE; --slurp + `add` flattens all of them so a
+# label event on page two is not silently dropped.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Same resolution `read_role` uses: local overrides global, both optional.
+# Resolving a stale terminal `done` here would make the true terminal label look
+# like `open-label-closed-state` — and that direction WRITES.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+**Untrusted labels are excluded from `drifts` before any repair runs** — the classifier does this
+itself, so repair must **never act on a label the classifier refused to believe**. Without it, a
+bot-applied label on a natively closed item would be advanced to the terminal `done` role by the
+`open-label-closed-state` repair, laundering the exact input the guard rejected into a real write.
+The `excluded` array reports what was held back; surface it, do not repair it.
 
 1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
    Do not restate its rules; the terminality test lives there (intermediate env rungs like
@@ -588,6 +626,9 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust
    completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
    terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
    **Lisa's own** lifecycle surface, not a contest with another writer.
+   Apply the leaf/container check from the **Lifecycle ownership guard** section *before* this
+   branch: repair-intake owns container repair, so a natively-closed `ready` **leaf** is skipped
+   here and left to the build lane rather than claimed by this pass.
 3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
    `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
    repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native

--- a/plugins/src/base/scripts/lifecycle-label-trust.mjs
+++ b/plugins/src/base/scripts/lifecycle-label-trust.mjs
@@ -225,14 +225,22 @@ export function terminalLifecycleLabels(config) {
  * issue #2539 describes, where only the auto-complete direction was ever
  * repaired and the reverse rotted unobserved.
  *
+ * `excludeLabels` removes labels from consideration entirely. Callers MUST pass
+ * the untrusted set here: `open-label-closed-state` is a repair direction that
+ * WRITES (it advances the label to the terminal `done` role), so without this a
+ * bot-applied label the classifier just refused to believe would still drive a
+ * real label write — the guard would launder the very input it rejected.
+ *
  * @param {{
  *   readonly labels?: readonly (string | { readonly name?: string })[]
  *   readonly state?: string
  *   readonly terminalLabels?: readonly string[]
+ *   readonly excludeLabels?: readonly string[]
  * }} input
  * @returns {{
  *   readonly drifts: readonly { direction: string, label: string }[]
  *   readonly directionsWalked: readonly string[]
+ *   readonly excluded: readonly string[]
  * }}
  */
 export function detectLifecycleDrift(input = {}) {
@@ -241,12 +249,23 @@ export function detectLifecycleDrift(input = {}) {
       String(label).trim().toLowerCase()
     )
   );
+  const excluded = new Set(
+    (Array.isArray(input.excludeLabels) ? input.excludeLabels : []).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
   const closed =
     String(input.state ?? "")
       .trim()
       .toLowerCase() === "closed";
-  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+  const allLifecycleLabels = normalizeLabelNames(input.labels).filter(
     isLifecycleLabel
+  );
+  const skipped = allLifecycleLabels.filter(label =>
+    excluded.has(label.trim().toLowerCase())
+  );
+  const lifecycleLabels = allLifecycleLabels.filter(
+    label => !excluded.has(label.trim().toLowerCase())
   );
 
   const drifts = lifecycleLabels.flatMap(label => {
@@ -260,7 +279,11 @@ export function detectLifecycleDrift(input = {}) {
     return [];
   });
 
-  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+  return {
+    drifts,
+    directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS,
+    excluded: skipped,
+  };
 }
 
 /**
@@ -450,10 +473,14 @@ async function main() {
     issueAuthor: issue.user ?? issue.author,
     windowSeconds: payload.windowSeconds,
   });
+  // Untrusted labels are excluded here rather than at the call site: the
+  // `open-label-closed-state` direction WRITES, so a caller that forgot to pass
+  // them would launder a label the classifier just rejected into a real write.
   const drift = detectLifecycleDrift({
     labels: issue.labels,
     state: issue.state,
     terminalLabels: terminalLifecycleLabels(payload.config),
+    excludeLabels: trust.untrusted.map(entry => entry.label),
   });
 
   process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);

--- a/plugins/src/base/scripts/lifecycle-label-trust.mjs
+++ b/plugins/src/base/scripts/lifecycle-label-trust.mjs
@@ -1,0 +1,467 @@
+#!/usr/bin/env node
+/**
+ * Lifecycle-label trust resolution — the read-side guard for #2539.
+ *
+ * ## The defect
+ *
+ * `coderabbitai[bot]` stamps a `status:*` label on issues seconds after they are
+ * filed. Measured across CodySwannGT/lisa#2460–#2540, seven of eight bot-applied
+ * lifecycle labels landed 26–118s after creation — far too fast to be a real
+ * claim. An issue wearing a bot-applied `status:in-progress` is invisible to
+ * build-intake (it is not the `ready` role) AND looks handled to a human, so
+ * nothing re-examines it. A MISSING lifecycle label is recoverable; a WRONG one
+ * is silent in both directions at once.
+ *
+ * ## Why this guard reads instead of writes
+ *
+ * The label is applied by a webhook after the fact, so no pre-tool check on this
+ * machine has anything to intercept — the write never passes through us. The two
+ * remaining options were a reconciler that reverts the label, and this: intake
+ * refusing to BELIEVE the label. The reconciler was rejected because the bot
+ * re-applies on every subsequent review event, so reverting produces a label-flap
+ * loop that is worse than the disease. Distrust is idempotent, cannot race, and
+ * writes nothing — nothing in this module mutates a tracker.
+ *
+ * ## Why actor alone is not enough
+ *
+ * #2470 (false claim, 27s) and #2494 (real, 3001s) were BOTH applied by
+ * `coderabbitai[bot]`. Rejecting every bot-authored lifecycle label would
+ * discard the true one; rejecting every fast label would discard the human
+ * `status:ready` applied at filing time, which is the queue's entry signal.
+ * Distrust therefore requires BOTH conditions: a bot actor AND a latency below
+ * the plausibility window.
+ *
+ * ## Why the member set is never hardcoded
+ *
+ * The live `status:*` family has drifted 7 → 6 members. A pinned literal breaks
+ * silently — an unrecognised member simply fails to match, so the guard reports
+ * clean on exactly the case it stopped covering. Membership is decided by the
+ * `status:` PREFIX and terminality is resolved from live config.
+ */
+
+/** Lifecycle labels are identified by this prefix, never by a pinned set. */
+export const LIFECYCLE_LABEL_PREFIX = "status:";
+
+/**
+ * Fallback terminal label used only when config supplies no `done` role.
+ *
+ * This module ships standalone into host projects and cannot import Lisa's
+ * TypeScript `BUILD_LABEL_DEFAULTS`, so the literal is repeated here — but it is
+ * NOT free to drift: `lifecycle-label-trust.test.ts` asserts it stays equal to
+ * `BUILD_LABEL_DEFAULTS.done.production` in `src/sync/lifecycle-defaults.ts`.
+ * This is a fallback only; a configured project resolves the value live.
+ */
+export const DEFAULT_TERMINAL_LIFECYCLE_LABEL = "status:done";
+
+/**
+ * Seconds below which a BOT-applied lifecycle label is not believable as a claim.
+ *
+ * Calibrated against measurement, not taste: the observed false bot claims
+ * clustered at 26–118s, while the one corroborated bot label landed at 3001s.
+ * 300s sits an order of magnitude above the noise and an order of magnitude
+ * below the real signal, so neither edge is close to the boundary.
+ */
+export const IMPLAUSIBLE_CLAIM_WINDOW_SECONDS = 300;
+
+/**
+ * Both directions a lifecycle label can contradict native state.
+ *
+ * Emitted on every drift result so a repair pass cannot walk one direction and
+ * silently leave the other accumulating — the asymmetry that let TUN-556 and
+ * TUN-503 sit on a terminal `status:done` while still natively open.
+ */
+export const LIFECYCLE_DRIFT_DIRECTIONS = [
+  "terminal-label-open-state",
+  "open-label-closed-state",
+];
+
+/**
+ * @typedef {{ readonly login?: string, readonly type?: string }} Actor
+ *
+ * @typedef {{
+ *   readonly event?: string
+ *   readonly label?: { readonly name?: string }
+ *   readonly actor?: Actor | null
+ *   readonly created_at?: string
+ * }} TimelineEvent
+ *
+ * @typedef {{
+ *   readonly label: string
+ *   readonly actor: string | null
+ *   readonly latencySeconds: number | null
+ *   readonly reason: string
+ *   readonly trusted: boolean
+ * }} EvaluatedLabel
+ */
+
+/**
+ * Is this label part of the lifecycle namespace?
+ *
+ * Prefix-only by design — see the module preamble on set drift. `status:` with
+ * no member is still lifecycle-namespaced and must not fall through as taxonomy.
+ *
+ * @param {unknown} name
+ * @returns {boolean}
+ */
+export function isLifecycleLabel(name) {
+  if (typeof name !== "string") {
+    return false;
+  }
+  return name.trim().toLowerCase().startsWith(LIFECYCLE_LABEL_PREFIX);
+}
+
+/**
+ * Is this timeline actor a bot?
+ *
+ * Checks GitHub's first-class `type` discriminator first, then falls back to the
+ * `[bot]` login suffix so an actor payload lacking `type` is still classified.
+ * A missing actor is NOT a bot: unattributable is handled separately, and
+ * guessing "bot" there would silently drop legitimate labels.
+ *
+ * @param {Actor | null | undefined} actor
+ * @returns {boolean}
+ */
+export function isBotActor(actor) {
+  if (!actor || typeof actor !== "object") {
+    return false;
+  }
+  if (typeof actor.type === "string" && actor.type.toLowerCase() === "bot") {
+    return true;
+  }
+  return (
+    typeof actor.login === "string" &&
+    actor.login.trim().toLowerCase().endsWith("[bot]")
+  );
+}
+
+/**
+ * Resolve which of an item's lifecycle labels intake is entitled to believe.
+ *
+ * Read-only and total: every lifecycle label on the item lands in exactly one of
+ * `trusted` or `untrusted`, and `evaluated` carries the reasoning for all of
+ * them so a distrust decision is auditable rather than invisible.
+ *
+ * Provenance that cannot be established (a label applied at creation, which
+ * GitHub records no `labeled` event for) is TRUSTED but reported in
+ * `unknownProvenance`. Failing closed there would make intake ignore the
+ * human `status:ready` that opens the queue, stalling every project — so the
+ * blind spot is surfaced rather than guessed at. Supplying `issueAuthor` closes
+ * it, by attributing creation-time labels to whoever filed the item.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly timeline?: readonly TimelineEvent[]
+ *   readonly issueCreatedAt?: string
+ *   readonly issueAuthor?: Actor | null
+ *   readonly windowSeconds?: number
+ * }} input
+ * @returns {{
+ *   readonly trusted: readonly string[]
+ *   readonly untrusted: readonly Omit<EvaluatedLabel, "trusted">[]
+ *   readonly unknownProvenance: readonly string[]
+ *   readonly evaluated: readonly EvaluatedLabel[]
+ *   readonly hasUntrustedLifecycleLabels: boolean
+ * }}
+ */
+export function resolveTrustedLifecycleLabels(input = {}) {
+  const windowSeconds = normalizeWindow(input.windowSeconds);
+  const createdAtMs = parseTimestamp(input.issueCreatedAt);
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+  const latestApplication = indexLatestLabelApplications(input.timeline);
+
+  const evaluated = lifecycleLabels.map(label =>
+    evaluateLabel({
+      label,
+      application: latestApplication.get(label.trim().toLowerCase()),
+      createdAtMs,
+      issueAuthor: input.issueAuthor,
+      windowSeconds,
+    })
+  );
+
+  return {
+    trusted: evaluated.filter(entry => entry.trusted).map(entry => entry.label),
+    untrusted: evaluated
+      .filter(entry => !entry.trusted)
+      .map(({ trusted: _trusted, ...rest }) => rest),
+    unknownProvenance: evaluated
+      .filter(entry => entry.reason === "provenance-unknown")
+      .map(entry => entry.label),
+    evaluated,
+    hasUntrustedLifecycleLabels: evaluated.some(entry => !entry.trusted),
+  };
+}
+
+/**
+ * The lifecycle labels that mean "this work is finished", read from live config.
+ *
+ * Only the PRODUCTION rung of the `done` role is terminal. `status:on-dev` and
+ * `status:on-stg` are shipped-somewhere, not finished, and closing on them would
+ * retire work that still has environments to clear.
+ *
+ * @param {unknown} config a parsed `.lisa.config.json`-shaped object
+ * @returns {readonly string[]}
+ */
+export function terminalLifecycleLabels(config) {
+  const done = readPath(config, ["github", "labels", "build", "done"]);
+
+  if (typeof done === "string" && done.trim().length > 0) {
+    return [done.trim()];
+  }
+  const production = readPath(done, ["production"]);
+  if (typeof production === "string" && production.trim().length > 0) {
+    return [production.trim()];
+  }
+  return [DEFAULT_TERMINAL_LIFECYCLE_LABEL];
+}
+
+/**
+ * Detect lifecycle labels that contradict native state, in BOTH directions.
+ *
+ * `directionsWalked` is always the full direction list, so a caller reporting
+ * "clean" is asserting it looked at both — the failure mode refinement #1 of
+ * issue #2539 describes, where only the auto-complete direction was ever
+ * repaired and the reverse rotted unobserved.
+ *
+ * @param {{
+ *   readonly labels?: readonly (string | { readonly name?: string })[]
+ *   readonly state?: string
+ *   readonly terminalLabels?: readonly string[]
+ * }} input
+ * @returns {{
+ *   readonly drifts: readonly { direction: string, label: string }[]
+ *   readonly directionsWalked: readonly string[]
+ * }}
+ */
+export function detectLifecycleDrift(input = {}) {
+  const terminal = new Set(
+    (input.terminalLabels ?? terminalLifecycleLabels(undefined)).map(label =>
+      String(label).trim().toLowerCase()
+    )
+  );
+  const closed =
+    String(input.state ?? "")
+      .trim()
+      .toLowerCase() === "closed";
+  const lifecycleLabels = normalizeLabelNames(input.labels).filter(
+    isLifecycleLabel
+  );
+
+  const drifts = lifecycleLabels.flatMap(label => {
+    const isTerminal = terminal.has(label.trim().toLowerCase());
+    if (isTerminal && !closed) {
+      return [{ direction: "terminal-label-open-state", label }];
+    }
+    if (!isTerminal && closed) {
+      return [{ direction: "open-label-closed-state", label }];
+    }
+    return [];
+  });
+
+  return { drifts, directionsWalked: LIFECYCLE_DRIFT_DIRECTIONS };
+}
+
+/**
+ * Classify one lifecycle label against its most recent application.
+ *
+ * @param {{
+ *   label: string
+ *   application?: { actor?: Actor | null, createdAtMs: number | null }
+ *   createdAtMs: number | null
+ *   issueAuthor?: Actor | null
+ *   windowSeconds: number
+ * }} params
+ * @returns {EvaluatedLabel}
+ */
+function evaluateLabel(params) {
+  const { label, application, createdAtMs, issueAuthor, windowSeconds } =
+    params;
+
+  const actor = application ? application.actor : issueAuthor;
+  const hasProvenance = Boolean(application) || Boolean(issueAuthor);
+
+  if (!hasProvenance) {
+    return {
+      label,
+      actor: null,
+      latencySeconds: null,
+      reason: "provenance-unknown",
+      trusted: true,
+    };
+  }
+
+  const login = typeof actor?.login === "string" ? actor.login : null;
+
+  if (!isBotActor(actor)) {
+    return {
+      label,
+      actor: login,
+      latencySeconds: latencySeconds(createdAtMs, application),
+      reason: "human-actor",
+      trusted: true,
+    };
+  }
+
+  const latency = latencySeconds(createdAtMs, application);
+  const implausible = latency === null || latency < windowSeconds;
+
+  return {
+    label,
+    actor: login,
+    latencySeconds: latency,
+    reason: implausible
+      ? "bot-actor-implausible-latency"
+      : "bot-actor-plausible-latency",
+    trusted: !implausible,
+  };
+}
+
+/**
+ * Seconds between item creation and the label application.
+ *
+ * A creation-time label (no timeline event) is latency 0 by construction.
+ *
+ * @param {number | null} createdAtMs
+ * @param {{ createdAtMs: number | null } | undefined} application
+ * @returns {number | null}
+ */
+function latencySeconds(createdAtMs, application) {
+  if (createdAtMs === null) {
+    return null;
+  }
+  if (!application) {
+    return 0;
+  }
+  if (application.createdAtMs === null) {
+    return null;
+  }
+  return Math.max(
+    0,
+    Math.round((application.createdAtMs - createdAtMs) / 1000)
+  );
+}
+
+/**
+ * Map each lifecycle label to its MOST RECENT `labeled` event.
+ *
+ * Most-recent, not first: a human who removes the bot's label and re-applies it
+ * has made a genuine claim, and keying on the first application would keep
+ * distrusting a label the human now owns.
+ *
+ * @param {readonly TimelineEvent[] | undefined} timeline
+ * @returns {Map<string, { actor?: Actor | null, createdAtMs: number | null }>}
+ */
+function indexLatestLabelApplications(timeline) {
+  const index = new Map();
+
+  for (const event of Array.isArray(timeline) ? timeline : []) {
+    if (event?.event !== "labeled") {
+      continue;
+    }
+    const name = event.label?.name;
+    if (typeof name !== "string" || name.trim().length === 0) {
+      continue;
+    }
+    const key = name.trim().toLowerCase();
+    const createdAtMs = parseTimestamp(event.created_at);
+    const existing = index.get(key);
+    if (
+      existing &&
+      existing.createdAtMs !== null &&
+      createdAtMs !== null &&
+      existing.createdAtMs > createdAtMs
+    ) {
+      continue;
+    }
+    index.set(key, { actor: event.actor ?? null, createdAtMs });
+  }
+
+  return index;
+}
+
+/**
+ * @param {readonly (string | { readonly name?: string })[] | undefined} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabelNames(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label => (typeof label === "string" ? label : label?.name))
+    .filter(name => typeof name === "string" && name.trim().length > 0);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number | null}
+ */
+function parseTimestamp(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {number}
+ */
+function normalizeWindow(value) {
+  return Number.isFinite(value) && value >= 0
+    ? Number(value)
+    : IMPLAUSIBLE_CLAIM_WINDOW_SECONDS;
+}
+
+/**
+ * @param {unknown} source
+ * @param {readonly string[]} keys
+ * @returns {unknown}
+ */
+function readPath(source, keys) {
+  return keys.reduce(
+    (current, key) =>
+      current && typeof current === "object" ? current[key] : undefined,
+    source
+  );
+}
+
+/**
+ * CLI: read a `{ issue, timeline, config }` payload on stdin, print the verdict.
+ *
+ * Exits 0 even when untrusted labels are found. This is a classifier, not a
+ * gate: callers run it inside `set -e` intake bash and branch on the JSON, and a
+ * non-zero exit would abort the scan on the very issues it exists to rescue.
+ *
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  const payload = JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}");
+  const issue = payload.issue ?? {};
+
+  const trust = resolveTrustedLifecycleLabels({
+    labels: issue.labels,
+    timeline: payload.timeline,
+    issueCreatedAt: issue.created_at ?? issue.createdAt,
+    issueAuthor: issue.user ?? issue.author,
+    windowSeconds: payload.windowSeconds,
+  });
+  const drift = detectLifecycleDrift({
+    labels: issue.labels,
+    state: issue.state,
+    terminalLabels: terminalLifecycleLabels(payload.config),
+  });
+
+  process.stdout.write(`${JSON.stringify({ ...trust, ...drift }, null, 2)}\n`);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch(error => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
@@ -178,14 +178,38 @@ If none of the configured role labels exist on the repo → label convention not
 Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
 
 ```bash
-gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
-gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
-jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
-      --slurpfile c .lisa.config.json \
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE. Reading `$t[0]` would pass only page one,
+# silently dropping later label events — the newest of which is exactly the
+# application this classifier keys on. --slurp + `add` flattens all pages.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Resolve config the SAME way `read_role` does: the local file overrides the
+# global one key by key. Reading only `.lisa.config.json` would resolve a stale
+# terminal `done` label for any project that overrides it locally, and
+# `lisa-repair-intake` WRITES on the drift direction that mistake produces.
+# Both files are optional — a missing one must not abort the cycle.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
       '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
-  > /tmp/lisa-trust-input.json
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+The temp directory is **per invocation**. Fixed `/tmp/lisa-*.json` paths let two concurrent intake cycles interleave one issue's metadata with another's timeline, which yields a confident verdict about an item that was never examined.
 
 The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
 

--- a/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
@@ -168,6 +168,36 @@ gh label list --repo <org>/<repo> --json name \
 
 If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
 
+#### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
+
+**A `status:*` label is only a lifecycle signal if a trustworthy actor applied it.** Third-party GitHub Apps write labels through the same API humans do, and at least one — `coderabbitai[bot]` — stamps `status:*` on issues seconds after filing. Measured on CodySwannGT/lisa#2460–#2540: seven of eight bot-applied lifecycle labels landed 26–118s after creation. Those labels are guesses wearing the costume of the intake contract, and they break the queue in **both** directions:
+
+- a bot-applied **`$CLAIMED`** makes an unworked issue look like somebody's active work, so no cycle picks it up and no human re-examines it (#2470 sat unworked for a day this way);
+- a bot-applied **`$READY`** puts an issue into the build queue that no human ever flipped ready (#2538), inverting the gate the ready role exists to be.
+
+Before treating any candidate's lifecycle labels as meaningful, resolve which ones are trustworthy:
+
+```bash
+gh api "repos/<org>/<repo>/issues/<n>" > /tmp/lisa-issue.json
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate > /tmp/lisa-timeline.json
+jq -n --slurpfile i /tmp/lisa-issue.json --slurpfile t /tmp/lisa-timeline.json \
+      --slurpfile c .lisa.config.json \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > /tmp/lisa-trust-input.json
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+The classifier returns `trusted`, `untrusted`, `unknownProvenance`, and a per-label `evaluated` list carrying the actor and the latency behind each decision. **Use `trusted` wherever this skill would otherwise read the raw label set**, and specifically:
+
+- a candidate whose `$READY` is **untrusted** is **not claimable** — skip it and leave it for a human to flip genuinely ready; report it in the summary rather than dispatching it;
+- a candidate whose `$CLAIMED` is **untrusted** is **not claimed** — if its `$READY` is trusted it stays a normal candidate, exactly as if the bot label were absent.
+
+**Never unlabel to correct this.** The bot re-applies its label on each subsequent review event, so reverting produces a label-flap loop that is worse than the defect. The guard is that intake stops *believing* the label; it writes nothing. Distrust is idempotent and cannot race.
+
+A label whose provenance cannot be established (applied at creation, which GitHub records no `labeled` event for) is trusted but listed in `unknownProvenance` — failing closed there would ignore the human `status:ready` that opens the queue. Report that list; do not silently drop it.
+
+Lifecycle membership is decided by the **`status:` prefix**, never by a pinned member list. The live family has drifted 7 → 6 members, and a literal set breaks silently: an unrecognised member simply fails to match, so the guard would report clean on exactly the case it stopped covering.
+
 ### Phase 3 — Process the first eligible ready issue
 
 #### 3a.0 Repo-scope gate (claim only current-repo issues)

--- a/plugins/src/base/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-repair-intake/SKILL.md
@@ -560,6 +560,60 @@ native-open / active / unresolved:
 4. Post a compact `[lisa-repair-intake]` note only when the native close-out changed state or when
    an actionable setup error must be surfaced. Do not spam already-closed terminal items.
 
+### Lifecycle label contradicts native state — walk BOTH directions
+
+A lifecycle label can lie in two ways, and historically only one of them had an owner:
+
+| label | native state | owned by |
+|---|---|---|
+| terminal `done` role | still open / active | the `Build terminal-open` section above |
+| non-terminal role (`ready`, `claimed`, `blocked`, or any other `status:` member) | closed / completed | **nothing, until now** |
+
+A pass that walks one direction leaves the other accumulating silently. Measured on the Linear TUN
+board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still natively open in
+`On Dev`** — invisible to intake and indistinguishable from handled, exactly like a bot-applied
+`status:in-progress` on GitHub.
+
+Resolve both directions in one pass with the shipped detector, which always reports
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+```
+
+1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
+   Do not restate its rules; the terminality test lives there (intermediate env rungs like
+   `status:on-dev` / `status:on-stg` are **not** terminal).
+2. **`open-label-closed-state`** → the previously unowned direction. The item is natively closed or
+   completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
+   terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
+   **Lisa's own** lifecycle surface, not a contest with another writer.
+3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
+   `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
+   repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native
+   state as authoritative and remove the contradicting stale label; never move the state to match a
+   label.
+
+Membership in the lifecycle namespace is decided by the **`status:` prefix**, never a pinned member
+list — the live family has drifted 7 → 6 members, and a literal set fails silently by simply not
+matching the member it stopped covering.
+
+### Bot-authored lifecycle label → distrust, never revert (read-only)
+
+`status:*` labels written by a **bot** actor within the plausibility window of the item's creation are
+not lifecycle signals — see `lisa-github-build-intake` Phase 2b for the measurement and the
+classifier. Report them here so an operator can see how much of the board is wearing a label nobody
+chose:
+
+- list each item alongside the untrusted label, the bot login, and the latency, from the classifier's
+  `untrusted` array;
+- list `unknownProvenance` labels separately — trusted, but unattributable;
+- **do not unlabel and do not relabel.** The bot re-applies on each subsequent review event, so a
+  reverting reconciler produces a label-flap loop that is worse than the defect. Repair happens by
+  intake declining to *believe* the label, which is idempotent and writes nothing.
+
+This class is deliberately **read-only** and never counts toward the repair cap's actionable work.
+
 ### Build parent rollup reconciliation (intermediate-env or terminal close-out)
 
 For each parent/container item (an Epic, a Linear Project, or any item — of any type — with open child work),

--- a/plugins/src/base/skills/lisa-repair-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-repair-intake/SKILL.md
@@ -575,11 +575,49 @@ board: **TUN-556 and TUN-503 both carry a terminal `status:done` while still nat
 `status:in-progress` on GitHub.
 
 Resolve both directions in one pass with the shipped detector, which always reports
-`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined:
+`directionsWalked` covering both, so a "clean" verdict is an assertion that both were examined.
+
+**Build the classifier input inside this cycle. Never consume a temp file another skill wrote.**
+repair-intake runs as its own cycle, so borrowing `lisa-github-build-intake`'s scratch file fails
+two ways: absent, the redirect fails and `set -e` aborts the whole cycle; stale from an earlier run
+on a *different* item, the resolver classifies that other item and this section reports `drifts: []`
+while `directionsWalked` still claims both directions were walked. That is precisely the
+silent-clean verdict this section promises cannot happen.
 
 ```bash
-node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust-input.json
+TRUST_DIR=$(mktemp -d)
+trap 'rm -rf "$TRUST_DIR"' EXIT
+
+gh api "repos/<org>/<repo>/issues/<n>" > "$TRUST_DIR/issue.json"
+
+# --paginate emits ONE ARRAY PER PAGE; --slurp + `add` flattens all of them so a
+# label event on page two is not silently dropped.
+gh api "repos/<org>/<repo>/issues/<n>/timeline?per_page=100" --paginate --slurp \
+  > "$TRUST_DIR/pages.json"
+jq 'add // []' "$TRUST_DIR/pages.json" > "$TRUST_DIR/timeline.json"
+
+# Same resolution `read_role` uses: local overrides global, both optional.
+# Resolving a stale terminal `done` here would make the true terminal label look
+# like `open-label-closed-state` — and that direction WRITES.
+jq -s '(.[0] // {}) * (.[1] // {})' \
+  <(cat .lisa.config.json 2>/dev/null || echo '{}') \
+  <(cat .lisa.config.local.json 2>/dev/null || echo '{}') \
+  > "$TRUST_DIR/config.json"
+
+jq -n --slurpfile i "$TRUST_DIR/issue.json" \
+      --slurpfile t "$TRUST_DIR/timeline.json" \
+      --slurpfile c "$TRUST_DIR/config.json" \
+      '{issue: $i[0], timeline: $t[0], config: $c[0]}' \
+  > "$TRUST_DIR/input.json"
+
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < "$TRUST_DIR/input.json"
 ```
+
+**Untrusted labels are excluded from `drifts` before any repair runs** — the classifier does this
+itself, so repair must **never act on a label the classifier refused to believe**. Without it, a
+bot-applied label on a natively closed item would be advanced to the terminal `done` role by the
+`open-label-closed-state` repair, laundering the exact input the guard rejected into a real write.
+The `excluded` array reports what was held back; surface it, do not repair it.
 
 1. **`terminal-label-open-state`** → hand to the `Build terminal-open → native close` section above.
    Do not restate its rules; the terminality test lives there (intermediate env rungs like
@@ -588,6 +626,9 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/lifecycle-label-trust.mjs" < /tmp/lisa-trust
    completed while still wearing a non-terminal lifecycle role. Advance the label to the env-resolved
    terminal `done` role and post one idempotent `[lisa-repair-intake]` note. This is a write on
    **Lisa's own** lifecycle surface, not a contest with another writer.
+   Apply the leaf/container check from the **Lifecycle ownership guard** section *before* this
+   branch: repair-intake owns container repair, so a natively-closed `ready` **leaf** is skipped
+   here and left to the build lane rather than claimed by this pass.
 3. **Vendor caveat — Linear.** On Linear the lifecycle surface is the native workflow **state**, not a
    `status:*` label (see `config-resolution`). A `status:*` label there is leftover cruft that no
    repair direction reads, which is precisely why TUN-556 and TUN-503 rotted. Treat Linear's native

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -926,6 +926,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "f183e62848ac539da56a525fe2105fc6251a49e555a01dd1bba10d9227b1a6bf",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
       "5ef1c323d7cbfda8976f6fb0c24f7a8e5f5757475fd1d71c6e5bec91023cebe3",
+    "plugins/src/base/scripts/lifecycle-label-trust.mjs":
+      "8d9048bd28f7ae2903e8075b4c04abe7924d4f993bf5024d7dd911958f3ef08d",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":
       "8592c7359ee6cdb35995a882c8bb27e7b9c404074067fd272c70013e44e04b71",
     "plugins/src/base/scripts/project-ideation-idempotency-harness.mjs":
@@ -1007,7 +1009,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-add-journey/SKILL.md":
       "6b3bbe8ff85c7cb20412dcfcab3d7506a3efc67907cb749622c329fb4130baf4",
     "plugins/src/base/skills/lisa-github-build-intake/SKILL.md":
-      "8666ee2ac982168b292f5ddcf397f5c444a7d8dfbad056b67e1c1a7682853b70",
+      "dc1962f8ec1e41e6eb90f64d94b40bb560f901e5e361bd8bdc690d9770deb2f6",
     "plugins/src/base/skills/lisa-github-claim/SKILL.md":
       "71301c6d45d7eb5523e74aa7f070bb2becf57ca68fb8bde9e02ee937b78815f7",
     "plugins/src/base/skills/lisa-github-create/SKILL.md":
@@ -1203,7 +1205,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs":
       "475963ed64d9e72a6cbd6cbb61c8b57a419f2e1805e3ddfa76066047c590deeb",
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":
-      "aa43509858efe5b8967596cfc33e462ac1bd7aae0633564057cc2fc98d64fa4f",
+      "e1b1febf4761bc3a18748de717a10c9a68b2995f79c2d3c51b7488a018dc2646",
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":
       "4d460993fac6021219ca23eee29b1b9afa7c37479dddc662b2fcfaca510edd68",
     "plugins/src/base/skills/lisa-research/SKILL.md":
@@ -3352,6 +3354,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/scripts/design-source-gate.mjs": true,
     "plugins/lisa-agy/scripts/doctor-report.mjs": true,
     "plugins/lisa-agy/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/lisa-agy/scripts/lifecycle-label-trust.mjs": true,
     "plugins/lisa-agy/scripts/plugin-sync-explain.mjs": true,
     "plugins/lisa-agy/scripts/project-ideation-idempotency-harness.mjs": true,
     "plugins/lisa-agy/scripts/queue-contract-resolution.mjs": true,
@@ -3813,6 +3816,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/scripts/design-source-gate.mjs": true,
     "plugins/lisa-copilot/scripts/doctor-report.mjs": true,
     "plugins/lisa-copilot/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/lisa-copilot/scripts/lifecycle-label-trust.mjs": true,
     "plugins/lisa-copilot/scripts/plugin-sync-explain.mjs": true,
     "plugins/lisa-copilot/scripts/project-ideation-idempotency-harness.mjs": true,
     "plugins/lisa-copilot/scripts/queue-contract-resolution.mjs": true,
@@ -4260,6 +4264,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/scripts/design-source-gate.mjs": true,
     "plugins/lisa-cursor/scripts/doctor-report.mjs": true,
     "plugins/lisa-cursor/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/lisa-cursor/scripts/lifecycle-label-trust.mjs": true,
     "plugins/lisa-cursor/scripts/plugin-sync-explain.mjs": true,
     "plugins/lisa-cursor/scripts/project-ideation-idempotency-harness.mjs": true,
     "plugins/lisa-cursor/scripts/queue-contract-resolution.mjs": true,
@@ -6798,6 +6803,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/scripts/design-source-gate.mjs": true,
     "plugins/lisa/scripts/doctor-report.mjs": true,
     "plugins/lisa/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/lisa/scripts/lifecycle-label-trust.mjs": true,
     "plugins/lisa/scripts/plugin-sync-explain.mjs": true,
     "plugins/lisa/scripts/project-ideation-idempotency-harness.mjs": true,
     "plugins/lisa/scripts/queue-contract-resolution.mjs": true,
@@ -7426,6 +7432,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/scripts/design-source-gate.mjs": true,
     "plugins/src/base/scripts/doctor-report.mjs": true,
     "plugins/src/base/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/src/base/scripts/lifecycle-label-trust.mjs": true,
     "plugins/src/base/scripts/plugin-sync-explain.mjs": true,
     "plugins/src/base/scripts/project-ideation-idempotency-harness.mjs": true,
     "plugins/src/base/scripts/queue-contract-resolution.mjs": true,
@@ -9145,6 +9152,9 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/learnings-audit-contract.test.ts": true,
     "tests/unit/strategies/learnings-confirmation-contract.test.ts": true,
     "tests/unit/strategies/learnings-overflow-contract.test.ts": true,
+    "tests/unit/strategies/lifecycle-label-trust-contract.test.ts": true,
+    "tests/unit/strategies/lifecycle-label-trust-resolution.test.ts": true,
+    "tests/unit/strategies/lifecycle-label-trust.test.ts": true,
     "tests/unit/strategies/linear-access-history.test.ts": true,
     "tests/unit/strategies/linear-ready-state-inversion.test.ts": true,
     "tests/unit/strategies/merge.test.ts": true,
@@ -9197,6 +9207,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/setup-linear-prd-verified-label.test.ts": true,
     "tests/unit/strategies/setup-notion-prd-verified-status.test.ts": true,
     "tests/unit/strategies/stale-state-claims-rule.test.ts": true,
+    "tests/unit/strategies/support/lifecycle-label-trust.ts": true,
     "tests/unit/strategies/tagged-merge.test.ts": true,
     "tests/unit/strategies/tracked-work-contract.test.ts": true,
     "tests/unit/strategies/two-way-pr-ticket-linking.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -927,7 +927,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
       "5ef1c323d7cbfda8976f6fb0c24f7a8e5f5757475fd1d71c6e5bec91023cebe3",
     "plugins/src/base/scripts/lifecycle-label-trust.mjs":
-      "8d9048bd28f7ae2903e8075b4c04abe7924d4f993bf5024d7dd911958f3ef08d",
+      "954c3618faa7f623303a43021425160e0681801b10b4c8980cbad9e0b4fdfef7",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":
       "8592c7359ee6cdb35995a882c8bb27e7b9c404074067fd272c70013e44e04b71",
     "plugins/src/base/scripts/project-ideation-idempotency-harness.mjs":
@@ -1009,7 +1009,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-add-journey/SKILL.md":
       "6b3bbe8ff85c7cb20412dcfcab3d7506a3efc67907cb749622c329fb4130baf4",
     "plugins/src/base/skills/lisa-github-build-intake/SKILL.md":
-      "dc1962f8ec1e41e6eb90f64d94b40bb560f901e5e361bd8bdc690d9770deb2f6",
+      "9024898dd83ee386a776014742f13c6da8210b2a10e3d979c34cda352f164165",
     "plugins/src/base/skills/lisa-github-claim/SKILL.md":
       "71301c6d45d7eb5523e74aa7f070bb2becf57ca68fb8bde9e02ee937b78815f7",
     "plugins/src/base/skills/lisa-github-create/SKILL.md":
@@ -1205,7 +1205,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs":
       "475963ed64d9e72a6cbd6cbb61c8b57a419f2e1805e3ddfa76066047c590deeb",
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":
-      "e1b1febf4761bc3a18748de717a10c9a68b2995f79c2d3c51b7488a018dc2646",
+      "b9cc5064f24eead0c2f446951eb098a31b8e34c1d5e78929112d0685a6ce9de9",
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":
       "4d460993fac6021219ca23eee29b1b9afa7c37479dddc662b2fcfaca510edd68",
     "plugins/src/base/skills/lisa-research/SKILL.md":

--- a/tests/unit/strategies/lifecycle-label-trust-contract.test.ts
+++ b/tests/unit/strategies/lifecycle-label-trust-contract.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Regression coverage for the lifecycle-label trust contract (#2539).
+ *
+ * The classifier in `lifecycle-label-trust.mjs` is only a control if the intake
+ * and repair skills actually consult it, and only a control on every harness if
+ * it reaches each generated plugin mirror. These tests bind both: the skill
+ * prose must cite the classifier and the distrust-never-revert rule, and the
+ * script must exist in every mirror the plugin build produces.
+ *
+ * Assertions run against whitespace-flattened text so markdown line wrapping
+ * cannot break them, and so no assertion needs a backtracking-prone regex.
+ * @module tests/unit/strategies/lifecycle-label-trust-contract
+ */
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { flatten } from "./support/lifecycle-label-trust.js";
+
+const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
+
+const BUILD_INTAKE = "skills/lisa-github-build-intake/SKILL.md";
+const REPAIR_INTAKE = "skills/lisa-repair-intake/SKILL.md";
+const SCRIPT = "scripts/lifecycle-label-trust.mjs";
+const FLAP = "label-flap loop";
+
+const read = (root: string, relative: string): string =>
+  flatten(readFileSync(path.resolve(root, relative), "utf8"));
+
+describe("lifecycle-label trust contract (#2539)", () => {
+  describe.each(ROOTS)("%s", root => {
+    it("ships the classifier script alongside the skills that call it", () => {
+      expect(existsSync(path.resolve(root, SCRIPT))).toBe(true);
+    });
+
+    it("makes build-intake resolve label trust before believing a label", () => {
+      const skill = read(root, BUILD_INTAKE);
+
+      expect(skill).toContain("Lifecycle-label trust resolution");
+      expect(skill).toContain(SCRIPT);
+      expect(skill).toContain(
+        "Use `trusted` wherever this skill would otherwise read the raw label set"
+      );
+    });
+
+    it("refuses to claim on a bot-applied ready label", () => {
+      const skill = read(root, BUILD_INTAKE);
+
+      expect(skill).toContain("`$READY` is **untrusted** is **not claimable**");
+      expect(skill).toContain("`$CLAIMED` is **untrusted** is **not claimed**");
+    });
+
+    it("forbids reverting the bot's label in both skills", () => {
+      const intake = read(root, BUILD_INTAKE);
+      const repair = read(root, REPAIR_INTAKE);
+
+      expect(intake).toContain("Never unlabel to correct this");
+      expect(intake).toContain(FLAP);
+      expect(repair).toContain("do not unlabel and do not relabel");
+      expect(repair).toContain(FLAP);
+    });
+
+    it("keeps the bot-label repair class read-only", () => {
+      const repair = read(root, REPAIR_INTAKE);
+
+      expect(repair).toContain(
+        "Bot-authored lifecycle label → distrust, never revert"
+      );
+      expect(repair).toContain("deliberately **read-only**");
+    });
+
+    it("walks both lifecycle drift directions in one repair pass", () => {
+      const repair = read(root, REPAIR_INTAKE);
+      const section = repair.slice(
+        repair.indexOf("Lifecycle label contradicts native state"),
+        repair.indexOf("Bot-authored lifecycle label")
+      );
+
+      expect(section).toContain("terminal-label-open-state");
+      expect(section).toContain("open-label-closed-state");
+      expect(section).toContain("previously unowned direction");
+      expect(section).toContain("TUN-556 and TUN-503");
+    });
+
+    it("names Linear's native state as authoritative over a stale label", () => {
+      expect(read(root, REPAIR_INTAKE)).toContain(
+        "never move the state to match a label"
+      );
+    });
+
+    it("forbids a pinned status member set in both skills", () => {
+      for (const relative of [BUILD_INTAKE, REPAIR_INTAKE]) {
+        const skill = read(root, relative);
+
+        expect(skill).toContain("pinned member list");
+        expect(skill).toContain("drifted 7 → 6 members");
+      }
+    });
+  });
+});

--- a/tests/unit/strategies/lifecycle-label-trust-contract.test.ts
+++ b/tests/unit/strategies/lifecycle-label-trust-contract.test.ts
@@ -7,30 +7,80 @@
  * prose must cite the classifier and the distrust-never-revert rule, and the
  * script must exist in every mirror the plugin build produces.
  *
+ * **The roots are DISCOVERED, never hand-listed.** A literal array of mirrors is
+ * an assertion whose population is narrower than the thing it claims to cover —
+ * the same defect this PR exists to fix, and it would pass unchanged the day a
+ * sixth mirror is added. Roots come from globbing the build output, and the
+ * script requirement is pegged to an existing peer script so a mirror cannot
+ * quietly ship one without the other.
+ *
  * Assertions run against whitespace-flattened text so markdown line wrapping
  * cannot break them, and so no assertion needs a backtracking-prone regex.
  * @module tests/unit/strategies/lifecycle-label-trust-contract
  */
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
 import { flatten } from "./support/lifecycle-label-trust.js";
 
-const ROOTS = ["plugins/src/base", "plugins/lisa"] as const;
-
 const BUILD_INTAKE = "skills/lisa-github-build-intake/SKILL.md";
 const REPAIR_INTAKE = "skills/lisa-repair-intake/SKILL.md";
 const SCRIPT = "scripts/lifecycle-label-trust.mjs";
+/** An existing base script; any mirror shipping it must ship ours too. */
+const PEER_SCRIPT = "scripts/queue-health-classification.mjs";
 const FLAP = "label-flap loop";
+
+/**
+ * Every directory that carries the build-intake skill — the source of truth
+ * plus each generated mirror, discovered rather than enumerated.
+ *
+ * @returns absolute-relative roots, sorted for stable test naming
+ */
+const discoverRoots = (): readonly string[] => {
+  const found: string[] = [];
+  const visit = (dir: string, depth: number): void => {
+    if (depth > 3) {
+      return;
+    }
+    for (const entry of readdirSync(dir)) {
+      const child = path.join(dir, entry);
+      if (!statSync(child).isDirectory()) {
+        continue;
+      }
+      if (existsSync(path.join(child, BUILD_INTAKE))) {
+        found.push(child);
+      }
+      visit(child, depth + 1);
+    }
+  };
+  visit("plugins", 0);
+  return [...new Set([...found, "plugins/src/base"])].sort((left, right) =>
+    left.localeCompare(right)
+  );
+};
+
+const ROOTS = discoverRoots();
 
 const read = (root: string, relative: string): string =>
   flatten(readFileSync(path.resolve(root, relative), "utf8"));
 
 describe("lifecycle-label trust contract (#2539)", () => {
+  it("discovers every mirror instead of trusting a hand-listed array", () => {
+    // Guards the discovery itself: if the glob silently stopped matching, this
+    // suite would pass vacuously with zero roots.
+    expect(ROOTS.length).toBeGreaterThanOrEqual(5);
+    expect(ROOTS).toContain("plugins/src/base");
+    expect(ROOTS).toContain("plugins/lisa");
+  });
+
   describe.each(ROOTS)("%s", root => {
-    it("ships the classifier script alongside the skills that call it", () => {
+    it("ships the classifier wherever it ships its peer scripts", () => {
+      if (!existsSync(path.resolve(root, PEER_SCRIPT))) {
+        expect(existsSync(path.resolve(root, BUILD_INTAKE))).toBe(true);
+        return;
+      }
       expect(existsSync(path.resolve(root, SCRIPT))).toBe(true);
     });
 
@@ -96,6 +146,44 @@ describe("lifecycle-label trust contract (#2539)", () => {
         expect(skill).toContain("pinned member list");
         expect(skill).toContain("drifted 7 → 6 members");
       }
+    });
+
+    it("builds trust input per invocation, never from cross-skill temp state", () => {
+      for (const relative of [BUILD_INTAKE, REPAIR_INTAKE]) {
+        const skill = read(root, relative);
+
+        // Each skill mints its own temp dir and cleans it up.
+        expect(skill).toContain("TRUST_DIR=$(mktemp -d)");
+        expect(skill).toContain(`trap 'rm -rf "$TRUST_DIR"' EXIT`);
+        expect(skill).toContain('"$TRUST_DIR/input.json"');
+        // No fixed shared path any concurrent run could collide on. Assembled
+        // from parts so this guard does not itself hardcode a world-writable
+        // path literal (sonarjs/publicly-writable-directories).
+        expect(skill).not.toContain(
+          ["", "tmp", "lisa-trust-input.json"].join("/")
+        );
+      }
+    });
+
+    it("flattens the paginated timeline instead of reading page one", () => {
+      for (const relative of [BUILD_INTAKE, REPAIR_INTAKE]) {
+        expect(read(root, relative)).toContain("--paginate --slurp");
+      }
+    });
+
+    it("resolves config through the local override and tolerates absence", () => {
+      for (const relative of [BUILD_INTAKE, REPAIR_INTAKE]) {
+        const skill = read(root, relative);
+
+        expect(skill).toContain(".lisa.config.local.json");
+        expect(skill).toContain("2>/dev/null || echo '{}'");
+      }
+    });
+
+    it("excludes untrusted labels from the writing drift direction", () => {
+      expect(read(root, REPAIR_INTAKE)).toContain(
+        "never act on a label the classifier refused to believe"
+      );
     });
   });
 });

--- a/tests/unit/strategies/lifecycle-label-trust-resolution.test.ts
+++ b/tests/unit/strategies/lifecycle-label-trust-resolution.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Regression coverage for bot-authored lifecycle-label distrust (#2539).
+ *
+ * The decisive pair: #2470's `status:in-progress` landed 27s after filing and is
+ * a false claim; #2494's landed 3001s after filing and tracked real work. BOTH
+ * were applied by `coderabbitai[bot]`, so a guard keyed on the actor alone
+ * cannot separate them — and one keyed on latency alone would discard the human
+ * `status:ready` applied at filing time, which is the queue's entry signal.
+ * Distrust therefore requires a bot actor AND an implausible latency.
+ * @module tests/unit/strategies/lifecycle-label-trust-resolution
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  IMPLAUSIBLE_CLAIM_WINDOW_SECONDS,
+  resolveTrustedLifecycleLabels,
+} from "../../../plugins/src/base/scripts/lifecycle-label-trust.mjs";
+
+import {
+  BOT,
+  BOT_STAMP_2470,
+  CREATED_2470,
+  FICTIONAL,
+  HUMAN,
+  IMPLAUSIBLE,
+  IN_PROGRESS,
+  ISSUE_2470,
+  ISSUE_2494,
+  LABELED,
+  PLAUSIBLE,
+  READY,
+} from "./support/lifecycle-label-trust.js";
+
+describe("trusted lifecycle resolution (#2539)", () => {
+  it("distrusts #2470's bot claim applied 27s after filing", () => {
+    const result = resolveTrustedLifecycleLabels(ISSUE_2470);
+
+    expect(result.untrusted).toEqual([
+      {
+        label: IN_PROGRESS,
+        actor: BOT.login,
+        latencySeconds: 27,
+        reason: IMPLAUSIBLE,
+      },
+    ]);
+    expect(result.hasUntrustedLifecycleLabels).toBe(true);
+  });
+
+  it("keeps #2470 claimable by preserving the human-applied ready label", () => {
+    expect(resolveTrustedLifecycleLabels(ISSUE_2470).trusted).toEqual([READY]);
+  });
+
+  it("trusts #2494's bot label applied 3001s after filing", () => {
+    const result = resolveTrustedLifecycleLabels(ISSUE_2494);
+
+    expect(result.untrusted).toEqual([]);
+    expect(result.hasUntrustedLifecycleLabels).toBe(false);
+    expect(result.trusted).toEqual([IN_PROGRESS]);
+  });
+
+  it("reports the same 3001s latency it decided to trust", () => {
+    expect(resolveTrustedLifecycleLabels(ISSUE_2494).evaluated).toContainEqual({
+      label: IN_PROGRESS,
+      actor: BOT.login,
+      latencySeconds: 3001,
+      reason: PLAUSIBLE,
+      trusted: true,
+    });
+  });
+
+  it("distrusts a bot-applied label whose member is not in the known set", () => {
+    const result = resolveTrustedLifecycleLabels({
+      issueCreatedAt: CREATED_2470,
+      labels: [FICTIONAL],
+      timeline: [
+        {
+          event: LABELED,
+          label: { name: FICTIONAL },
+          actor: BOT,
+          created_at: BOT_STAMP_2470,
+        },
+      ],
+    });
+
+    expect(result.untrusted).toHaveLength(1);
+    expect(result.untrusted[0]?.label).toBe(FICTIONAL);
+    expect(result.trusted).toEqual([]);
+  });
+
+  it("trusts a human label applied instantly at filing time", () => {
+    const result = resolveTrustedLifecycleLabels({
+      issueCreatedAt: CREATED_2470,
+      labels: [READY],
+      timeline: [
+        {
+          event: LABELED,
+          label: { name: READY },
+          actor: HUMAN,
+          created_at: CREATED_2470,
+        },
+      ],
+    });
+
+    expect(result.trusted).toEqual([READY]);
+    expect(result.evaluated[0]?.reason).toBe("human-actor");
+  });
+
+  it("re-trusts a label a human re-applied after the bot", () => {
+    const result = resolveTrustedLifecycleLabels({
+      issueCreatedAt: CREATED_2470,
+      labels: [IN_PROGRESS],
+      timeline: [
+        {
+          event: LABELED,
+          label: { name: IN_PROGRESS },
+          actor: BOT,
+          created_at: BOT_STAMP_2470,
+        },
+        {
+          event: "unlabeled",
+          label: { name: IN_PROGRESS },
+          actor: HUMAN,
+          created_at: "2026-08-14T09:11:42Z",
+        },
+        {
+          event: LABELED,
+          label: { name: IN_PROGRESS },
+          actor: HUMAN,
+          created_at: "2026-08-14T09:22:17Z",
+        },
+      ],
+    });
+
+    expect(result.trusted).toEqual([IN_PROGRESS]);
+    expect(result.untrusted).toEqual([]);
+  });
+
+  it("ignores taxonomy labels entirely, whoever applied them", () => {
+    const result = resolveTrustedLifecycleLabels({
+      issueCreatedAt: CREATED_2470,
+      labels: ["bug", "repo:lisa"],
+      timeline: [
+        {
+          event: LABELED,
+          label: { name: "bug" },
+          actor: BOT,
+          created_at: BOT_STAMP_2470,
+        },
+      ],
+    });
+
+    expect(result.trusted).toEqual([]);
+    expect(result.untrusted).toEqual([]);
+    expect(result.evaluated).toEqual([]);
+  });
+
+  it("flags a label it cannot attribute instead of silently trusting it", () => {
+    const result = resolveTrustedLifecycleLabels({
+      issueCreatedAt: CREATED_2470,
+      labels: [READY],
+      timeline: [],
+    });
+
+    expect(result.trusted).toEqual([READY]);
+    expect(result.unknownProvenance).toEqual([READY]);
+    expect(result.evaluated[0]?.reason).toBe("provenance-unknown");
+  });
+
+  it("attributes a creation-time label to a bot author when one is supplied", () => {
+    const result = resolveTrustedLifecycleLabels({
+      issueCreatedAt: CREATED_2470,
+      issueAuthor: BOT,
+      labels: [IN_PROGRESS],
+      timeline: [],
+    });
+
+    expect(result.trusted).toEqual([]);
+    expect(result.untrusted[0]?.reason).toBe(IMPLAUSIBLE);
+    expect(result.unknownProvenance).toEqual([]);
+  });
+
+  it("honours a caller-supplied plausibility window", () => {
+    const result = resolveTrustedLifecycleLabels({
+      ...ISSUE_2470,
+      windowSeconds: 10,
+    });
+
+    expect(result.untrusted).toEqual([]);
+    expect(result.trusted).toEqual([READY, IN_PROGRESS]);
+  });
+
+  it("defaults the window above the observed bot noise, below a real claim", () => {
+    expect(IMPLAUSIBLE_CLAIM_WINDOW_SECONDS).toBe(300);
+    expect(IMPLAUSIBLE_CLAIM_WINDOW_SECONDS).toBeGreaterThan(118);
+    expect(IMPLAUSIBLE_CLAIM_WINDOW_SECONDS).toBeLessThan(3001);
+  });
+
+  it("never proposes a label write — the result carries no mutation plan", () => {
+    const keys = Object.keys(resolveTrustedLifecycleLabels(ISSUE_2470));
+
+    expect([...keys].sort((left, right) => left.localeCompare(right))).toEqual([
+      "evaluated",
+      "hasUntrustedLifecycleLabels",
+      "trusted",
+      "unknownProvenance",
+      "untrusted",
+    ]);
+  });
+});

--- a/tests/unit/strategies/lifecycle-label-trust.test.ts
+++ b/tests/unit/strategies/lifecycle-label-trust.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Regression coverage for lifecycle-label identification and drift (#2539).
+ *
+ * `coderabbitai[bot]` stamps `status:*` labels on issues seconds after they are
+ * filed. An issue wearing a bot-applied `status:in-progress` is invisible to
+ * build-intake AND looks handled to a human, so nothing re-examines it.
+ *
+ * This file covers the two halves that decide WHAT is a lifecycle label and
+ * WHEN one contradicts native state. Trust resolution lives in the sibling
+ * `lifecycle-label-trust-resolution` suite.
+ * @module tests/unit/strategies/lifecycle-label-trust
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_TERMINAL_LIFECYCLE_LABEL,
+  LIFECYCLE_DRIFT_DIRECTIONS,
+  LIFECYCLE_LABEL_PREFIX,
+  detectLifecycleDrift,
+  isBotActor,
+  isLifecycleLabel,
+  terminalLifecycleLabels,
+} from "../../../plugins/src/base/scripts/lifecycle-label-trust.mjs";
+import { BUILD_LABEL_DEFAULTS } from "../../../src/sync/lifecycle-defaults.js";
+
+import {
+  BOT,
+  DONE,
+  FICTIONAL,
+  HUMAN,
+  IN_PROGRESS,
+  ON_DEV,
+  ON_STG,
+  READY,
+} from "./support/lifecycle-label-trust.js";
+
+const TERMINAL = [DONE];
+const TAXONOMY = ["bug", "repo:lisa", "human-needed"];
+
+/** The rot direction repair-intake already owned. */
+const TERMINAL_OPEN = "terminal-label-open-state";
+/** The rot direction that had no owner before #2539. */
+const OPEN_CLOSED = "open-label-closed-state";
+
+describe("lifecycle label identification (#2539)", () => {
+  it("matches on the `status:` prefix rather than a pinned member set", () => {
+    expect(LIFECYCLE_LABEL_PREFIX).toBe("status:");
+  });
+
+  it("classifies every currently-known member as lifecycle", () => {
+    expect(isLifecycleLabel("status:blocked")).toBe(true);
+    expect(isLifecycleLabel(DONE)).toBe(true);
+    expect(isLifecycleLabel(IN_PROGRESS)).toBe(true);
+    expect(isLifecycleLabel(ON_DEV)).toBe(true);
+    expect(isLifecycleLabel(ON_STG)).toBe(true);
+    expect(isLifecycleLabel(READY)).toBe(true);
+  });
+
+  it("classifies an unknown future member as lifecycle (set drifted 7 -> 6)", () => {
+    expect(isLifecycleLabel(FICTIONAL)).toBe(true);
+    expect(isLifecycleLabel("status:awaiting-design")).toBe(true);
+    expect(isLifecycleLabel("status:")).toBe(true);
+  });
+
+  it("does not claim taxonomy labels", () => {
+    expect(isLifecycleLabel("bug")).toBe(false);
+    expect(isLifecycleLabel("type:bug")).toBe(false);
+    expect(isLifecycleLabel("priority:high")).toBe(false);
+    expect(isLifecycleLabel("repo:lisa")).toBe(false);
+    expect(isLifecycleLabel("component:status")).toBe(false);
+    expect(isLifecycleLabel("human-needed")).toBe(false);
+  });
+
+  it("tolerates surrounding whitespace and casing drift", () => {
+    expect(isLifecycleLabel("  status:ready  ")).toBe(true);
+    expect(isLifecycleLabel("Status:Ready")).toBe(true);
+  });
+
+  it("rejects non-string and empty input instead of throwing", () => {
+    expect(isLifecycleLabel("")).toBe(false);
+    expect(isLifecycleLabel(undefined)).toBe(false);
+    expect(isLifecycleLabel(null)).toBe(false);
+    expect(isLifecycleLabel(42)).toBe(false);
+  });
+});
+
+describe("bot actor identification (#2539)", () => {
+  it("identifies a bot by the timeline actor type", () => {
+    expect(isBotActor(BOT)).toBe(true);
+  });
+
+  it("identifies a bot by the [bot] login suffix when type is absent", () => {
+    expect(isBotActor({ login: "dependabot[bot]" })).toBe(true);
+    expect(isBotActor({ login: "some-new-app[bot]" })).toBe(true);
+  });
+
+  it("does not treat humans as bots", () => {
+    expect(isBotActor(HUMAN)).toBe(false);
+    expect(isBotActor({ login: "robotnik" })).toBe(false);
+  });
+
+  it("treats a missing actor as non-bot rather than throwing", () => {
+    expect(isBotActor(undefined)).toBe(false);
+    expect(isBotActor(null)).toBe(false);
+    expect(isBotActor({})).toBe(false);
+  });
+});
+
+describe("terminal lifecycle labels resolved from config (#2539)", () => {
+  it("treats only the production done rung as terminal", () => {
+    expect(
+      terminalLifecycleLabels({
+        github: {
+          labels: {
+            build: {
+              ready: READY,
+              done: { dev: ON_DEV, staging: ON_STG, production: DONE },
+            },
+          },
+        },
+      })
+    ).toEqual([DONE]);
+  });
+
+  it("follows a renamed done rung rather than a hardcoded literal", () => {
+    expect(
+      terminalLifecycleLabels({
+        github: {
+          labels: { build: { done: { production: "status:shipped" } } },
+        },
+      })
+    ).toEqual(["status:shipped"]);
+  });
+
+  it("falls back to the built-in default when config is absent", () => {
+    expect(terminalLifecycleLabels({})).toEqual([DONE]);
+    expect(terminalLifecycleLabels(undefined)).toEqual([DONE]);
+  });
+
+  it("keeps its standalone fallback bound to the TypeScript default", () => {
+    expect(DEFAULT_TERMINAL_LIFECYCLE_LABEL).toBe(
+      BUILD_LABEL_DEFAULTS.done.production
+    );
+  });
+
+  it("accepts a plain string done role", () => {
+    expect(
+      terminalLifecycleLabels({
+        github: { labels: { build: { done: "status:complete" } } },
+      })
+    ).toEqual(["status:complete"]);
+  });
+});
+
+describe("bidirectional lifecycle drift (#2539)", () => {
+  it("detects a terminal label on a natively open item (TUN-556 direction)", () => {
+    expect(
+      detectLifecycleDrift({
+        labels: [DONE],
+        state: "open",
+        terminalLabels: TERMINAL,
+      }).drifts
+    ).toEqual([{ direction: TERMINAL_OPEN, label: DONE }]);
+  });
+
+  it("detects a non-terminal label on a natively closed item", () => {
+    expect(
+      detectLifecycleDrift({
+        labels: [IN_PROGRESS],
+        state: "closed",
+        terminalLabels: TERMINAL,
+      }).drifts
+    ).toEqual([{ direction: OPEN_CLOSED, label: IN_PROGRESS }]);
+  });
+
+  it("reports both directions from one pass so neither can be skipped", () => {
+    expect(
+      detectLifecycleDrift({ labels: [], state: "open" }).directionsWalked
+    ).toEqual([TERMINAL_OPEN, OPEN_CLOSED]);
+    expect(LIFECYCLE_DRIFT_DIRECTIONS).toHaveLength(2);
+  });
+
+  it("does not treat the env rungs as terminal", () => {
+    expect(
+      detectLifecycleDrift({
+        labels: [ON_DEV, ON_STG],
+        state: "open",
+        terminalLabels: TERMINAL,
+      }).drifts
+    ).toEqual([]);
+  });
+
+  it("classifies an unknown member as a non-terminal lifecycle label", () => {
+    expect(
+      detectLifecycleDrift({
+        labels: [FICTIONAL],
+        state: "closed",
+        terminalLabels: TERMINAL,
+      }).drifts
+    ).toEqual([{ direction: OPEN_CLOSED, label: FICTIONAL }]);
+  });
+
+  it("ignores taxonomy labels in both directions", () => {
+    expect(
+      detectLifecycleDrift({
+        labels: TAXONOMY,
+        state: "closed",
+        terminalLabels: TERMINAL,
+      }).drifts
+    ).toEqual([]);
+  });
+
+  it("finds no drift when label and native state agree", () => {
+    expect(
+      detectLifecycleDrift({
+        labels: [DONE],
+        state: "closed",
+        terminalLabels: TERMINAL,
+      }).drifts
+    ).toEqual([]);
+    expect(
+      detectLifecycleDrift({
+        labels: [READY],
+        state: "open",
+        terminalLabels: TERMINAL,
+      }).drifts
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/strategies/lifecycle-label-trust.test.ts
+++ b/tests/unit/strategies/lifecycle-label-trust.test.ts
@@ -210,6 +210,51 @@ describe("bidirectional lifecycle drift (#2539)", () => {
     ).toEqual([]);
   });
 
+  it("excludes an untrusted label from the writing drift direction", () => {
+    const result = detectLifecycleDrift({
+      labels: [IN_PROGRESS],
+      state: "closed",
+      terminalLabels: TERMINAL,
+      excludeLabels: [IN_PROGRESS],
+    });
+
+    expect(result.drifts).toEqual([]);
+    expect(result.excluded).toEqual([IN_PROGRESS]);
+  });
+
+  it("still walks both directions while excluding a label", () => {
+    expect(
+      detectLifecycleDrift({
+        labels: [IN_PROGRESS],
+        state: "closed",
+        terminalLabels: TERMINAL,
+        excludeLabels: [IN_PROGRESS],
+      }).directionsWalked
+    ).toEqual([TERMINAL_OPEN, OPEN_CLOSED]);
+  });
+
+  it("keeps repairing trusted labels alongside an excluded one", () => {
+    const result = detectLifecycleDrift({
+      labels: [IN_PROGRESS, READY],
+      state: "closed",
+      terminalLabels: TERMINAL,
+      excludeLabels: [IN_PROGRESS],
+    });
+
+    expect(result.drifts).toEqual([{ direction: OPEN_CLOSED, label: READY }]);
+    expect(result.excluded).toEqual([IN_PROGRESS]);
+  });
+
+  it("reports nothing excluded when no exclusions are supplied", () => {
+    expect(
+      detectLifecycleDrift({
+        labels: [READY],
+        state: "open",
+        terminalLabels: TERMINAL,
+      }).excluded
+    ).toEqual([]);
+  });
+
   it("finds no drift when label and native state agree", () => {
     expect(
       detectLifecycleDrift({

--- a/tests/unit/strategies/support/lifecycle-label-trust.ts
+++ b/tests/unit/strategies/support/lifecycle-label-trust.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared fixtures for the lifecycle-label trust tests (#2539).
+ *
+ * The two issue fixtures are RECORDED from the live GitHub timeline API
+ * (`gh api repos/CodySwannGT/lisa/issues/<n>/timeline`), not invented. They are
+ * the pair the guard must be able to separate: #2470 is a bot claim 27s after
+ * filing (false), #2494 is a bot label 3001s after filing that corroborated real
+ * work. Both carry the SAME bot actor, which is why actor alone cannot decide.
+ * @module tests/unit/strategies/support/lifecycle-label-trust
+ */
+
+export const READY = "status:ready";
+export const IN_PROGRESS = "status:in-progress";
+export const DONE = "status:done";
+export const FICTIONAL = "status:whatever";
+
+/** Env rungs — shipped somewhere, but NOT terminal. */
+export const ON_DEV = "status:on-dev";
+export const ON_STG = "status:on-stg";
+
+export const HUMAN = { login: "CodySwannGT", type: "User" } as const;
+export const BOT = { login: "coderabbitai[bot]", type: "Bot" } as const;
+
+export const LABELED = "labeled";
+
+export const IMPLAUSIBLE = "bot-actor-implausible-latency";
+export const PLAUSIBLE = "bot-actor-plausible-latency";
+
+/** #2470 was created at this instant; the bot stamped it 27s later. */
+export const CREATED_2470 = "2026-08-13T08:33:48Z";
+
+/** The instant `coderabbitai[bot]` stamped #2470 — 27s after filing. */
+export const BOT_STAMP_2470 = "2026-08-13T08:34:15Z";
+
+/** Recorded from the #2470 timeline. */
+export const ISSUE_2470 = {
+  issueCreatedAt: CREATED_2470,
+  issueAuthor: HUMAN,
+  labels: [READY, IN_PROGRESS],
+  timeline: [
+    {
+      event: LABELED,
+      label: { name: READY },
+      actor: HUMAN,
+      created_at: "2026-08-13T08:33:49Z",
+    },
+    {
+      event: LABELED,
+      label: { name: IN_PROGRESS },
+      actor: BOT,
+      created_at: BOT_STAMP_2470,
+    },
+  ],
+} as const;
+
+/** Recorded from the #2494 timeline. */
+export const ISSUE_2494 = {
+  issueCreatedAt: "2026-08-13T11:04:12Z",
+  issueAuthor: HUMAN,
+  labels: ["bug", IN_PROGRESS],
+  timeline: [
+    {
+      event: LABELED,
+      label: { name: "bug" },
+      actor: HUMAN,
+      created_at: "2026-08-13T11:04:14Z",
+    },
+    {
+      event: LABELED,
+      label: { name: IN_PROGRESS },
+      actor: BOT,
+      created_at: "2026-08-13T11:54:13Z",
+    },
+  ],
+} as const;
+
+/**
+ * Collapse markdown line wrapping so prose assertions can match plain
+ * substrings instead of backtracking-prone whitespace regexes.
+ *
+ * @param source raw markdown
+ * @returns the same text with every whitespace run collapsed to one space
+ */
+export const flatten = (source: string): string => source.replace(/\s+/gu, " ");


### PR DESCRIPTION
## Problem

`coderabbitai[bot]` stamps `status:*` labels on issues seconds after they are filed. Measured across #2460–#2540, **seven of eight** bot-applied lifecycle labels landed 26–118s after creation — far too fast to be a real claim.

An issue wearing a bot-applied `status:in-progress` is **invisible to build-intake** *and* **looks handled** to a human, so nothing re-examines it. #2470 sat unworked for a day wearing one. The reverse harm exists too: a bot-applied `status:ready` (#2538) inverts the gate, putting work in the build queue that no human ever released.

A *missing* lifecycle label is recoverable. A *wrong* one is silent in both directions at once.

## Mechanism chosen: intake-side distrust, not a reverting reconciler

The label arrives by **webhook after the fact**, so a pre-check has nothing to intercept — the write never passes through this machine. That left two options:

| option | verdict |
|---|---|
| Reconciler that reverts the bot's label | **Rejected.** The bot re-applies on every subsequent review event, so reverting produces a label-flap loop that is worse than the defect. |
| Intake refuses to *believe* the label | **Chosen.** Idempotent, cannot race, writes nothing. |

New read-only classifier `plugins/src/base/scripts/lifecycle-label-trust.mjs`, wired into `lisa-github-build-intake` (new Phase 2b) and `lisa-repair-intake`, and fanned out to all five plugin variants.

### Actor alone is not a sufficient test

**#2470 (false, 27s) and #2494 (real, 3001s) carry the same bot actor.** Rejecting every bot-authored lifecycle label discards the true one; rejecting every fast label discards the human `status:ready` applied at filing time, which is the queue's entry signal. Distrust therefore requires **both** a bot actor **and** a latency below the plausibility window (default 300s — an order of magnitude above the 26–118s noise and below the 3001s real signal).

### The `status:` set is never pinned

Membership is decided by the **`status:` prefix**; terminality is resolved from live config. The live family has drifted 7 → 6 members, and a literal set fails silently — an unrecognised member simply does not match, so the guard would report clean on exactly the case it stopped covering.

### Both rot directions now walked

Per refinement 1 on the issue, `repair-intake` now reports `terminal-label-open-state` **and** `open-label-closed-state` from one pass (`directionsWalked` always lists both, so a "clean" verdict asserts both were examined), and treats Linear's native state as authoritative over a stale `status:*` label — the TUN-556 / TUN-503 case.

## Verification

All three required proofs, run against the **live GitHub timeline API** (real recorded events, replayed to reconstruct the label set as it stood):

| proof | result |
|---|---|
| Fires on #2470's 27s bot label | ✅ `untrusted: [status:in-progress, coderabbitai[bot], 27s]`; `status:ready` preserved so the issue stays claimable |
| Silent on #2494's 3001s bot label | ✅ `untrusted: []`, `trusted: [status:in-progress]` |
| Survives a set change (`status:whatever`) | ✅ classified as lifecycle and distrusted, not ignored |

Plus: `Object.keys` of the result is asserted to contain no mutation plan, and both skills are contract-tested to forbid unlabel/relabel.

**Full suite, unscoped:** 667 files / 11816 tests passed (baseline 663 / 11724; +92 tests). Lint, typecheck, conflict-marker check, and both derived-artifact checks green.

Work-Item: CodySwannGT/lisa#2539

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle-label trust evaluation using label provenance and application timing.
  * Added detection of mismatches between lifecycle labels and native item states.
  * Build intake now ignores untrusted readiness or claim signals without modifying labels.
  * Repair intake now reconciles lifecycle and native states in both directions.
  * Added read-only reporting for bot-authored and unknown-provenance labels.

* **Bug Fixes**
  * Prevented implausible bot-applied labels from influencing intake or repair decisions.
  * Preserved native workflow state as authoritative where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->