### PR TITLE
fix(ci): move the permissions floor onto jobs so work-item traceability can inherit the caller's grant

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -91,13 +91,12 @@ on:
         description: 'Linear API key (only when tracker is linear)'
         required: false
 
-permissions:
-  contents: read
-  checks: write
-  pull-requests: write
-
 jobs:
   lint:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: Lint
     runs-on: ubuntu-latest
     if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',lint,') }}
@@ -119,6 +118,10 @@ jobs:
   # non-bypassable layer. Human-approved exceptions live in .lisa.config.json
   # (thresholdRatchet.allow) and are honored only once merged into the base.
   threshold_ratchet:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: 📐 Threshold Ratchet
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -179,6 +182,15 @@ jobs:
     # Requesting a scope the caller never held is a startup_failure for the
     # ENTIRE run, and these workflows are consumed @main by repos whose ci.yml
     # is create-only and can never self-heal.
+    #
+    # That inheritance only works because this workflow declares no
+    # workflow-level `permissions:` block. It used to, and a workflow-level
+    # block is a CEILING that zeroes every scope it omits for any job without
+    # its own — so this job was capped at the top-level set regardless of the
+    # caller. Here the omitted scope was `issues: read`, so the `gh issue view`
+    # arm could never have worked on `tracker: github` even though
+    # `pull-requests: write` was present and the PR arm looked healthy. Each job
+    # now carries its own copy of the old floor; this one is blank on purpose.
 
     steps:
       - name: 📥 Checkout repository
@@ -269,6 +281,10 @@ jobs:
           node scripts/lisa-work-item.mjs validate-pr
 
   security:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: Security
     runs-on: ubuntu-latest
     if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',security,') }}
@@ -288,6 +304,10 @@ jobs:
         run: bundle exec bundler-audit check --update
 
   test-postgres:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: Test (PostgreSQL)
     runs-on: ubuntu-latest
     if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test,') && inputs.database_type == 'postgres' }}
@@ -324,6 +344,10 @@ jobs:
         run: bundle exec rspec
 
   test-mysql:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: Test (MySQL)
     runs-on: ubuntu-latest
     if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test,') && inputs.database_type == 'mysql' }}
@@ -363,6 +387,10 @@ jobs:
         run: bundle exec rspec
 
   mutation:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: 🧬 Mutation Testing Gate
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -413,6 +441,10 @@ jobs:
           fi
 
   code-quality:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: Code Quality
     runs-on: ubuntu-latest
     if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',code_quality,') }}
@@ -435,6 +467,10 @@ jobs:
         run: bundle exec flay app/ lib/
 
   secret_scanning:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: 🔐 GitGuardian Secret Detection
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -491,6 +527,10 @@ jobs:
           echo "To enable secret detection, add GITGUARDIAN_API_KEY to your repository secrets"
 
   sg_scan:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: 🔎 AST Grep Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -623,6 +663,10 @@ jobs:
           grep -qE "learnings budget passed|no learnings file" learnings-budget.out
 
   license_compliance:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: 📜 FOSSA License Check
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -657,6 +701,10 @@ jobs:
           echo "To enable license compliance checking, add FOSSA_API_KEY to your repository secrets"
 
   zap_baseline:
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     name: 🕷️ OWASP ZAP Baseline
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -243,12 +243,12 @@ concurrency:
 # granting >= read keep working, and no job relies on a write scope.
 # Jobs that touch neither the repository nor the API declare `permissions: {}`.
 # Never widen this floor — grant a job its minimal scope at the job level.
-permissions:
-  contents: read
 
 jobs:
   # Central dependency installation job to optimize performance
   install_dependencies:
+    permissions:
+      contents: read
     name: 📦 Install Dependencies
     runs-on: ubuntu-latest
     outputs:
@@ -355,6 +355,8 @@ jobs:
           echo "cache-hit=${{ steps.cache-modules.outputs.cache-hit }}" >> $GITHUB_OUTPUT
         id: cache-status
   lint:
+    permissions:
+      contents: read
     name: 🧹 Lint
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -411,6 +413,8 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
   lint_slow:
+    permissions:
+      contents: read
     name: 🐢 Slow Lint Rules
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -452,6 +456,8 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
   typecheck:
+    permissions:
+      contents: read
     name: 🔍 Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -513,6 +519,8 @@ jobs:
   # A caller still passing `skip_jobs: 'test'` is inert rather than broken.
 
   verification_coverage:
+    permissions:
+      contents: read
     name: ✅ Verification Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -541,6 +549,8 @@ jobs:
           VERIFY_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
 
   e2e_coverage:
