### PR TITLE
fix(ci): separate the three causes the traceability scope-gap error collapsed into one line

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -252,8 +252,21 @@ jobs:
           # and it FAILS rather than exits 0: a check that cannot verify must
           # not report success (#2476, #2497). The repair is always in the
           # CALLER's ci.yml, which is the only place the grant can come from.
+          # Two different faults print here, and they used to share one line:
+          # a caller genuinely missing the grant, and a run that resolved a STALE
+          # upstream. `rerun` replays the reusable-workflow SHA the original run
+          # resolved, so a fresh attempt can execute old code with no sign of it
+          # anywhere in the UI. Four separate misdiagnoses traced to that
+          # ambiguity, so the message now names both and hands over the command
+          # that tells them apart. This job cannot resolve its own SHA itself:
+          # that needs `actions: read`, and requesting a scope the caller may not
+          # hold is a startup_failure for the caller's whole run.
           scope_gap() {
-            echo "::error::Work-Item Traceability could verify NOTHING: the calling workflow does not grant '$1'. Add contents/issues/pull-requests read to the quality job's permissions in this repo's .github/workflows/ci.yml, or run 'lisa apply' to have Lisa add the block for you."
+            echo "::error::Work-Item Traceability could verify NOTHING: the token reached this job without '$1', so the gate refused rather than report a success it had not earned."
+            echo "::error::Cause A — this repo's caller does not grant it. Add contents/issues/pull-requests read to the quality job's permissions in .github/workflows/ci.yml, or run 'lisa apply' to have Lisa add the block."
+            echo "::error::Cause B — this run resolved a STALE upstream. A re-run replays the reusable-workflow SHA the original run resolved; only a NEW push re-resolves @main."
+            echo "::error::Tell them apart: gh api repos/${GITHUB_REPOSITORY:-<owner>/<repo>}/actions/runs/${GITHUB_RUN_ID:-<run-id>} --jq '.referenced_workflows[]|\"\(.path)@\(.ref) \(.sha)\"' — if that sha predates the fix you want, it is Cause B and no caller edit will help."
+            echo "::error::The scopes this job actually received are listed above under 'GITHUB_TOKEN Permissions'. If '$1' is absent there, the grant never arrived; the group is the ground truth, not this message."
             exit 1
           }
           pr_probe="repos/${GITHUB_REPOSITORY}/pulls?per_page=1"

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2107,8 +2107,21 @@ jobs:
           # whose gate was green with no trailer, no body line, and no backlink.
           # A gate that cannot verify must not report success (#2476, #2497), so
           # it now fails and names the exact scope and the exact edit.
+          # Two different faults print here, and they used to share one line:
+          # a caller genuinely missing the grant, and a run that resolved a STALE
+          # upstream. `rerun` replays the reusable-workflow SHA the original run
+          # resolved, so a fresh attempt can execute old code with no sign of it
+          # anywhere in the UI. Four separate misdiagnoses traced to that
+          # ambiguity, so the message now names both and hands over the command
+          # that tells them apart. This job cannot resolve its own SHA itself:
+          # that needs `actions: read`, and requesting a scope the caller may not
+          # hold is a startup_failure for the caller's whole run.
           scope_gap() {
-            echo "::error::Work-Item Traceability could verify NOTHING: the calling workflow does not grant '$1'. Add contents/issues/pull-requests read to the quality job's permissions in this repo's .github/workflows/ci.yml, or run 'lisa apply' to have Lisa add the block for you."
+            echo "::error::Work-Item Traceability could verify NOTHING: the token reached this job without '$1', so the gate refused rather than report a success it had not earned."
+            echo "::error::Cause A — this repo's caller does not grant it. Add contents/issues/pull-requests read to the quality job's permissions in .github/workflows/ci.yml, or run 'lisa apply' to have Lisa add the block."
+            echo "::error::Cause B — this run resolved a STALE upstream. A re-run replays the reusable-workflow SHA the original run resolved; only a NEW push re-resolves @main."
+            echo "::error::Tell them apart: gh api repos/${GITHUB_REPOSITORY:-<owner>/<repo>}/actions/runs/${GITHUB_RUN_ID:-<run-id>} --jq '.referenced_workflows[]|\"\(.path)@\(.ref) \(.sha)\"' — if that sha predates the fix you want, it is Cause B and no caller edit will help."
+            echo "::error::The scopes this job actually received are listed above under 'GITHUB_TOKEN Permissions'. If '$1' is absent there, the grant never arrived; the group is the ground truth, not this message."
             exit 1
           }
           pr_probe="repos/${GITHUB_REPOSITORY}/pulls?per_page=1"