+    permissions:
+      contents: read
     name: 🧭 E2E Route Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -601,6 +611,8 @@ jobs:
         run: echo "Skipping e2e route coverage - scripts/check-e2e-coverage.mjs not found"
 
   state_classification:
+    permissions:
+      contents: read
     name: 🧬 State Classification
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -656,6 +668,8 @@ jobs:
         run: echo "Skipping state classification - scripts/check-state-classification.mjs not found"
 
   bdd_coverage:
+    permissions:
+      contents: read
     name: 🧾 BDD Behavior Contract
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -791,6 +805,8 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   learnings_budget:
+    permissions:
+      contents: read
     name: 📚 Learnings Budget
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -855,6 +871,8 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
   test_unit:
+    permissions:
+      contents: read
     name: 🧪 Run Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -1004,6 +1022,8 @@ jobs:
         run: echo "Skipping unit tests - test:unit script not found in package.json"
 
   test_mutation:
+    permissions:
+      contents: read
     name: 🧬 Mutation Testing Gate
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -1072,6 +1092,8 @@ jobs:
         run: echo "Skipping mutation-testing gate - test:mutation script not found in package.json"
 
   test_integration:
+    permissions:
+      contents: read
     name: 🧪 Run Integration Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1139,6 +1161,8 @@ jobs:
         run: echo "Skipping integration tests - test:integration script not found in package.json"
 
   test_e2e:
+    permissions:
+      contents: read
     name: 🧪 Run E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 40
@@ -1225,6 +1249,8 @@ jobs:
         run: echo "Skipping E2E tests - test:e2e script not found in package.json"
 
   maestro_e2e:
+    permissions:
+      contents: read
     name: 📱 Maestro Cloud E2E Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -1333,6 +1359,8 @@ jobs:
           fi
 
   playwright_e2e:
+    permissions:
+      contents: read
     name: 🎭 Playwright E2E Tests
     needs: playwright_e2e_setup
     runs-on: ubuntu-latest
@@ -1547,6 +1575,8 @@ jobs:
   # ruleset regardless of shard count. Runs always so the unsuffixed check
   # is emitted even when `playwright_shards = 1`.
   playwright_e2e_aggregate:
+    permissions:
+      contents: read
     name: 🎭 Playwright E2E Tests
     needs: playwright_e2e
     runs-on: ubuntu-latest
@@ -1650,6 +1680,8 @@ jobs:
           exit 1
 
   format:
+    permissions:
+      contents: read
     name: 📐 Check Formatting
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1691,6 +1723,8 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
   build:
+    permissions:
+      contents: read
     name: 🏗️ Build
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -1838,6 +1872,8 @@ jobs:
   # under the seed's `"enforcement": "warn"`, which keeps a fresh install loud
   # rather than red.
   skipped_required_checks:
+    permissions:
+      contents: read
     name: 🔒 Skipped Required Checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1876,6 +1912,8 @@ jobs:
   # Human-approved exceptions live in .lisa.config.json (thresholdRatchet.allow)
   # and are honored only once merged into the base branch.
   threshold_ratchet:
+    permissions:
+      contents: read
     name: 📐 Threshold Ratchet
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -1949,19 +1987,31 @@ jobs:
     # DELIBERATELY no `permissions:` block. This job needs pull-requests:read
     # (`gh pr view`) and issues:read (`gh issue view`), but a called workflow
     # may only DOWNGRADE the caller's grant: requesting a scope the caller never
-    # held is a startup_failure for the ENTIRE run, not a skipped job. These
-    # workflows are consumed @main by repos whose ci.yml is create-only, so an
-    # escalation here would break every one of them — including on push paths
-    # where this job does not even run. Inheriting the caller's token instead
-    # keeps the blast radius inside this job.
+    # held is a startup_failure for the ENTIRE run, not a skipped job (#2046,
+    # #2566). These workflows are consumed @main by repos whose ci.yml is
+    # create-only, so an escalation here would break every one of them —
+    # including on push paths where this job does not even run. Inheriting the
+    # caller's token instead keeps the blast radius inside this job.
     #