--- a/tests/unit/config/work-item-traceability-scope-gate.test.ts
+++ b/tests/unit/config/work-item-traceability-scope-gate.test.ts
@@ -119,6 +119,9 @@ function runStep(options: {
     ...process.env,
     PATH: `${bin}:${process.env["PATH"] ?? ""}`,
     GITHUB_REPOSITORY: "acme/widget",
+    // Actions always sets this; the harness did not, which is how the first
+    // draft of the diagnostic printed `.../actions/runs/` with no id.
+    GITHUB_RUN_ID: "987654321",
     LISA_PR_NUMBER: "42",
     LISA_PR_BASE_SHA: "aaaa",
     LISA_PR_HEAD_SHA: "bbbb",
@@ -164,6 +167,37 @@ describe.each(WORKFLOW_FILES)(
       expect(result.output).not.toContain("STUB_VALIDATOR_RAN");
     });
 
+    it("separates the caller-gap cause from the stale-upstream cause", () => {
+      // These two faults print the same check, the same exit code and — until
+      // now — the same sentence, which blamed the caller. `rerun` replays the
+      // reusable-workflow SHA the ORIGINAL run resolved, so a fresh attempt can
+      // execute stale upstream code with nothing in the UI saying so. Four
+      // separate misdiagnoses traced to that one line, including a fix being
+      // scored as ineffective when it had never actually run.
+      const result = runStep({ workflow, ghExitCode: 1, tracker: "github" });
+
+      expect(result.output).toContain("Cause A");
+      expect(result.output).toContain("Cause B");
+      // Naming both is not enough — the reader needs the discriminator.
+      expect(result.output).toContain("referenced_workflows");
+      expect(result.output).toContain("only a NEW push re-resolves");
+      // And a pointer to the ground truth, which is the runner's own log group
+      // rather than anything this message asserts about itself.
+      expect(result.output).toContain("GITHUB_TOKEN Permissions");
+    });
+
+    it("interpolates the run's own ids into the discriminating command", () => {
+      // A remediation command the reader has to hand-edit is one they will get
+      // wrong. The printed `gh api` call must be copy-pasteable as-is.
+      const result = runStep({ workflow, ghExitCode: 1, tracker: "github" });
+
+      expect(result.output).toMatch(
+        /gh api repos\/[^/\s]+\/[^/\s]+\/actions\/runs\/\d+/
+      );
+      // jq interpolation must survive the shell's double quotes intact.
+      expect(result.output).toContain(String.raw`"\(.path)@\(.ref) \(.sha)"`);
+    });
+
     it("never reports success on a missing scope, whatever the tracker", () => {
       for (const tracker of ["github", "jira", "linear"]) {
         const result = runStep({
@@ -180,8 +214,12 @@ describe.each(WORKFLOW_FILES)(
         });
 
         expect(result.status, `tracker ${tracker}`).not.toBe(0);
+        // Assert the intent — the missing scope is named — rather than the exact
+        // sentence, which was reworded to separate the caller-gap cause from the
+        // stale-upstream cause. Pinning prose makes a message improvement read as
+        // a regression.
         expect(result.output, `tracker ${tracker}`).toContain(
-          "does not grant 'pull-requests: read'"
+          "'pull-requests: read'"
         );
       }
     });


### PR DESCRIPTION
Follow-up to #2571 / #2572.

The `work_item_traceability` scope-gap error prints **one sentence for three different situations**, and that sentence blames the caller:

```
::error::Work-Item Traceability could verify NOTHING: the calling workflow does not
grant 'pull-requests: read'. Add contents/issues/pull-requests read to the quality
job's permissions in this repo's .github/workflows/ci.yml, or run 'lisa apply'...
```

The three situations:

| situation | is the advice right? |
|---|---|
| caller genuinely lacks the grant | yes |
| run resolved a **stale upstream** | **no** — no caller edit can help |
| grant arrived, trailer genuinely missing | different failure entirely |

## Why the stale-upstream case is not hypothetical

`gh run rerun` **replays the reusable-workflow SHA the original run resolved**, even for a mutable `@main` ref. A re-run therefore produces a genuinely fresh attempt — new `run_attempt`, new `run_started_at` — that executes arbitrarily old upstream code, with nothing in the UI indicating it. Only a new event re-resolves the ref.

During #2571 this produced **four separate misdiagnoses across two sessions in one hour**:

1. A pre-fix red on two consumers read as "the fix didn't work."
2. A verification script that scored the stale conclusion because it polled the PR check rollup rather than the attempt.
3. `Contents: read, Metadata: read` on a caller with no block read as *confirmation* the fix worked — that output is what the pre-fix floor produces **and** what a post-fix empty grant produces, so it discriminates nothing.
4. A correct finding ("three callers need the block") withdrawn because two *other* callers already had it — the same error string across two different populations.

Every one of these is downstream of one line that cannot say which of its three causes fired.

## Fix

Keep the refusal exactly as it is — a gate that cannot verify must not report success — and make the message separate the causes:

- name **Cause A** (caller gap) and **Cause B** (stale upstream) explicitly;
- print the **discriminating command** with this run's ids already substituted, so it is copy-pasteable:
  `gh api repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID --jq '.referenced_workflows[]|"\(.path)@\(.ref) \(.sha)"'`
- point at `##[group]GITHUB_TOKEN Permissions`, already in every job log, as the ground truth for what actually arrived — rather than having the message assert it.

The job **cannot** resolve its own SHA itself: that needs `actions: read`, and requesting a scope the caller may not hold is a `startup_failure` for the caller's entire run (#2046, #2566). Hence pointing at the command rather than running it.

## Rendered output

```
::error::Work-Item Traceability could verify NOTHING: the token reached this job without 'pull-requests: read', so the gate refused rather than report a success it had not earned.
::error::Cause A — this repo's caller does not grant it. Add contents/issues/pull-requests read to the quality job's permissions in .github/workflows/ci.yml, or run 'lisa apply' to have Lisa add the block.
::error::Cause B — this run resolved a STALE upstream. A re-run replays the reusable-workflow SHA the original run resolved; only a NEW push re-resolves @main.
::error::Tell them apart: gh api repos/acme/widget/actions/runs/987654321 --jq '.referenced_workflows[]|"\\(.path)@\\(.ref) \\(.sha)"' — if that sha predates the fix you want, it is Cause B and no caller edit will help.
::error::The scopes this job actually received are listed above under 'GITHUB_TOKEN Permissions'. If 'pull-requests: read' is absent there, the grant never arrived; the group is the ground truth, not this message.
```

The printed `gh api` command was run verbatim against a real run and returns what the reader needs.

## Two defects the new assertions caught

- `GITHUB_RUN_ID` unset rendered `.../actions/runs/` with **no id** — a printed command silently malformed. Now defaulted; the harness sets the variable Actions always provides.
- An existing assertion pinned the exact sentence rather than the intent, so improving the message read as a regression. It now asserts the missing scope is named.

## Probe

Reverting to the single-cause message fails **three** tests, including the one requiring the discriminating command rather than merely naming both causes.

Full suite: **668 files / 11,900 tests, 0 failures.**

Work-Item: CodySwannGT/lisa#2573