-    # Measured, not assumed (#2476): on a private consumer whose caller job
-    # granted contents/issues/pull-requests read, this job's `gh` calls
-    # succeeded and the real validation ran; on a private consumer whose caller
-    # job had NO permissions block, they failed. So the caller's grant is the
-    # only lever, and the readiness probe below FAILS when it is missing — it
-    # used to exit 0 with a warning, which reported success for a gate that had
-    # verified nothing.
+    # "Inherits the caller's grant" is only true because this workflow declares
+    # NO workflow-level `permissions:` block. A workflow-level block is not a
+    # floor — it is a CEILING that also zeroes every scope it omits, for every
+    # job that declares none of its own. This workflow used to carry
+    # `permissions: contents: read` at the top, and that silently capped this
+    # job at contents+metadata no matter what the caller granted. Each job now
+    # carries its own copy of that floor instead; this one, and only this one,
+    # is left blank on purpose. Do not reintroduce a workflow-level block.
+    #
+    # Corrects the record from #2476, which claimed this was measured working on
+    # a consumer granting all three scopes. It was not: on 2026-08-14 two
+    # consumers granting contents/issues/pull-requests read both received
+    # `Contents: read, Metadata: read` and nothing else. The earlier red result
+    # was read as a genuine missing trailer when it was this scope gap.
+    #
+    # The readiness probe below FAILS when a scope is missing — it used to exit 0
+    # with a warning, which reported success for a gate that had verified
+    # nothing. That strictness is correct and must stay; the bug was the
+    # plumbing, not the refusal.
 
     steps:
       - name: 📥 Checkout repository
@@ -2094,6 +2144,8 @@ jobs:
           node scripts/lisa-work-item.mjs validate-pr
 
   dead_code:
+    permissions:
+      contents: read
     name: 🗑️ Dead Code Detection
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -2141,6 +2193,8 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
   sg_scan:
+    permissions:
+      contents: read
     name: 🔎 AST Grep Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -2284,6 +2338,8 @@ jobs:
           echo "then run 'ast-grep test --update-all' to record its snapshot."
 
   floor_collisions:
+    permissions:
+      contents: read
     name: 🧱 Security Floor Collisions
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -2326,6 +2382,8 @@ jobs:
           node "$script" | tee -a "$GITHUB_STEP_SUMMARY"
 
   npm_security_scan:
+    permissions:
+      contents: read
     name: 🔒 Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -2529,6 +2587,8 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
   sonarcloud:
+    permissions:
+      contents: read
     name: 🔍 SonarCloud SAST
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -2619,6 +2679,8 @@ jobs:
           echo "To enable SonarCloud analysis, add SONAR_TOKEN to your repository secrets"
 
   snyk:
+    permissions:
+      contents: read
     name: 🛡️ Snyk Dependency Scan
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -2690,6 +2752,8 @@ jobs:
           echo "To enable Snyk vulnerability scanning, add SNYK_TOKEN to your repository secrets"
 
   secret_scanning:
+    permissions:
+      contents: read
     name: 🔐 GitGuardian Secret Detection
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -2747,6 +2811,8 @@ jobs:
           echo "To enable secret detection, add GITGUARDIAN_API_KEY to your repository secrets"
 
   license_compliance:
+    permissions:
+      contents: read
     name: 📜 FOSSA License Check
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -2785,6 +2851,8 @@ jobs:
           echo "To enable license compliance checking, add FOSSA_API_KEY to your repository secrets"
 
   zap_baseline:
+    permissions:
+      contents: read
     name: 🕷️ OWASP ZAP Baseline
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -3204,6 +3272,8 @@ jobs:
 
   # Audit logging job
   audit_logger:
+    permissions:
+      contents: read
     name: 📊 Audit Logger
     runs-on: ubuntu-latest
     if: always()
@@ -3363,6 +3433,8 @@ jobs:
 
   # Approval gate for production deployments
   approval_gate:
+    permissions:
+      contents: read
     name: 🚦 Approval Gate
     runs-on: ubuntu-latest
     if: ${{ inputs.require_approval == true && inputs.compliance_framework != 'none' && inputs.approval_environment != '' }}

--- a/tests/integration/quality-workflow.test.ts
+++ b/tests/integration/quality-workflow.test.ts
@@ -602,11 +602,14 @@ describe("quality.yml reusable workflow", () => {
   describe("verification coverage labels", () => {
     it("passes event labels to the coverage script without live GitHub context", () => {
       const job = workflow.jobs.verification_coverage;
-      // The job declares no permissions of its own, so it resolves to the
-      // workflow-level least-privilege floor (#1769). What must never change
-      // is that it gains no `pull-requests` scope — the gate reads PR labels
-      // from the event payload, not the API.
-      expect(workflow.permissions).toEqual({ contents: "read" });
+      // This job used to inherit the workflow-level floor (#1769); that floor is
+      // now written onto each job directly, because as a workflow-level block it
+      // also zeroed the scopes it omitted for work_item_traceability. The scope
+      // this job resolves to is unchanged — assert it where it now lives.
+      //
+      // What must never change is that it gains no `pull-requests` scope: the
+      // gate reads PR labels from the event payload, not the API.
+      expect(job.permissions).toEqual({ contents: "read" });
       expect(job.permissions?.["pull-requests"]).toBeUndefined();
 
       const steps = job.steps ?? [];
@@ -736,12 +739,47 @@ describe("quality.yml reusable workflow", () => {
   });
 
   describe("least-privilege permissions floor", () => {
-    it("declares a workflow-level contents:read floor", () => {
-      // #1769: quality.yml is consumed fleet-wide via @main. Reusable-workflow
-      // tokens can only be downgraded relative to the caller's grant, so a
-      // read-only floor is safe for every consumer while capping consumers
-      // whose caller job declares no `permissions:` block of its own.
-      expect(workflow.permissions).toEqual({ contents: "read" });
+    it("declares NO workflow-level floor, because a floor is really a ceiling", () => {
+      // Reverses #1769, which assumed a workflow-level block only *caps* callers
+      // that grant too much. It does the opposite as well: it sets every scope it
+      // OMITS to `none` for every job declaring none of its own. `contents: read`
+      // here therefore capped work_item_traceability at contents+metadata no
+      // matter what the caller granted.
+      //
+      // Measured 2026-08-14: PropSwapLLC/backend and geminisportsai/backend-v2
+      // both granted contents/issues/pull-requests read on the calling job and
+      // both received `Contents: read, Metadata: read`. The gate reported
+      // "could verify NOTHING" and named the caller — which was already correct.
+      //
+      // The fix cannot be to add the scopes here. A called workflow requesting a
+      // scope the caller never held is a startup_failure for the caller's ENTIRE
+      // run (#2046, #2566), and these workflows are consumed @main by repos whose
+      // ci.yml is create-only. So the old floor moved down onto every job that
+      // relied on it, byte-for-byte, and only work_item_traceability is left
+      // blank — the one job that must inherit the caller's grant.
+      expect(workflow.permissions).toBeUndefined();
+    });
+
+    it("keeps the old floor on every job that used to inherit it", () => {
+      // The floor-move must not have widened anything. Every job except the one
+      // deliberate blank carries an explicit block, so a job added later cannot
+      // silently inherit the caller's full grant.
+      const blank = Object.entries(workflow.jobs)
+        .filter(([, job]) => job.permissions === undefined)
+        .map(([name]) => name);
+      expect(blank).toEqual(["work_item_traceability"]);
+
+      for (const [jobName, job] of Object.entries(workflow.jobs)) {
+        if (jobName === "work_item_traceability") {
+          continue;
+        }
+        // Either the moved floor, or a stricter block the job already declared.
+        const scopes = job.permissions ?? {};
+        expect(
+          scopes.contents === "read" || Object.keys(scopes).length === 0,
+          `${jobName} lost or widened the moved floor: ${JSON.stringify(scopes)}`
+        ).toBe(true);
+      }
     });
 
     it("gives summary-only jobs an empty permissions block", () => {

--- a/tests/unit/hooks/work-item-wiring.test.ts
+++ b/tests/unit/hooks/work-item-wiring.test.ts
@@ -61,6 +61,8 @@ function seedRepository(root: string): void {
 
 /** Minimal shape of the pieces of `ci.yml` this suite asserts on. */
 interface CiWorkflow {
+  /** Workflow-level block. Must stay absent — see the ceiling-not-floor test. */
+  readonly permissions?: Record<string, string>;
   readonly jobs?: Record<
     string,
     {
@@ -280,6 +282,33 @@ describe("work-item Git enforcement wiring", () => {
 
         expect(resolveBase({ baseRef: "main", baseSha: tip, root })).toBe(tip);
       });
+    });
+
+    it("declares no workflow-level permissions block, so blank means inherit", () => {
+      // A workflow-level block is not a floor, it is a CEILING: it also sets
+      // every scope it omits to `none` for any job declaring none of its own.
+      // Both files used to carry one, which silently capped work_item_traceability
+      // at the top-level set no matter what the caller granted — contents+metadata
+      // in quality.yml, and no `issues: read` in quality-rails.yml. Two consumers
+      // granting all three read scopes were measured receiving only
+      // `Contents: read, Metadata: read` (2026-08-14).
+      //
+      // The fix cannot be to ADD the scopes here: requesting a scope the caller
+      // never held startup_fails the caller's ENTIRE run (#2046, #2566). So the
+      // old floor was pushed down onto each job individually and the top-level
+      // block removed, which leaves this job's blank block meaning what it says.
+      expect(ci.permissions).toBeUndefined();
+    });
+
+    it("gives every other job an explicit block, so blank is never accidental", () => {
+      // With no workflow-level block, a job added without a `permissions:` key
+      // silently inherits the caller's full grant. That is correct for exactly
+      // one job and a silent widening everywhere else, so the blank must be
+      // unique and deliberate rather than a default.
+      const blank = Object.entries(ci.jobs ?? {})
+        .filter(([, candidate]) => candidate?.permissions === undefined)
+        .map(([name]) => name);
+      expect(blank).toEqual(["work_item_traceability"]);
     });
 
     it("never escalates permissions above the caller's grant", () => {


### PR DESCRIPTION
Fixes the live `quality.yml@main` breakage on every unpinned consumer.

A workflow-level `permissions:` block in a **called** workflow is not a floor. It is a **ceiling that also sets every scope it omits to `none`** for any job declaring none of its own. `work_item_traceability` deliberately declares no block so it can inherit the caller's grant — so `permissions: contents: read` at the top of `quality.yml` capped it regardless of what the caller granted.

## Measured, not inferred

`PropSwapLLC/backend#976` and `geminisportsai/backend-v2#2999` both grant all three scopes on the calling job. Both received:

```
##[group]GITHUB_TOKEN Permissions
Contents: read
Metadata: read
```

The gate's message — *"could verify NOTHING: the calling workflow does not grant 'pull-requests: read'"* — pointed at the caller, the one place the fix did not belong. PropSwap's HEAD commit is literally `ci: grant the quality job the read scopes traceability inherits`, and it still failed.

`quality-rails.yml` has the same defect with a different omission: its floor grants `pull-requests: write` but not `issues: read`, so the `gh issue view` arm could never work on `tracker: github` while the PR arm looked healthy. Latent, not yet reported.

## Why the obvious fix is the dangerous one

Adding the scopes — at job level or to the top-level block — is exactly what #2567 removed from `maestro-native-e2e.yml`. A called workflow requesting a scope the caller never held is a **`startup_failure` for the caller's entire run**, decided before any job starts, so an `if:` guard saves no one. Installed callers are `create-only` and cannot self-heal.

So the floor moves **down** onto each of the jobs that relied on it, byte-for-byte, and the workflow-level block is deleted:

- no new scope is requested anywhere, so no caller can newly `startup_failure`;
- every job's effective scope is unchanged;
- `work_item_traceability`'s blank block finally means what its comment claims.

## Proof of behaviour preservation

Both files parsed before and after, computing each job's effective scope the way GitHub does (job block if present, else workflow block, else inherit) and diffing:

| file | jobs | changed |
|---|---|---|
| `quality.yml` | 36 | 1 — `work_item_traceability`: `{contents: read}` → inherit |
| `quality-rails.yml` | 13 | 1 — `work_item_traceability`: `{contents: read, checks: write, pull-requests: write}` → inherit |

Nothing else moved. I also audited every job in `quality.yml` that reaches the API without its own block: `work_item_traceability` is the only one, so there is no second job silently degrading.

#2570's new baseline guard passes untouched, and legitimately — it unions the workflow-level block with every job's, so the set of scopes required *of callers* is invariant under this refactor.

## Probes, both directions

| probe | result |
|---|---|
| reintroduce the workflow-level block | fails `declares NO workflow-level floor` |
| add a job with no `permissions:` block | fails `blank is never accidental`, naming `probe_new_job` |

The second pins the one deliberate blank. Without the top-level block, a job added later would silently inherit the caller's full grant — the new failure mode this change creates, closed in the same commit.

Full suite: **668 files / 11,896 tests, 0 failures.** Typecheck clean.

## Corrections to the record

Three places asserted the opposite and are fixed here: the job comment, the `#1769` test (*"a read-only floor is safe for every consumer"*), and **#2476's closing note, which claimed this was measured working on a consumer granting all three scopes.** It was not — that red result was read as a genuine missing trailer when it was this scope gap. That was my error, and the comment now records what was actually observed.

## Deliberately not changed

The strictness. The gate used to `exit 0` with a warning — a vacuous green measured on a private consumer with no trailer, no body line and no backlink (#2476/#2497). **A gate that cannot verify must not report success.** The bug was the plumbing, not the refusal.

Work-Item: CodySwannGT/lisa#2571
