### PR TITLE
fix(scripts): ship the shared entry guard and cell escaper Lisa's consumers import

### DIFF
--- a/all/copy-overwrite/scripts/check-state-classification.mjs
+++ b/all/copy-overwrite/scripts/check-state-classification.mjs
@@ -40,8 +40,9 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 import {
   buildEnvelope,
   emitEnvelope,
@@ -604,9 +605,6 @@ export function main(argv) {
 }
 
 // Run only when invoked directly — importing for tests must have no side effects.
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   process.exitCode = main(process.argv.slice(2));
 }

--- a/all/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/all/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -10,9 +10,15 @@
  *
  * The obvious spelling is `import.meta.url === pathToFileURL(process.argv[1]).href`,
  * and it is wrong in a way that cannot be seen in review. `import.meta.url` is
- * always the REAL path — node resolves ESM through `realpath` unless
- * `--preserve-symlinks` is set — while `argv[1]` is whatever spelling the caller
- * typed. Reached through a symlinked checkout, a symlinked bin shim, or a
+ * normally the REAL path — node resolves ESM through `realpath` unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever spelling the caller typed. Naming only the first of those two
+ * flags is what let a second instance of this very defect survive review here:
+ * `--preserve-symlinks-main` is a SEPARATE flag that applies to the entry
+ * module specifically, which is exactly the module this guard runs in, so it is
+ * the one that matters most and the one easiest to leave out. See the section
+ * on realpathing both sides below.
+ * Reached through a symlinked checkout, a symlinked bin shim, or a
  * `/tmp` path on macOS (`/tmp` is itself a symlink to `/private/tmp`), the two
  * differ, the guard is false, `main()` never runs, and the process exits 0
  * having done nothing.

--- a/all/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/all/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -1,0 +1,76 @@
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
+/**
+ * invoked-as-script — the one implementation of "was this module run as the CLI
+ * entry point?", shared by every guarded `.mjs` entry point Lisa ships.
+ *
+ * @remarks
+ * ## Why this is shared rather than copied
+ *
+ * The obvious spelling is `import.meta.url === pathToFileURL(process.argv[1]).href`,
+ * and it is wrong in a way that cannot be seen in review. `import.meta.url` is
+ * always the REAL path — node resolves ESM through `realpath` unless
+ * `--preserve-symlinks` is set — while `argv[1]` is whatever spelling the caller
+ * typed. Reached through a symlinked checkout, a symlinked bin shim, or a
+ * `/tmp` path on macOS (`/tmp` is itself a symlink to `/private/tmp`), the two
+ * differ, the guard is false, `main()` never runs, and the process exits 0
+ * having done nothing.
+ *
+ * That failure mode is not symmetric. A no-op GENERATOR usually fails closed —
+ * whatever consumes its output notices the missing artifact. A no-op CHECK
+ * fails **OPEN**: it prints nothing, exits 0, and the npm script "succeeds", so
+ * a gate that is meant to block a merge silently stops having an opinion. Every
+ * `check-*.mjs` in this tree is in the second category, and git worktrees —
+ * which every Lisa-driven agent uses — put a symlinked path on that code path
+ * as a matter of routine.
+ *
+ * ## `moduleUrl` is REQUIRED, and is the FIRST parameter
+ *
+ * A deliberate deviation from the obvious signature
+ * `invokedAsScript(argv1 = process.argv[1], moduleUrl = import.meta.url)`. A
+ * defaulted `import.meta.url` inside a SHARED module resolves to *this* file,
+ * which is never anybody's `process.argv[1]` — so a caller that forgot the
+ * second argument would get `false` forever and no-op silently. That is exactly
+ * the fail-open defect this module exists to remove, re-introduced by its own
+ * convenience default. Making it required and first means a call site cannot be
+ * written wrong.
+ *
+ * ## Why ANY resolution error returns false
+ *
+ * `realpathSync` throws ENOENT, EACCES, ELOOP and ENOTDIR, not just ENOENT. A
+ * fallback that narrows to ENOENT and then compares `resolve(argv1)` reinstates
+ * the un-normalized comparison the realpath exists to avoid, so the symlink
+ * defect survives on precisely the path meant to be the safety net.
+ *
+ * Returning `false` on an unresolvable `argv[1]` is sound rather than merely
+ * convenient: node resolved and LOADED the entry point from that path moments
+ * earlier, so a path that cannot be resolved now is not the path this module
+ * was loaded through. Comparing an unnormalized spelling instead would answer
+ * "maybe" with a confident "yes".
+ *
+ * @module scripts/lib/invoked-as-script
+ */
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * `import.meta.url` is already the REAL path, so `argv[1]` is realpath'd before
+ * comparison — see the module remarks for why a raw comparison silently answers
+ * "no" under a symlinked path.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  // `node -e`, `node --eval`, `node --print` and the REPL leave `argv[1]`
+  // undefined. Nothing was asked to run, so nothing should.
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+  } catch {
+    return false;
+  }
+}

--- a/all/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/all/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -49,6 +49,19 @@
  * was loaded through. Comparing an unnormalized spelling instead would answer
  * "maybe" with a confident "yes".
  *
+ * ## Why BOTH sides are realpath'd, not just `argv[1]`
+ *
+ * "`import.meta.url` is always the real path" is true by default and false under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry.
+ * Normalizing only `argv[1]` then compares a real path against a symlinked one
+ * and answers `false` for an entry point that WAS invoked directly — the same
+ * fail-open this module exists to remove, reappearing on the flag that most
+ * looks like it should not matter. Measured: a symlinked entry point reports
+ * `true` normally and `false` under the flag.
+ *
+ * Realpathing both sides is free in the ordinary case, where `moduleUrl` is
+ * already canonical and `realpathSync` is the identity.
+ *
  * @module scripts/lib/invoked-as-script
  */
 import { realpathSync } from "node:fs";
@@ -57,9 +70,10 @@ import { fileURLToPath } from "node:url";
 /**
  * True when `moduleUrl` names the module node was asked to run.
  *
- * `import.meta.url` is already the REAL path, so `argv[1]` is realpath'd before
- * comparison — see the module remarks for why a raw comparison silently answers
- * "no" under a symlinked path.
+ * Both sides are realpath'd before comparison — see the module remarks for why a
+ * raw comparison silently answers "no" under a symlinked path, and why
+ * normalizing only `argv[1]` leaves the same hole open under
+ * `--preserve-symlinks-main`.
  * @param {string} moduleUrl - The caller's own `import.meta.url`.
  * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
  * @returns {boolean} Whether the caller should run its CLI body.
@@ -69,7 +83,7 @@ export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
   // undefined. Nothing was asked to run, so nothing should.
   if (!argv1) return false;
   try {
-    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
   } catch {
     return false;
   }

--- a/all/copy-overwrite/scripts/lisa-command-envelope.mjs
+++ b/all/copy-overwrite/scripts/lisa-command-envelope.mjs
@@ -23,8 +23,9 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 import { destructiveDenial } from "./lisa-destructive-guard.mjs";
 import { validateAgainstSchema } from "./lisa-schema-validate.mjs";
 
@@ -239,9 +240,6 @@ export function main(argv) {
 }
 
 // Run only when invoked directly — importing for tests must have no side effects.
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   process.exitCode = main(process.argv.slice(2));
 }

--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -18,7 +18,8 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const RELEASE_SUBJECT =
   /^chore\(release\): \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)? \[skip ci\]$/;
@@ -1463,9 +1464,6 @@ export function runCli() {
 // This branch covers a host project, where the file is copied to
 // `scripts/lisa-work-item.mjs` and invoked directly. Lisa's own checkout keeps
 // a re-exporting entrypoint instead, which calls runCli() itself.
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   runCli();
 }

--- a/expo/copy-overwrite/scripts/bdd-matrix.mjs
+++ b/expo/copy-overwrite/scripts/bdd-matrix.mjs
@@ -21,12 +21,13 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import { byCodeUnit, declaredPlatforms, trackerUrl } from "./bdd/contract.mjs";
 import { loadScenarios } from "./bdd/parse.mjs";
 import { indexResults } from "./bdd/report.mjs";
 import { loadExecutionResults } from "./check-bdd-coverage.mjs";
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const PACKAGE_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -250,5 +251,4 @@ function main() {
   console.log(`[bdd-matrix] wrote ${OUT_REL}`);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
-  main();
+if (invokedAsScript(import.meta.url)) main();

--- a/expo/copy-overwrite/scripts/bdd/markdown-cell.mjs
+++ b/expo/copy-overwrite/scripts/bdd/markdown-cell.mjs
@@ -1,0 +1,128 @@
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
+/**
+ * Markdown table-cell escaping, shared by the BDD burndown renderer and the
+ * Maestro failure classifier.
+ *
+ * Waiver reasons, scenario titles, discovered test names and Maestro failure
+ * messages are repo data that lands inside a generated Markdown table. A single
+ * `|` ends the cell early and shifts every column after it, so the columns to
+ * its right silently misreport — in a generated file nobody re-reads. A line
+ * ending is worse: it ends the ROW, so one record becomes two and every column
+ * after the break is read against the wrong header.
+ *
+ * This module exists because the escaper was module-private and DUPLICATED —
+ * `cell` inside `scripts/bdd/render.mjs` and `escapeCell` inside
+ * `scripts/classify-maestro-failures.mjs`. Neither copy could be reached by a
+ * unit test, so both could only be exercised indirectly through a whole
+ * rendered document, and the two had already drifted: one stripped `\r\n` and
+ * `\n`, the other only `\n`. Both leaked live column separators.
+ *
+ * The contract predicates below are exported alongside it deliberately, so
+ * "table safe" has one definition rather than one per test. That is worth
+ * having and it is NOT sufficient: the first fix on this defect shipped with
+ * `hasUnescapedPipe` already asserting the right answer for `\\|` while `cell`
+ * was never fed that input, so the escaper leaked at every even backslash run
+ * with the yardstick sitting right there, correct and unused. A shared
+ * predicate only helps once something SWEEPS the subject with it. Enumerate the
+ * property; the named instances are documentation.
+ *
+ * @module scripts/bdd/markdown-cell
+ */
+
+/**
+ * Escape one pipe together with the WHOLE backslash run in front of it.
+ *
+ * The rule is the same one {@link hasUnescapedPipe} measures, stated once:
+ * a pipe is a live column separator exactly when an EVEN number of backslashes
+ * (zero included) precedes it. So an even run needs one more backslash; an odd
+ * run is already an escape and must be left alone, or the escaper would grow
+ * the run on every pass and stop being idempotent.
+ *
+ * Two nearby spellings are wrong and both look right:
+ *
+ *  - `/\\?\|/` — consumes at most ONE preceding backslash, so `\\|` (escaped
+ *    backslash, live pipe) is seen as an escape that is already present and is
+ *    passed through untouched. It leaks at every even run: measured live at
+ *    runs 2, 4, 6 and 8. That was this defect's first fix and was itself a bug —
+ *    the report named two INSTANCES, and fixing those is not fixing the
+ *    property.
+ *  - `/((?:\\\\)*)\|/` with a `"$1\\|"` replacement — an even-run pattern with
+ *    no left anchor. The engine simply slides one character right and matches
+ *    an even run INSIDE an odd one, so `\|` becomes `\\\|`. Measured: 60 leaks
+ *    over the same sweep. A `(?<!\\)` lookbehind fixes it, but the arithmetic
+ *    below says the same thing without needing that argument.
+ *
+ * @param {string} _match - The whole match; unused.
+ * @param {string} backslashes - The backslash run preceding the pipe.
+ * @returns {string} The run, escaped, plus the pipe.
+ */
+const escapePipeRun = (_match, backslashes) =>
+  `${backslashes}${backslashes.length % 2 === 0 ? "\\" : ""}|`;
+
+/**
+ * Make author-supplied text safe inside a Markdown table cell.
+ *
+ * Both steps exist because the obvious spelling of each was wrong, and both
+ * failures are invisible in review:
+ *
+ *  - Pipes are escaped by RUN, not one at a time — see {@link escapePipeRun}.
+ *  - `/\r\n?|\n/` and not `/\r?\n/`. The latter only matches a CR that is
+ *    FOLLOWED by an LF, so a lone `\r` survives — and CommonMark treats a lone
+ *    CR as a line ending, which ends the row rather than the cell.
+ *
+ * The `?? ""` guard is load-bearing and must stay: without it a nullish waiver
+ * field prints the literal text "null" or "undefined" into the ledger, which
+ * reads as data.
+ *
+ * SCOPE — this is SAFETY, not FIDELITY, and the difference is deliberate. The
+ * only promise made is that no live column separator and no line ending reach
+ * the table; it is NOT promised that a reader can recover the input byte for
+ * byte. Lone backslashes are left exactly as they arrive, so Markdown consumes
+ * them pairwise and a cell holding N backslashes DISPLAYS `floor(N / 2)` of
+ * them. A round-trip-safe escaper is one step longer —
+ * `.replace(/\\/g, "\\\\").replace(/\|/g, "\\|")` — and was not chosen: it
+ * rewrites every backslash in every waiver reason and scenario title in the
+ * repo, which churns the generated ledger for a fidelity nobody consumes, and
+ * it is not what {@link hasUnescapedPipe} measures. If a caller ever needs the
+ * input back out of the table, it needs that escaper and a matching
+ * unescaper — not a patch to this one.
+ * @param {unknown} text - Arbitrary cell content.
+ * @returns {string} Text safe to interpolate into a table row.
+ */
+export const cell = text =>
+  String(text ?? "")
+    .replace(/(\\*)\|/g, escapePipeRun)
+    .replace(/\r\n?|\n/g, " ");
+
+/**
+ * Whether `text` still carries a line ending. A cell containing one splits the
+ * table row it sits in, so this is the second half of the safety contract.
+ * @param {string} text - Text already passed through {@link cell}.
+ * @returns {boolean} True when a CR or an LF survives.
+ */
+export const hasLineEnding = text => /[\r\n]/.test(String(text));
+
+/**
+ * Whether `text` still carries a pipe that Markdown will read as a column
+ * separator.
+ *
+ * A pipe is escaped only when an ODD number of backslashes precedes it: `\|` is
+ * a literal pipe, but `\\|` is an escaped backslash followed by a LIVE pipe.
+ * That distinction is the whole reason this predicate is not a regex.
+ * @param {string} text - Text already passed through {@link cell}.
+ * @returns {boolean} True when a column-separating pipe survives.
+ */
+export const hasUnescapedPipe = text => {
+  let backslashes = 0;
+  for (const character of String(text)) {
+    if (character === "\\") {
+      backslashes += 1;
+      continue;
+    }
+    if (character === "|" && backslashes % 2 === 0) return true;
+    backslashes = 0;
+  }
+  return false;
+};

--- a/expo/copy-overwrite/scripts/bdd/render.mjs
+++ b/expo/copy-overwrite/scripts/bdd/render.mjs
@@ -11,6 +11,7 @@
  * @module scripts/bdd/render
  */
 import { byCodeUnit } from "./contract.mjs";
+import { cell } from "./markdown-cell.mjs";
 
 /**
  * Format a coverage figure, refusing to print "100%" for an empty
@@ -24,20 +25,6 @@ const fmt = value =>
   value.total === 0 || value.percentage === null
     ? "n/a (no obligations)"
     : `${value.covered}/${value.total} (${value.percentage.toFixed(1)}%)`;
-
-/**
- * Make author-supplied text safe inside a Markdown table cell.
- *
- * Waiver reasons and scenario titles are repo data. A single `|` ends the
- * cell early and shifts every column after it, so the Ticket and Expires
- * columns silently misreport — in a generated file nobody re-reads.
- * @param {unknown} text - Arbitrary cell content.
- * @returns {string} Text safe to interpolate into a table row.
- */
-const cell = text =>
-  String(text ?? "")
-    .replace(/\|/g, "\\|")
-    .replace(/\r?\n/g, " ");
 
 /**
  * Render the per-platform traceability table.

--- a/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
@@ -43,7 +43,7 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 import {
   ADOPTION_STATES,
@@ -81,6 +81,7 @@ import {
   validateTrackerTags,
 } from "./bdd/validate.mjs";
 import { ISO_DATE, validateWaivers } from "./bdd/waivers.mjs";
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const PACKAGE_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -796,5 +797,4 @@ function printHuman(gateRun, envelope) {
   console.error(`[bdd-coverage] ${envelope.summary.headline}`);
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href)
-  main();
+if (invokedAsScript(import.meta.url)) main();

--- a/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-e2e-coverage.mjs
@@ -32,7 +32,8 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { pathToFileURL } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 export const defaultThresholds = {
   playwright: { routes: 80 },
@@ -389,9 +390,6 @@ function main() {
 }
 
 // Run only when invoked directly — importing for tests must have no side effects.
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   main();
 }

--- a/expo/copy-overwrite/scripts/classify-maestro-failures.mjs
+++ b/expo/copy-overwrite/scripts/classify-maestro-failures.mjs
@@ -104,7 +104,9 @@
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { pathToFileURL } from "node:url";
+
+import { cell } from "./bdd/markdown-cell.mjs";
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 /**
  * Wait commands whose `timeout:` is a ceiling the command burns before failing.
@@ -667,7 +669,7 @@ export function renderMarkdown({ report, failures, defects }) {
         ? `${failure.intermittent.ratePercent}% (${failure.intermittent.failures}/${failure.intermittent.runs}, measured ${failure.intermittent.measuredAt})`
         : "—";
       lines.push(
-        `| \`${failure.flow}\` | ${escapeCell(failure.message)} | ${known} |`
+        `| \`${failure.flow}\` | ${cell(failure.message)} | ${known} |`
       );
     }
     lines.push("");
@@ -694,15 +696,6 @@ export function renderMarkdown({ report, failures, defects }) {
     );
   }
   return lines.join("\n");
-}
-
-/**
- * Escape a value so it cannot break out of a markdown table cell.
- * @param {string} value - Raw text
- * @returns {string} Escaped text
- */
-function escapeCell(value) {
-  return String(value).replace(/\|/g, "\\|").replace(/\n/g, " ");
 }
 
 /**
@@ -770,9 +763,6 @@ function main(argv) {
   }
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   main(process.argv.slice(2));
 }

--- a/expo/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/expo/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -10,9 +10,15 @@
  *
  * The obvious spelling is `import.meta.url === pathToFileURL(process.argv[1]).href`,
  * and it is wrong in a way that cannot be seen in review. `import.meta.url` is
- * always the REAL path — node resolves ESM through `realpath` unless
- * `--preserve-symlinks` is set — while `argv[1]` is whatever spelling the caller
- * typed. Reached through a symlinked checkout, a symlinked bin shim, or a
+ * normally the REAL path — node resolves ESM through `realpath` unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever spelling the caller typed. Naming only the first of those two
+ * flags is what let a second instance of this very defect survive review here:
+ * `--preserve-symlinks-main` is a SEPARATE flag that applies to the entry
+ * module specifically, which is exactly the module this guard runs in, so it is
+ * the one that matters most and the one easiest to leave out. See the section
+ * on realpathing both sides below.
+ * Reached through a symlinked checkout, a symlinked bin shim, or a
  * `/tmp` path on macOS (`/tmp` is itself a symlink to `/private/tmp`), the two
  * differ, the guard is false, `main()` never runs, and the process exits 0
  * having done nothing.

--- a/expo/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/expo/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -1,0 +1,76 @@
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
+/**
+ * invoked-as-script — the one implementation of "was this module run as the CLI
+ * entry point?", shared by every guarded `.mjs` entry point Lisa ships.
+ *
+ * @remarks
+ * ## Why this is shared rather than copied
+ *
+ * The obvious spelling is `import.meta.url === pathToFileURL(process.argv[1]).href`,
+ * and it is wrong in a way that cannot be seen in review. `import.meta.url` is
+ * always the REAL path — node resolves ESM through `realpath` unless
+ * `--preserve-symlinks` is set — while `argv[1]` is whatever spelling the caller
+ * typed. Reached through a symlinked checkout, a symlinked bin shim, or a
+ * `/tmp` path on macOS (`/tmp` is itself a symlink to `/private/tmp`), the two
+ * differ, the guard is false, `main()` never runs, and the process exits 0
+ * having done nothing.
+ *
+ * That failure mode is not symmetric. A no-op GENERATOR usually fails closed —
+ * whatever consumes its output notices the missing artifact. A no-op CHECK
+ * fails **OPEN**: it prints nothing, exits 0, and the npm script "succeeds", so
+ * a gate that is meant to block a merge silently stops having an opinion. Every
+ * `check-*.mjs` in this tree is in the second category, and git worktrees —
+ * which every Lisa-driven agent uses — put a symlinked path on that code path
+ * as a matter of routine.
+ *
+ * ## `moduleUrl` is REQUIRED, and is the FIRST parameter
+ *
+ * A deliberate deviation from the obvious signature
+ * `invokedAsScript(argv1 = process.argv[1], moduleUrl = import.meta.url)`. A
+ * defaulted `import.meta.url` inside a SHARED module resolves to *this* file,
+ * which is never anybody's `process.argv[1]` — so a caller that forgot the
+ * second argument would get `false` forever and no-op silently. That is exactly
+ * the fail-open defect this module exists to remove, re-introduced by its own
+ * convenience default. Making it required and first means a call site cannot be
+ * written wrong.
+ *
+ * ## Why ANY resolution error returns false
+ *
+ * `realpathSync` throws ENOENT, EACCES, ELOOP and ENOTDIR, not just ENOENT. A
+ * fallback that narrows to ENOENT and then compares `resolve(argv1)` reinstates
+ * the un-normalized comparison the realpath exists to avoid, so the symlink
+ * defect survives on precisely the path meant to be the safety net.
+ *
+ * Returning `false` on an unresolvable `argv[1]` is sound rather than merely
+ * convenient: node resolved and LOADED the entry point from that path moments
+ * earlier, so a path that cannot be resolved now is not the path this module
+ * was loaded through. Comparing an unnormalized spelling instead would answer
+ * "maybe" with a confident "yes".
+ *
+ * @module scripts/lib/invoked-as-script
+ */
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * `import.meta.url` is already the REAL path, so `argv[1]` is realpath'd before
+ * comparison — see the module remarks for why a raw comparison silently answers
+ * "no" under a symlinked path.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  // `node -e`, `node --eval`, `node --print` and the REPL leave `argv[1]`
+  // undefined. Nothing was asked to run, so nothing should.
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+  } catch {
+    return false;
+  }
+}

--- a/expo/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/expo/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -49,6 +49,19 @@
  * was loaded through. Comparing an unnormalized spelling instead would answer
  * "maybe" with a confident "yes".
  *
+ * ## Why BOTH sides are realpath'd, not just `argv[1]`
+ *
+ * "`import.meta.url` is always the real path" is true by default and false under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry.
+ * Normalizing only `argv[1]` then compares a real path against a symlinked one
+ * and answers `false` for an entry point that WAS invoked directly — the same
+ * fail-open this module exists to remove, reappearing on the flag that most
+ * looks like it should not matter. Measured: a symlinked entry point reports
+ * `true` normally and `false` under the flag.
+ *
+ * Realpathing both sides is free in the ordinary case, where `moduleUrl` is
+ * already canonical and `realpathSync` is the identity.
+ *
  * @module scripts/lib/invoked-as-script
  */
 import { realpathSync } from "node:fs";
@@ -57,9 +70,10 @@ import { fileURLToPath } from "node:url";
 /**
  * True when `moduleUrl` names the module node was asked to run.
  *
- * `import.meta.url` is already the REAL path, so `argv[1]` is realpath'd before
- * comparison — see the module remarks for why a raw comparison silently answers
- * "no" under a symlinked path.
+ * Both sides are realpath'd before comparison — see the module remarks for why a
+ * raw comparison silently answers "no" under a symlinked path, and why
+ * normalizing only `argv[1]` leaves the same hole open under
+ * `--preserve-symlinks-main`.
  * @param {string} moduleUrl - The caller's own `import.meta.url`.
  * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
  * @returns {boolean} Whether the caller should run its CLI body.
@@ -69,7 +83,7 @@ export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
   // undefined. Nothing was asked to run, so nothing should.
   if (!argv1) return false;
   try {
-    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
   } catch {
     return false;
   }

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -153,6 +153,35 @@ if [ -f "$ROOT_DIR/scripts/lisa-enforcement-fallback.sh" ]; then
   chmod +x "$ROOT_DIR/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh"
 fi
 
+# The shared ESM entry guard, into every lane that has a consumer of it.
+#
+# Downstream, all of these land flat in one `scripts/` directory, so a single
+# `scripts/lib/invoked-as-script.mjs` serves every lane and `./lib/...` resolves
+# from each. Inside THIS repo the lanes are separate trees and Lisa's own unit
+# tests import the lane copies directly, so each lane that imports the helper
+# must carry it or those imports fail to resolve. Synced from one canonical
+# source rather than hand-copied, for the same reason the ratchet above is: a
+# unit test asserts byte-equality, so the three copies can never drift.
+#
+# `all` is applied to every project type before the stack lanes, so the copies
+# in `typescript` and `expo` are redundant at apply time — they exist for
+# in-repo resolution and are byte-identical, so whichever lane writes last
+# writes the same bytes.
+#
+# Guarded on the GENERATOR as well as the source. This script is run against
+# isolated fixtures that vendor `scripts/lib/` but not the repository's own
+# `scripts/*.mjs`, so testing the source alone would find it present and then
+# fail the whole build on a missing materializer.
+if [ -f "$ROOT_DIR/scripts/lib/invoked-as-script.mjs" ] &&
+  [ -f "$ROOT_DIR/scripts/materialize-copy-overwrite.mjs" ]; then
+  for guard_lane in all typescript expo; do
+    guard_lib_dir="$ROOT_DIR/$guard_lane/copy-overwrite/scripts/lib"
+    mkdir -p "$guard_lib_dir"
+    materialize "$ROOT_DIR/scripts/lib/invoked-as-script.mjs" \
+      "$guard_lib_dir/invoked-as-script.mjs"
+  done
+fi
+
 # Stack-specific plugins (NO base copy)
 STACKS=(typescript expo nestjs cdk harper-fabric phaser rails)
 for stack in "${STACKS[@]}"; do

--- a/scripts/check-conflict-markers.mjs
+++ b/scripts/check-conflict-markers.mjs
@@ -43,7 +43,9 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -302,10 +304,7 @@ export function main(argv, io = {}) {
   return results.length === 0 ? 0 : 1;
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   // exitCode (not process.exit): when stdout is a pipe, writes are async and
   // process.exit() truncates the report mid-flush.
   process.exitCode = main(process.argv.slice(2));

--- a/scripts/detect-stale-workflow-inputs.mjs
+++ b/scripts/detect-stale-workflow-inputs.mjs
@@ -41,7 +41,9 @@
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 import {
   diffStaleKeys,
   extractCallerJobs,
@@ -320,9 +322,6 @@ export function main(argv, io = {}) {
   return results.some(r => r.status === "stale") ? 1 : 0;
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   process.exit(main(process.argv.slice(2)));
 }

--- a/scripts/lib/invoked-as-script.mjs
+++ b/scripts/lib/invoked-as-script.mjs
@@ -46,6 +46,19 @@
  * was loaded through. Comparing an unnormalized spelling instead would answer
  * "maybe" with a confident "yes".
  *
+ * ## Why BOTH sides are realpath'd, not just `argv[1]`
+ *
+ * "`import.meta.url` is always the real path" is true by default and false under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry.
+ * Normalizing only `argv[1]` then compares a real path against a symlinked one
+ * and answers `false` for an entry point that WAS invoked directly — the same
+ * fail-open this module exists to remove, reappearing on the flag that most
+ * looks like it should not matter. Measured: a symlinked entry point reports
+ * `true` normally and `false` under the flag.
+ *
+ * Realpathing both sides is free in the ordinary case, where `moduleUrl` is
+ * already canonical and `realpathSync` is the identity.
+ *
  * @module scripts/lib/invoked-as-script
  */
 import { realpathSync } from "node:fs";
@@ -54,9 +67,10 @@ import { fileURLToPath } from "node:url";
 /**
  * True when `moduleUrl` names the module node was asked to run.
  *
- * `import.meta.url` is already the REAL path, so `argv[1]` is realpath'd before
- * comparison — see the module remarks for why a raw comparison silently answers
- * "no" under a symlinked path.
+ * Both sides are realpath'd before comparison — see the module remarks for why a
+ * raw comparison silently answers "no" under a symlinked path, and why
+ * normalizing only `argv[1]` leaves the same hole open under
+ * `--preserve-symlinks-main`.
  * @param {string} moduleUrl - The caller's own `import.meta.url`.
  * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
  * @returns {boolean} Whether the caller should run its CLI body.
@@ -66,7 +80,7 @@ export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
   // undefined. Nothing was asked to run, so nothing should.
   if (!argv1) return false;
   try {
-    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
   } catch {
     return false;
   }

--- a/scripts/lib/invoked-as-script.mjs
+++ b/scripts/lib/invoked-as-script.mjs
@@ -1,0 +1,73 @@
+/**
+ * invoked-as-script — the one implementation of "was this module run as the CLI
+ * entry point?", shared by every guarded `.mjs` entry point Lisa ships.
+ *
+ * @remarks
+ * ## Why this is shared rather than copied
+ *
+ * The obvious spelling is `import.meta.url === pathToFileURL(process.argv[1]).href`,
+ * and it is wrong in a way that cannot be seen in review. `import.meta.url` is
+ * always the REAL path — node resolves ESM through `realpath` unless
+ * `--preserve-symlinks` is set — while `argv[1]` is whatever spelling the caller
+ * typed. Reached through a symlinked checkout, a symlinked bin shim, or a
+ * `/tmp` path on macOS (`/tmp` is itself a symlink to `/private/tmp`), the two
+ * differ, the guard is false, `main()` never runs, and the process exits 0
+ * having done nothing.
+ *
+ * That failure mode is not symmetric. A no-op GENERATOR usually fails closed —
+ * whatever consumes its output notices the missing artifact. A no-op CHECK
+ * fails **OPEN**: it prints nothing, exits 0, and the npm script "succeeds", so
+ * a gate that is meant to block a merge silently stops having an opinion. Every
+ * `check-*.mjs` in this tree is in the second category, and git worktrees —
+ * which every Lisa-driven agent uses — put a symlinked path on that code path
+ * as a matter of routine.
+ *
+ * ## `moduleUrl` is REQUIRED, and is the FIRST parameter
+ *
+ * A deliberate deviation from the obvious signature
+ * `invokedAsScript(argv1 = process.argv[1], moduleUrl = import.meta.url)`. A
+ * defaulted `import.meta.url` inside a SHARED module resolves to *this* file,
+ * which is never anybody's `process.argv[1]` — so a caller that forgot the
+ * second argument would get `false` forever and no-op silently. That is exactly
+ * the fail-open defect this module exists to remove, re-introduced by its own
+ * convenience default. Making it required and first means a call site cannot be
+ * written wrong.
+ *
+ * ## Why ANY resolution error returns false
+ *
+ * `realpathSync` throws ENOENT, EACCES, ELOOP and ENOTDIR, not just ENOENT. A
+ * fallback that narrows to ENOENT and then compares `resolve(argv1)` reinstates
+ * the un-normalized comparison the realpath exists to avoid, so the symlink
+ * defect survives on precisely the path meant to be the safety net.
+ *
+ * Returning `false` on an unresolvable `argv[1]` is sound rather than merely
+ * convenient: node resolved and LOADED the entry point from that path moments
+ * earlier, so a path that cannot be resolved now is not the path this module
+ * was loaded through. Comparing an unnormalized spelling instead would answer
+ * "maybe" with a confident "yes".
+ *
+ * @module scripts/lib/invoked-as-script
+ */
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * `import.meta.url` is already the REAL path, so `argv[1]` is realpath'd before
+ * comparison — see the module remarks for why a raw comparison silently answers
+ * "no" under a symlinked path.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  // `node -e`, `node --eval`, `node --print` and the REPL leave `argv[1]`
+  // undefined. Nothing was asked to run, so nothing should.
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+  } catch {
+    return false;
+  }
+}

--- a/scripts/lib/invoked-as-script.mjs
+++ b/scripts/lib/invoked-as-script.mjs
@@ -7,9 +7,15 @@
  *
  * The obvious spelling is `import.meta.url === pathToFileURL(process.argv[1]).href`,
  * and it is wrong in a way that cannot be seen in review. `import.meta.url` is
- * always the REAL path — node resolves ESM through `realpath` unless
- * `--preserve-symlinks` is set — while `argv[1]` is whatever spelling the caller
- * typed. Reached through a symlinked checkout, a symlinked bin shim, or a
+ * normally the REAL path — node resolves ESM through `realpath` unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever spelling the caller typed. Naming only the first of those two
+ * flags is what let a second instance of this very defect survive review here:
+ * `--preserve-symlinks-main` is a SEPARATE flag that applies to the entry
+ * module specifically, which is exactly the module this guard runs in, so it is
+ * the one that matters most and the one easiest to leave out. See the section
+ * on realpathing both sides below.
+ * Reached through a symlinked checkout, a symlinked bin shim, or a
  * `/tmp` path on macOS (`/tmp` is itself a symlink to `/private/tmp`), the two
  * differ, the guard is false, `main()` never runs, and the process exits 0
  * having done nothing.

--- a/scripts/plugin-parity-drift.mjs
+++ b/scripts/plugin-parity-drift.mjs
@@ -40,7 +40,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -608,10 +610,7 @@ export function main(argv, io = {}) {
   return results.every(r => r.status === "ok") ? 0 : 1;
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   // exitCode (not process.exit): when stdout is a pipe, writes are async and
   // process.exit() truncates the report mid-flush (observed: a consumer's
   // $(...) capture stopped at the first 512-byte chunk). Setting exitCode lets

--- a/scripts/plugin-routing-validate.mjs
+++ b/scripts/plugin-routing-validate.mjs
@@ -36,7 +36,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 import { compareSemver, isValidSemver } from "./plugin-parity-drift.mjs";
 
 const REPO_ROOT = path.resolve(
@@ -639,9 +641,6 @@ export function main(argv, io = {}) {
   return results.every(r => r.errors.length === 0) ? 0 : 1;
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   process.exit(main(process.argv.slice(2)));
 }

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -149,6 +149,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "eaafd632dacfb181f6c83a22e5086f39586aff023788861d915c7254246d3175",
   ]),
   "scripts/lib/invoked-as-script.mjs": Object.freeze([
+    "302b3578d333717f61d0181a69f7b23a8bdf735c59fd5e95dc2da3da05896670",
     "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
   ]),
   "scripts/lisa-clean-git-env.sh": Object.freeze([

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -14,6 +14,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/bdd-matrix.mjs": Object.freeze([
     "4173a1c18d34285ab645314e0a99944f8baa02ae2632264b850c727347c8a836",
     "519273668f08db7c14053ba1f25830e4cbb6e34ddf11f06264e72d0f7a80b98d",
+    "97473cebb89562115320cb9154fb834e671deafea74ea52d34e0bc1511db3ee6",
     "c2ae09e979cb60c5accf108650f1356614018549db4eb4aee1c6191d069a8313",
     "f510e7e4484cd4f6182afab72f412ff9e8db458b18b96403ec1c0bd672f1dd51",
   ]),
@@ -41,6 +42,9 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "7bb2aa5dbe49fa97d3f14e5400fef3f76e0fd99ab74e88d568a3d037c94c601d",
     "ab3c9520be5c4c630ec3b6c8489015f24f97888c8687dde108865bbcff93efdb",
   ]),
+  "scripts/bdd/markdown-cell.mjs": Object.freeze([
+    "82f5881f9b1c743f572297e42cdf9acc6102d28cea909a9b6454042b091f8e44",
+  ]),
   "scripts/bdd/parse.mjs": Object.freeze([
     "18afb534f85c904af5da32e4dc0b48e4d2a89895a2866b60a544a790ce8b7afb",
     "53eb89417516f3125a879076a31d50e3738e21163367d475532274fbb41c732e",
@@ -51,6 +55,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "4678673c39b9f1aeeffc27265804566becb8373d47757d1ba8e28bdd0da21662",
     "46fa8e969dce9d243e7c97fc04f70ec457ba0d6426ace822420811eb944fa815",
     "47a5adb9fc607e5d330c246218d0b043be14a8527c7ba198b222df03fd96672a",
+    "bf64e239b4218bcb83f89e2b9ce1975b5b681450c3828ec0ade620de01a387b4",
     "c3cb36a6b3cf5771f5813cdd22f8273aa367c9de663ed1724c1fb3c59f2fbae9",
     "c900d5be3b4692bc7f2252f1461b0db987d300f99817ad83466428c530da4fce",
     "fa4f51fbb3a0517c4813c4a0dc9edde26d402efa115420cc251aaed7b5dfd5f3",
@@ -75,6 +80,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   ]),
   "scripts/check-bdd-coverage.mjs": Object.freeze([
     "13db95d2ed8bce81acfb4fdfd9adb195a60818952393268f6a269dbaa6e62d66",
+    "19cbbd7d368a99457212f2e1f9b37e6352cab6d459eb7dd11adb154f0c627c84",
     "36eb042310a754b67b5e4cfcd35bfb8f8fbed132e51b7daf6128ce03d987ac87",
     "98fa86e5987e7384c7fd23baa435f86830fb432424134bb7d8141c005af9167b",
     "9ef2ef274602bf49ef5346b55ec95be575e3989e5c19e5c2b566d668ce0fd3ba",
@@ -89,6 +95,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "3c45d8239708da62e9dd564909b1702c141d88c8a5dd453c67a0eca145b9d0f3",
     "880f37a8cc95ed051d7cfbdd4560d3e01cc99b1b9d01631681cadf0e33d37bd2",
     "9d570347fb1177be2381fe3f119882762be08a1a23c0a9486bdf5a6a97e02b5b",
+    "b284a59b3ce5dfa8fa4e6b9c5789c6c9c08120eaf957a91453fc659322feab28",
     "d7134b5f05ec93ce15d8d195f47bb79b346a5e9beec49dce3fd55b8a8e80e8e8",
   ]),
   "scripts/check-nightly-e2e-health.mjs": Object.freeze([
@@ -96,6 +103,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "3810fdea24d361f20895113f32d241f54d7194f4f3e3daba4dad01a941bbb230",
     "38900cd4c9bb33ff26ff10e82cb928cb4b0a7fa10bc614c9c30d4860d2c0d017",
     "5e64dad2e2ee08fabd99398c957cbe4dfc3b0a7243aae424c8e83f29283e503c",
+    "5f47f02563671a25ad14dc69210f1f52e9141e0e53a27bafce52d41899aa9d21",
     "c1e4bf2287982c9814f168a13f66792c013f557a6028adbc8110ee4214cecf15",
     "ce972e90c4a63a32b5753317c90eab56e7c4534f02132733a0e824a80dde7434",
     "e497015ea207f43492dcb8a32918066ff061588af71c684531f38dbc1f2ed89c",
@@ -106,6 +114,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "0a8b14790f38e00e5abfc665d3e3d2c29e0a139a2a22c4a65e0c08547b42fb7f",
     "1bcd3f065465731df4eb02b93b73a0162d287e365ed1a396138d97d71d403b31",
     "48d3fa3043e144bcf52feb0e20db887d75c7ebda3b1fa708fe93f6554f6bec78",
+    "5af5f112ba258c4874a65c72c8bed12165e75e4df407265eb46ee9c89c4e0e53",
     "86de31fbda9dd26a938bf30846c5fc70744cf199df7d475a35f3f25dbc0f7c2f",
     "86e9df17ea11fe0cd11d54f7fd60f016338e7fe28cdd4b07fab3b0b064b64ffb",
     "8eaac3ea96d92b55c418877c1fe338a7c0b3a8f48ef3593258f54a633f761c85",
@@ -114,6 +123,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/check-state-classification.mjs": Object.freeze([
     "94dc98e0bbfcf8d43cba035d4805a1c5d61a3a0db88faa791e8e06e34e741f46",
     "ac539349c86a7b5b0083ec0e6aaf0eb4c3e40fbd4dc31511c6460a2bad7af9a5",
+    "b218927f64a3db4f37762b60014e29d85a46899f4a0d17fcecc7782ce48bc499",
   ]),
   "scripts/check-threshold-ratchet.mjs": Object.freeze([
     "04f660131bf50864239eb09cbf4d9555e53921254f6ab45ff2b85c173e160901",
@@ -124,6 +134,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
   ]),
   "scripts/check-verification-coverage.mjs": Object.freeze([
+    "0cddac03366644cdc99cc239e74520ac420d475b461a40a21728e43756872b07",
     "3c037e2f0d2c7ae48d3b8c798522847910daef671a787393997fc71107cc7ead",
     "3c1d27d0668fc66a18cb014f2b607878f0a88c178a773fbe964b8e46b19e86d6",
     "432a84eea2370bbaf8af01f2850f2b5a8fff355a869551425c5667548fc7508d",
@@ -135,12 +146,17 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/classify-maestro-failures.mjs": Object.freeze([
     "7c550e8af431293b6b8d7ca2cfd777a07ec798fd3880275d8c12f7423d4d168b",
     "aadb773bfb994e754cfdf576f59d4bfe020184b21953908d40049ddfe3a93fc1",
+    "eaafd632dacfb181f6c83a22e5086f39586aff023788861d915c7254246d3175",
+  ]),
+  "scripts/lib/invoked-as-script.mjs": Object.freeze([
+    "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
   ]),
   "scripts/lisa-clean-git-env.sh": Object.freeze([
     "d15af6f13eedbca41046070972380e69fc0af8f7d903aac12b8644389b9a0c91",
     "e7121a0ee9e1bf7c01cd2ab55f563dd6d9ab75990739bb6ddf571a513efa10e9",
   ]),
   "scripts/lisa-command-envelope.mjs": Object.freeze([
+    "014a94647efc636cbce961364a82f03c1f3c1e54a55e9d21508fded88dce49c4",
     "2011331056b1c86bd181649713a395dbfd2768f9fcd7e37b521d6ad2a9318ea9",
     "4f76bb7d466eb153a4e1414d06f12856a1242de2cfa4cb4b1b942cf29d8b7f37",
     "6b198f088cd3cd862d4357fbb069b1ad5d3afeb7be594f2bf1ff603b092a8354",
@@ -245,6 +261,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "9223856be4618fb1e3e731b259ae5bf5328decc322f0b4a0d0fd18d6b12cd45a",
     "96a87c131606b3edd43e52485e68f8ffbf5c528cb4beb7a1185263519a9632ce",
     "ab0dede91c5c8a07984ae13aa48ec70cdcd2fa691b59617bc4b57998dc79a51c",
+    "b4e8aea72219f2c568429686a2ff1acd0da75ca26f244a66f3c4334297c8cd8e",
     "c78df9d5f0f3fc388ff60a7db5898478a2a4d6d7325833f10384b5a8c62bb34a",
     "e30016a49deff1c3cd3ae7951262aeb2ef3d472bce76bbbe2a177db6017c7cad",
     "e41e9534988ce69a836664437a78f3a3f3dc7ebbe396c86cdab0ea63fb7c19da",

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -151,6 +151,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/lib/invoked-as-script.mjs": Object.freeze([
     "302b3578d333717f61d0181a69f7b23a8bdf735c59fd5e95dc2da3da05896670",
     "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
+    "fbb9b88fc85a3e22f21af39e1c17acf67ff83fc6b5a6cdc8081bde333c48faa7",
   ]),
   "scripts/lisa-clean-git-env.sh": Object.freeze([
     "d15af6f13eedbca41046070972380e69fc0af8f7d903aac12b8644389b9a0c91",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -9,7 +9,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/check-state-classification.mjs":
       "b218927f64a3db4f37762b60014e29d85a46899f4a0d17fcecc7782ce48bc499",
     "all/copy-overwrite/scripts/lib/invoked-as-script.mjs":
-      "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
+      "302b3578d333717f61d0181a69f7b23a8bdf735c59fd5e95dc2da3da05896670",
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
       "014a94647efc636cbce961364a82f03c1f3c1e54a55e9d21508fded88dce49c4",
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs":
@@ -201,7 +201,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/scripts/classify-maestro-failures.mjs":
       "eaafd632dacfb181f6c83a22e5086f39586aff023788861d915c7254246d3175",
     "expo/copy-overwrite/scripts/lib/invoked-as-script.mjs":
-      "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
+      "302b3578d333717f61d0181a69f7b23a8bdf735c59fd5e95dc2da3da05896670",
     "expo/copy-overwrite/tsconfig.eslint.json":
       "375bb2ee8185e4a57d703e078ad57188f6d45b03b0fcbb16ef049fcf9b14c44b",
     "expo/copy-overwrite/tsconfig.expo.json":
@@ -2153,7 +2153,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/internal-opencode-skill-policy.json":
       "d7191650d8a12727549b67df61dbfa61e16cfb9cc31e461cd98d253ceab1612a",
     "scripts/lib/invoked-as-script.mjs":
-      "2d45e967ce6f49891e7920a407231b4d49309563a0979fb84f9985b27b3c2368",
+      "610f5ee26bf747f2172b89bb42ad21c4ccbd54a36dc833ac28291f94060dc25f",
     "scripts/lib/nest-plugin-commands.mjs":
       "c52b2f48edbc17edcc60ae33536549829cbc279c60c5d85d912ac6609cae9bea",
     "scripts/lib/per-agent-hook-filter.mjs":
@@ -2295,7 +2295,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
       "0cddac03366644cdc99cc239e74520ac420d475b461a40a21728e43756872b07",
     "typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs":
-      "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
+      "302b3578d333717f61d0181a69f7b23a8bdf735c59fd5e95dc2da3da05896670",
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":
       "8e0bdb491dfaea04e88be1c1e2c6cc7cd34fa4ca18adddf5fecc43d7de8ffded",
     "typescript/copy-overwrite/scripts/nightly-e2e-suites.schema.json":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7,9 +7,11 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "8104ccd32d7e6137cae706511c5037d11d6b6045b8e2a9bb7b3a48a81c053cfa",
     "all/copy-overwrite/scripts/check-state-classification.mjs":
-      "ac539349c86a7b5b0083ec0e6aaf0eb4c3e40fbd4dc31511c6460a2bad7af9a5",
+      "b218927f64a3db4f37762b60014e29d85a46899f4a0d17fcecc7782ce48bc499",
+    "all/copy-overwrite/scripts/lib/invoked-as-script.mjs":
+      "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
-      "6b198f088cd3cd862d4357fbb069b1ad5d3afeb7be594f2bf1ff603b092a8354",
+      "014a94647efc636cbce961364a82f03c1f3c1e54a55e9d21508fded88dce49c4",
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs":
       "66ade2c9cc0554c4934ed94a44563fd9d648b37cacfa9a5d31f17ac4f181e5a3",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
@@ -31,7 +33,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs":
       "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "c78df9d5f0f3fc388ff60a7db5898478a2a4d6d7325833f10384b5a8c62bb34a",
+      "b4e8aea72219f2c568429686a2ff1acd0da75ca26f244a66f3c4334297c8cd8e",
     "all/copy-overwrite/scripts/schemas/lisa-command-envelope.v1.schema.json":
       "d153b7c2953a30f180e38f09e98240c63327f5196eeba9bdf545e5a1f125a879",
     "all/copy-overwrite/scripts/schemas/lisa-state-contract.v1.schema.json":
@@ -171,7 +173,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/knip.json":
       "b19d0c177d8d0460779e07043c92d37555e7721224b6b2134ac2f6d10ab44b33",
     "expo/copy-overwrite/scripts/bdd-matrix.mjs":
-      "c2ae09e979cb60c5accf108650f1356614018549db4eb4aee1c6191d069a8313",
+      "97473cebb89562115320cb9154fb834e671deafea74ea52d34e0bc1511db3ee6",
     "expo/copy-overwrite/scripts/bdd/baseline.mjs":
       "77394187362d95043e448dd27f28afc115dfc6580330dd2338afa7b33de3d31e",
     "expo/copy-overwrite/scripts/bdd/contract.mjs":
@@ -180,10 +182,12 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "2e5aade29ad47b4924d446e168631f4296d5e4f92b2daedbc2b6d9e9bf241eaf",
     "expo/copy-overwrite/scripts/bdd/envelope.mjs":
       "2b44e2baffd2bde541c95ed267f4a6962b421e3e7d2723d5f4660f8829c19645",
+    "expo/copy-overwrite/scripts/bdd/markdown-cell.mjs":
+      "82f5881f9b1c743f572297e42cdf9acc6102d28cea909a9b6454042b091f8e44",
     "expo/copy-overwrite/scripts/bdd/parse.mjs":
       "53eb89417516f3125a879076a31d50e3738e21163367d475532274fbb41c732e",
     "expo/copy-overwrite/scripts/bdd/render.mjs":
-      "4678673c39b9f1aeeffc27265804566becb8373d47757d1ba8e28bdd0da21662",
+      "bf64e239b4218bcb83f89e2b9ce1975b5b681450c3828ec0ade620de01a387b4",
     "expo/copy-overwrite/scripts/bdd/report.mjs":
       "41d9b085f9b593c77d9cd1be91d55cdff2440de233dcf8a6baac5574a68e1641",
     "expo/copy-overwrite/scripts/bdd/validate.mjs":
@@ -191,11 +195,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/scripts/bdd/waivers.mjs":
       "4b62574a0d59476f050c704888e114ce7baae6c996bb3a2b043c168f74823490",
     "expo/copy-overwrite/scripts/check-bdd-coverage.mjs":
-      "36eb042310a754b67b5e4cfcd35bfb8f8fbed132e51b7daf6128ce03d987ac87",
+      "19cbbd7d368a99457212f2e1f9b37e6352cab6d459eb7dd11adb154f0c627c84",
     "expo/copy-overwrite/scripts/check-e2e-coverage.mjs":
-      "1b67cdc161191e9b2c51cef37ae864e57b2411d06df81bc5b8facff53c214f83",
+      "b284a59b3ce5dfa8fa4e6b9c5789c6c9c08120eaf957a91453fc659322feab28",
     "expo/copy-overwrite/scripts/classify-maestro-failures.mjs":
-      "7c550e8af431293b6b8d7ca2cfd777a07ec798fd3880275d8c12f7423d4d168b",
+      "eaafd632dacfb181f6c83a22e5086f39586aff023788861d915c7254246d3175",
+    "expo/copy-overwrite/scripts/lib/invoked-as-script.mjs":
+      "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
     "expo/copy-overwrite/tsconfig.eslint.json":
       "375bb2ee8185e4a57d703e078ad57188f6d45b03b0fcbb16ef049fcf9b14c44b",
     "expo/copy-overwrite/tsconfig.expo.json":
@@ -2075,9 +2081,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/merge/.claude/settings.json":
       "9c49f8c7c453f8749c90def3e22d412c3345c533d24b30dc7745ffa052ad6fa1",
     "scripts/build-plugins.sh":
-      "2ae01e074226393086369b8e7db807baa14ae61fe4f8aa89b149be0835d7e664",
+      "a2d935155a71e61c927c4a83e4a4151248fc13961214d7a57f5021e7bc3a8779",
     "scripts/check-conflict-markers.mjs":
-      "e2b25dd56eb3742f074ae5b8ece13ef194518e70e5bac4c2f49e3b819d3f7dc4",
+      "78c286ed6d7cce3a030fd7561fbe6285e2051d34540640f016b86ef89e3fb08b",
     "scripts/check-derived-artifacts.mjs":
       "1a35cc935515d29f0223a87d56dbfd5537aba19162d9d20e70fce8255688b76f",
     "scripts/check-duplicate-versions.mjs":
@@ -2111,7 +2117,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/copy-opencode-plugin-templates.mjs":
       "bef79103c293b73d7c37e8a8c9fa1b4f1f2e53367898a6326b12f8a0ba8ddc43",
     "scripts/detect-stale-workflow-inputs.mjs":
-      "204e64ccbd87de0edde0045668814638181dec2fa439fa4d8f06a0aaf5082af4",
+      "5ecf75354fee8beff7e6d02a78c5742de3cb6cd6753669966714411dcb0611d7",
     "scripts/fix-namespace-test-assertions.mjs":
       "bfed6f27753660b38457c3f0a032a6c866691666d2d5d61fc10c3fb2f4f4f412",
     "scripts/fix-test-assertions-pass2.mjs":
@@ -2146,6 +2152,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "c2ce87d2eeebfdc9f24d6486425c010cf9289376f8a459f4767ca22d2bf8670d",
     "scripts/internal-opencode-skill-policy.json":
       "d7191650d8a12727549b67df61dbfa61e16cfb9cc31e461cd98d253ceab1612a",
+    "scripts/lib/invoked-as-script.mjs":
+      "2d45e967ce6f49891e7920a407231b4d49309563a0979fb84f9985b27b3c2368",
     "scripts/lib/nest-plugin-commands.mjs":
       "c52b2f48edbc17edcc60ae33536549829cbc279c60c5d85d912ac6609cae9bea",
     "scripts/lib/per-agent-hook-filter.mjs":
@@ -2179,9 +2187,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/migrate-deploy-order.sh":
       "77d909b4cbbfc05169a79168d7868600ea7f56f846feefb7d5121618c54800c3",
     "scripts/plugin-parity-drift.mjs":
-      "34235c4c75c8735aaca96e3e0a52073ba1dee8bad54c85af01c3cf9912d0ea57",
+      "d3aa919d721a5ab6f475133a49fd5b7ca86b6ae1dfd5b6443039ce04eb3d6f77",
     "scripts/plugin-routing-validate.mjs":
-      "ddb2fcd950cbd66ca642e946aef33fd0bb2e7c4081ee96c19d4628a7d45694b8",
+      "e4278b4fb12d33c2043dc9d987d8995dbff6efb23151f57a2b7423ae3c777bcc",
     "scripts/probes/wave3-verification.sh":
       "c341c3682f2401339a433a48efc8b8dd80c9c190f12ec6287139bebd1e47c049",
     "scripts/remote-agent-aws-setup.sh":
@@ -2279,13 +2287,15 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/knip.json":
       "6eb93d705a2d645332fbae1dd42cf2d48f85978ebc265451a53790912f277d12",
     "typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs":
-      "5e64dad2e2ee08fabd99398c957cbe4dfc3b0a7243aae424c8e83f29283e503c",
+      "5f47f02563671a25ad14dc69210f1f52e9141e0e53a27bafce52d41899aa9d21",
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
-      "1bcd3f065465731df4eb02b93b73a0162d287e365ed1a396138d97d71d403b31",
+      "5af5f112ba258c4874a65c72c8bed12165e75e4df407265eb46ee9c89c4e0e53",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
       "46b7c2213112306af9702c910a9bcf485ea0b46154e46f0afe8fb8b5b0ba6c08",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
-      "3c037e2f0d2c7ae48d3b8c798522847910daef671a787393997fc71107cc7ead",
+      "0cddac03366644cdc99cc239e74520ac420d475b461a40a21728e43756872b07",
+    "typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs":
+      "4dd64efca0ff5841d0f3f27869c7bcc1c939571e6022f4b1823f7ef0d97b5d78",
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":
       "8e0bdb491dfaea04e88be1c1e2c6cc7cd34fa4ca18adddf5fecc43d7de8ffded",
     "typescript/copy-overwrite/scripts/nightly-e2e-suites.schema.json":
@@ -2519,6 +2529,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-contents/.gitattributes": true,
     "all/copy-contents/gitignore": true,
     "all/copy-overwrite/scripts/check-state-classification.mjs": true,
+    "all/copy-overwrite/scripts/lib/invoked-as-script.mjs": true,
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs": true,
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs": true,
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh": true,
@@ -2668,6 +2679,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "expo/copy-overwrite/scripts/bdd/contract.mjs": true,
     "expo/copy-overwrite/scripts/bdd/discover.mjs": true,
     "expo/copy-overwrite/scripts/bdd/envelope.mjs": true,
+    "expo/copy-overwrite/scripts/bdd/markdown-cell.mjs": true,
     "expo/copy-overwrite/scripts/bdd/parse.mjs": true,
     "expo/copy-overwrite/scripts/bdd/render.mjs": true,
     "expo/copy-overwrite/scripts/bdd/report.mjs": true,
@@ -2676,6 +2688,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "expo/copy-overwrite/scripts/check-bdd-coverage.mjs": true,
     "expo/copy-overwrite/scripts/check-e2e-coverage.mjs": true,
     "expo/copy-overwrite/scripts/classify-maestro-failures.mjs": true,
+    "expo/copy-overwrite/scripts/lib/invoked-as-script.mjs": true,
     "expo/copy-overwrite/tsconfig.eslint.json": true,
     "expo/copy-overwrite/tsconfig.expo.json": true,
     "expo/copy-overwrite/tsconfig.json": true,
@@ -8127,6 +8140,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/internal-copilot-skill-policy.json": true,
     "scripts/internal-cursor-skill-policy.json": true,
     "scripts/internal-opencode-skill-policy.json": true,
+    "scripts/lib/invoked-as-script.mjs": true,
     "scripts/lib/nest-plugin-commands.mjs": true,
     "scripts/lib/per-agent-hook-filter.mjs": true,
     "scripts/lib/reusable-workflow-contract.d.mts": true,
@@ -8924,6 +8938,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/bdd-gate-defects.test.ts": true,
     "tests/unit/scripts/bdd-gate-paths.test.ts": true,
     "tests/unit/scripts/bdd-grammar.test.ts": true,
+    "tests/unit/scripts/bdd-markdown-cell.test.ts": true,
     "tests/unit/scripts/bdd-nonregression.test.ts": true,
     "tests/unit/scripts/bdd-ratchet-removal.test.ts": true,
     "tests/unit/scripts/bdd-render.test.ts": true,
@@ -8957,6 +8972,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/generate-cursor-plugin-artifacts.test.ts": true,
     "tests/unit/scripts/github-governance.test.ts": true,
     "tests/unit/scripts/install-claude-plugins-self.test.ts": true,
+    "tests/unit/scripts/invoked-as-script.test.ts": true,
     "tests/unit/scripts/lisa-github-environments.test.ts": true,
     "tests/unit/scripts/lisa-github-repo-settings.test.ts": true,
     "tests/unit/scripts/lisa-github-rulesets.test.ts": true,
@@ -9327,6 +9343,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs": true,
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs": true,
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs": true,
+    "typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs": true,
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs": true,
     "typescript/copy-overwrite/scripts/nightly-e2e-suites.schema.json": true,
     "typescript/copy-overwrite/scripts/threshold-ratchet-compare.mjs": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -9,7 +9,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/check-state-classification.mjs":
       "b218927f64a3db4f37762b60014e29d85a46899f4a0d17fcecc7782ce48bc499",
     "all/copy-overwrite/scripts/lib/invoked-as-script.mjs":
-      "302b3578d333717f61d0181a69f7b23a8bdf735c59fd5e95dc2da3da05896670",
+      "fbb9b88fc85a3e22f21af39e1c17acf67ff83fc6b5a6cdc8081bde333c48faa7",
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
       "014a94647efc636cbce961364a82f03c1f3c1e54a55e9d21508fded88dce49c4",
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs":
@@ -201,7 +201,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/scripts/classify-maestro-failures.mjs":
       "eaafd632dacfb181f6c83a22e5086f39586aff023788861d915c7254246d3175",
     "expo/copy-overwrite/scripts/lib/invoked-as-script.mjs":
-      "302b3578d333717f61d0181a69f7b23a8bdf735c59fd5e95dc2da3da05896670",
+      "fbb9b88fc85a3e22f21af39e1c17acf67ff83fc6b5a6cdc8081bde333c48faa7",
     "expo/copy-overwrite/tsconfig.eslint.json":
       "375bb2ee8185e4a57d703e078ad57188f6d45b03b0fcbb16ef049fcf9b14c44b",
     "expo/copy-overwrite/tsconfig.expo.json":
@@ -2153,7 +2153,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/internal-opencode-skill-policy.json":
       "d7191650d8a12727549b67df61dbfa61e16cfb9cc31e461cd98d253ceab1612a",
     "scripts/lib/invoked-as-script.mjs":
-      "610f5ee26bf747f2172b89bb42ad21c4ccbd54a36dc833ac28291f94060dc25f",
+      "4711b3e900dc85c000c287dd6a675f519fd0f5f288508ae1d5acefdab136ad4e",
     "scripts/lib/nest-plugin-commands.mjs":
       "c52b2f48edbc17edcc60ae33536549829cbc279c60c5d85d912ac6609cae9bea",
     "scripts/lib/per-agent-hook-filter.mjs":
@@ -2295,7 +2295,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
       "0cddac03366644cdc99cc239e74520ac420d475b461a40a21728e43756872b07",
     "typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs":
-      "302b3578d333717f61d0181a69f7b23a8bdf735c59fd5e95dc2da3da05896670",
+      "fbb9b88fc85a3e22f21af39e1c17acf67ff83fc6b5a6cdc8081bde333c48faa7",
     "typescript/copy-overwrite/scripts/lisa-mutation.mjs":
       "8e0bdb491dfaea04e88be1c1e2c6cc7cd34fa4ca18adddf5fecc43d7de8ffded",
     "typescript/copy-overwrite/scripts/nightly-e2e-suites.schema.json":

--- a/tests/integration/maestro-native-flake-classification.test.ts
+++ b/tests/integration/maestro-native-flake-classification.test.ts
@@ -39,6 +39,20 @@ const CLASSIFIER_SRC = path.join(
   CLASSIFIER_FILE
 );
 
+/**
+ * The classifier's own module dependencies, as repo-relative paths under the
+ * lane's `scripts/` directory.
+ *
+ * Installed alongside it because the scratch project is a real vendored
+ * checkout, not a stub: without them node fails the import outright, and the
+ * step reads back as a classifier that found nothing rather than one that could
+ * not start.
+ */
+const CLASSIFIER_DEPENDENCIES = [
+  path.join("lib", "invoked-as-script.mjs"),
+  path.join("bdd", "markdown-cell.mjs"),
+];
+
 /** `bash` by absolute path — never resolved through a writeable $PATH. */
 const BASH = "/bin/bash";
 
@@ -160,6 +174,12 @@ function scratchProject(options: {
   fs.ensureDirSync(path.join(dir, SCRIPTS_DIR));
   if (options.classifier === "real") {
     fs.copySync(CLASSIFIER_SRC, installedClassifier);
+    for (const dependency of CLASSIFIER_DEPENDENCIES) {
+      fs.copySync(
+        path.join(REPO_ROOT, "expo", "copy-overwrite", SCRIPTS_DIR, dependency),
+        path.join(dir, SCRIPTS_DIR, dependency)
+      );
+    }
     fs.ensureDirSync(flowsDir);
     fs.writeFileSync(
       path.join(flowsDir, "card-detail.yaml"),

--- a/tests/unit/hooks/commit-msg.test.ts
+++ b/tests/unit/hooks/commit-msg.test.ts
@@ -35,6 +35,9 @@ const WORK_ITEM_TRAILER = `Work-Item: ${WORK_ITEM_REF}`;
 const TRACKER_SCRIPT = path.resolve(
   "all/copy-overwrite/scripts/lisa-work-item.mjs"
 );
+const ENTRY_GUARD_SCRIPT = path.resolve(
+  "all/copy-overwrite/scripts/lib/invoked-as-script.mjs"
+);
 
 let tempDirs: string[] = [];
 
@@ -157,7 +160,7 @@ function createProject(options: ProjectOptions): string {
   const gitEnv = cleanGitEnv(process.env);
   tempDirs.push(project);
   mkdirSync(path.join(project, "node_modules", ".bin"), { recursive: true });
-  mkdirSync(path.join(project, "scripts"), { recursive: true });
+  mkdirSync(path.join(project, "scripts/lib"), { recursive: true });
   writeFileSync(path.join(project, "package-lock.json"), "{}\n");
   writeFileSync(
     path.join(project, ".lisa.config.json"),
@@ -167,6 +170,12 @@ function createProject(options: ProjectOptions): string {
   copyFileSync(
     TRACKER_SCRIPT,
     path.join(project, "scripts/lisa-work-item.mjs")
+  );
+  // The shared entry guard the tracker imports. Missing it turns every
+  // diagnostic this suite asserts on into an ERR_MODULE_NOT_FOUND stack.
+  copyFileSync(
+    ENTRY_GUARD_SCRIPT,
+    path.join(project, "scripts/lib/invoked-as-script.mjs")
   );
   writeBin(project, options.binName, options.binBody);
   writeBin(

--- a/tests/unit/hooks/parity-push-gate.test.ts
+++ b/tests/unit/hooks/parity-push-gate.test.ts
@@ -106,6 +106,7 @@ function gateRepo(skill: string): string {
   for (const dir of [
     ".husky",
     SCRIPTS_DIR,
+    path.join(SCRIPTS_DIR, "lib"),
     ROUTING_DIR,
     ".claude/skills",
     path.dirname(SKILL_PATH),
@@ -119,6 +120,13 @@ function gateRepo(skill: string): string {
       path.join(root, SCRIPTS_DIR, script)
     );
   }
+  // The shared entry guard every gate script imports. Without it the scripts
+  // die on ERR_MODULE_NOT_FOUND and the hook's own diagnostics never run, which
+  // reads back as a gate failure rather than a missing fixture file.
+  copyFileSync(
+    path.resolve(SCRIPTS_DIR, "lib", "invoked-as-script.mjs"),
+    path.join(root, SCRIPTS_DIR, "lib", "invoked-as-script.mjs")
+  );
   // A real, schema-valid routing artifact + its paired .md companion.
   for (const entry of [ARTIFACT, "has-manifest@demo-marketplace.md"]) {
     copyFileSync(

--- a/tests/unit/scripts/bdd-markdown-cell.test.ts
+++ b/tests/unit/scripts/bdd-markdown-cell.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the shared Markdown table-cell escaper.
+ *
+ * The escaper protects generated tables that nobody re-reads line by line. A
+ * live `|` shifts every column to its right, so the Ticket and Expires cells
+ * silently misreport; a surviving line ending is worse, because it ends the ROW
+ * and one record becomes two read against the wrong header.
+ *
+ * The property is SWEPT rather than sampled, deliberately. The first fix on
+ * this defect named two instances, fixed exactly those two, shipped a fully
+ * green suite, and still leaked a live column separator at every EVEN backslash
+ * run — with `hasUnescapedPipe` sitting right there, correct and never pointed
+ * at the subject. Enumerate the property; the named instances are documentation.
+ * @module tests/unit/scripts/bdd-markdown-cell
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  cell,
+  hasLineEnding,
+  hasUnescapedPipe,
+} from "../../../expo/copy-overwrite/scripts/bdd/markdown-cell.mjs";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const EXPO_SCRIPTS = "expo/copy-overwrite/scripts";
+const MODULE_REL = `${EXPO_SCRIPTS}/bdd/markdown-cell.mjs`;
+
+/**
+ * An inline escaper, matched by what it DOES rather than by what it is called.
+ *
+ * The duplication this module ends was two functions with different names —
+ * `cell` in the renderer and `escapeCell` in the classifier — that had already
+ * drifted from each other. Matching on a name would have caught neither of the
+ * next two.
+ */
+const INLINE_ESCAPER = /\.replace\(\s*\/(?:\\\\\??)?\\\|\/[a-z]*\s*,/u;
+
+/** How deep the backslash-run sweep goes. Even runs are where it leaked. */
+const MAX_BACKSLASH_RUN = 16;
+
+/** Every line ending CommonMark recognizes, including the lone CR. */
+const LINE_ENDINGS = ["\n", "\r\n", "\r"] as const;
+
+describe("cell — named instances", () => {
+  it("escapes a bare pipe", () => {
+    expect(cell("stdout | stderr")).toBe("stdout \\| stderr");
+  });
+
+  it("escapes the pipe after an escaped backslash", () => {
+    // `\\|` is an escaped backslash followed by a LIVE pipe. The obvious
+    // `/\\?\|/` reads it as an escape already present and passes it through.
+    expect(cell("a\\\\|b")).toBe("a\\\\\\|b");
+  });
+
+  it("leaves an already-escaped pipe alone", () => {
+    // Idempotency counterweight: an escaper that grows the run on every pass
+    // would satisfy the universal negative below and still be wrong.
+    expect(cell("a\\|b")).toBe("a\\|b");
+  });
+
+  it("replaces a lone CR, which /\\r?\\n/ silently misses", () => {
+    expect(cell("one\rtwo")).toBe("one two");
+  });
+
+  it("replaces CRLF as one break, not two", () => {
+    expect(cell("one\r\ntwo")).toBe("one two");
+  });
+
+  it("renders nullish input as empty, never as the text 'null'", () => {
+    // Without the `?? ""` guard a missing waiver field prints the literal word
+    // into the ledger, where it reads as data.
+    expect(cell(null)).toBe("");
+    expect(cell(undefined)).toBe("");
+  });
+});
+
+describe("cell — the escaping property, swept rather than sampled", () => {
+  for (let run = 0; run <= MAX_BACKSLASH_RUN; run += 1) {
+    it(`leaves no live column separator after a run of ${run} backslashes`, () => {
+      const subject = `before${"\\".repeat(run)}|after`;
+      expect(hasUnescapedPipe(cell(subject))).toBe(false);
+    });
+  }
+
+  it("holds for a pipe at the very start of a cell", () => {
+    for (let run = 0; run <= MAX_BACKSLASH_RUN; run += 1) {
+      const subject = `${"\\".repeat(run)}|tail`;
+      expect(hasUnescapedPipe(cell(subject)), `run ${run}`).toBe(false);
+    }
+  });
+
+  it("holds for several runs in one cell", () => {
+    const subject = Array.from(
+      { length: MAX_BACKSLASH_RUN + 1 },
+      (_unused, run) => `${"\\".repeat(run)}|`
+    ).join("x");
+    expect(hasUnescapedPipe(cell(subject))).toBe(false);
+  });
+
+  it("holds for every line ending, in any position", () => {
+    for (const ending of LINE_ENDINGS) {
+      for (const subject of [
+        `${ending}lead`,
+        `mid${ending}dle`,
+        `trail${ending}`,
+      ]) {
+        expect(hasLineEnding(cell(subject)), JSON.stringify(subject)).toBe(
+          false
+        );
+      }
+    }
+  });
+
+  it("is idempotent — a second pass changes nothing", () => {
+    for (let run = 0; run <= MAX_BACKSLASH_RUN; run += 1) {
+      const once = cell(`before${"\\".repeat(run)}|after`);
+      expect(cell(once), `run ${run}`).toBe(once);
+    }
+  });
+
+  it("is minimal — text with nothing to escape comes back untouched", () => {
+    // Counterweight to the universal negative: an escaper that escaped
+    // everything unconditionally would satisfy every assertion above.
+    const plain = "a plain reason with no separators at all";
+    expect(cell(plain)).toBe(plain);
+    expect(cell("a\\b")).toBe("a\\b");
+  });
+});
+
+describe("hasUnescapedPipe — the yardstick itself", () => {
+  it("counts an even backslash run as leaving the pipe live", () => {
+    expect(hasUnescapedPipe("|")).toBe(true);
+    expect(hasUnescapedPipe("\\\\|")).toBe(true);
+    expect(hasUnescapedPipe("\\\\\\\\|")).toBe(true);
+  });
+
+  it("counts an odd backslash run as an escape", () => {
+    expect(hasUnescapedPipe("\\|")).toBe(false);
+    expect(hasUnescapedPipe("\\\\\\|")).toBe(false);
+  });
+
+  it("does not let a backslash run carry across an intervening character", () => {
+    expect(hasUnescapedPipe("\\x|")).toBe(true);
+  });
+});
+
+describe("drift guard — one escaper under the expo scripts tree", () => {
+  it("finds no inline pipe-escaper outside the shared module", () => {
+    const entries = fs.readdirSync(path.join(REPO_ROOT, EXPO_SCRIPTS), {
+      recursive: true,
+      withFileTypes: true,
+    });
+    const offenders: string[] = [];
+    let swept = 0;
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith(".mjs")) continue;
+      const relativePath = path.relative(
+        REPO_ROOT,
+        path.join(entry.parentPath, entry.name)
+      );
+      if (relativePath === MODULE_REL) continue;
+      swept += 1;
+      if (
+        INLINE_ESCAPER.test(
+          fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8")
+        )
+      ) {
+        offenders.push(relativePath);
+      }
+    }
+    // A moved tree would empty the sweep and pass by testing nothing.
+    expect(swept).toBeGreaterThan(5);
+    expect(offenders).toEqual([]);
+  });
+
+  it("bites: it matches both copies this module replaced", () => {
+    // The negative above is worth its runtime only if it can fail, so feed it
+    // the exact text of the two escapers that were deleted.
+    expect(INLINE_ESCAPER.test('.replace(/\\|/g, "\\\\|")')).toBe(true);
+    expect(INLINE_ESCAPER.test('.replace(/\\\\?\\|/g, "\\\\|")')).toBe(true);
+    // Minimality: the shared module's own call site must not match, or the
+    // guard would only be satisfiable by deleting the escaping entirely.
+    expect(INLINE_ESCAPER.test(".replace(/(\\\\*)\\|/g, escapePipeRun)")).toBe(
+      false
+    );
+  });
+});
+
+describe("hasLineEnding", () => {
+  it("sees every line ending CommonMark does", () => {
+    for (const ending of LINE_ENDINGS) {
+      expect(hasLineEnding(`a${ending}b`), JSON.stringify(ending)).toBe(true);
+    }
+    expect(hasLineEnding("no breaks here")).toBe(false);
+  });
+});

--- a/tests/unit/scripts/bdd/sources.ts
+++ b/tests/unit/scripts/bdd/sources.ts
@@ -35,11 +35,14 @@ export function sourceCode(relativePath: string): string {
  * @returns The scripts directory.
  */
 export function vendorGateWithoutSchemas(project: string): string {
-  // The real path, because the gate's own entry guard compares `process.argv[1]`
-  // against `import.meta.url`, and macOS `os.tmpdir()` is a symlink — passing
-  // the symlinked spelling makes Node's `main` block never run at all.
+  // The real path. The gate's entry guard now realpaths `process.argv[1]`
+  // itself, so the symlinked spelling of macOS `os.tmpdir()` no longer makes
+  // `main` silently never run — but the fixture keeps resolving it, so a
+  // regression in the guard shows up as the guard's own test failing rather
+  // than as this whole suite going quiet.
   const scripts = path.join(fs.realpathSync(project), "scripts");
   fs.mkdirSync(path.join(scripts, "bdd"), { recursive: true });
+  fs.mkdirSync(path.join(scripts, "lib"), { recursive: true });
   for (const name of fs.readdirSync(path.join(REPO_ROOT, GATE_DIR))) {
     const from = path.join(REPO_ROOT, GATE_DIR, name);
     if (fs.statSync(from).isFile()) {
@@ -52,6 +55,13 @@ export function vendorGateWithoutSchemas(project: string): string {
       path.join(scripts, "bdd", name)
     );
   }
+  // The shared entry guard, which every vendored entry point imports. Copied
+  // for the same reason the three modules below are: this fixture models a copy
+  // missing `scripts/schemas/`, not one missing code.
+  fs.copyFileSync(
+    path.join(REPO_ROOT, SHARED_DIR, "lib", "invoked-as-script.mjs"),
+    path.join(scripts, "lib", "invoked-as-script.mjs")
+  );
   // The envelope's own code dependencies. `lisa-destructive-guard.mjs` is a
   // HARD dependency deliberately: it carries the production refusal, and an
   // envelope that degraded gracefully when the guard was missing would turn a

--- a/tests/unit/scripts/invoked-as-script.test.ts
+++ b/tests/unit/scripts/invoked-as-script.test.ts
@@ -11,6 +11,7 @@
  * and without any downstream signal at all.
  * @module tests/unit/scripts/invoked-as-script
  */
+import { spawnSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -183,6 +184,37 @@ describe("invokedAsScript", () => {
 
     // BOTH sides carry the symlinked spelling, which is what the flag produces.
     expect(invokedAsScript(pathToFileURL(link).href, link)).toBe(true);
+  });
+
+  it("BITE: a real script reached through a symlink under --preserve-symlinks-main runs its body", () => {
+    // The unit case above pins the comparison; this pins the thing that
+    // actually matters — that a CHECK invoked this way does its work instead of
+    // exiting 0 in silence. It spawns node for real, because the flag's whole
+    // effect is on how node populates `import.meta.url` for the entry module,
+    // which cannot be simulated from inside an already-loaded test process.
+    //
+    // Verified to bite: with the one-sided `realpathSync(argv1) ===
+    // fileURLToPath(moduleUrl)`, the flagged run prints nothing and exits 0 —
+    // a passing gate that checked nothing.
+    const dir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "invoked-as-script-cli-"))
+    );
+    const helper = path.join(REPO_ROOT, CANONICAL_REL);
+    const script = path.join(dir, "gate.mjs");
+    const link = path.join(dir, "gate-link.mjs");
+    fs.writeFileSync(
+      script,
+      `import { invokedAsScript } from ${JSON.stringify(pathToFileURL(helper).href)};\n` +
+        `if (invokedAsScript(import.meta.url)) console.log("RAN");\n`
+    );
+    fs.symlinkSync(script, link);
+
+    for (const argv of [[link], ["--preserve-symlinks-main", link]]) {
+      const run = spawnSync(process.execPath, argv, { encoding: "utf-8" });
+      expect(run.status, argv.join(" ")).toBe(0);
+      // Exit 0 is NOT the assertion — a no-op guard also exits 0. The output is.
+      expect(run.stdout.trim(), argv.join(" ")).toBe("RAN");
+    }
   });
 
   it("is false for a module that was merely imported", () => {

--- a/tests/unit/scripts/invoked-as-script.test.ts
+++ b/tests/unit/scripts/invoked-as-script.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Tests for the shared ESM entry guard: its behavior, its byte-identical
+ * parity across the lanes that carry a copy, and a sweep asserting no shipped
+ * `.mjs` entry point has re-grown a hand-rolled guard.
+ *
+ * The defect being pinned is silent. A guard comparing `import.meta.url`
+ * against an un-realpath'd `process.argv[1]` is false whenever the script is
+ * reached through a symlinked path, so `main()` never runs and the process
+ * exits 0 having checked nothing. Every `check-*.mjs` Lisa ships is a gate, so
+ * that is a gate that stops having an opinion without failing, without logging,
+ * and without any downstream signal at all.
+ * @module tests/unit/scripts/invoked-as-script
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { invokedAsScript } from "../../../scripts/lib/invoked-as-script.mjs";
+import {
+  hasOwnershipHeader,
+  withoutOwnershipHeader,
+} from "../../../scripts/materialize-copy-overwrite.mjs";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const CANONICAL_REL = "scripts/lib/invoked-as-script.mjs";
+/** Any well-formed module URL; the cases below never resolve it to a file. */
+const ANY_MODULE_URL = "file:///anything.mjs";
+
+/**
+ * The lanes the build materializes the helper into.
+ *
+ * Downstream every lane collapses into one `scripts/` directory, so a single
+ * copy would do. In this repo the lanes are separate trees and Lisa's own unit
+ * tests import the lane copies directly, so a lane with a consumer must carry
+ * the helper or those imports fail to resolve at all.
+ */
+const HELPER_LANES = ["all", "typescript", "expo"] as const;
+
+/** Template trees whose `.mjs` entry points must route through the helper. */
+const SHIPPED_SCRIPT_DIRS = [
+  "all/copy-overwrite/scripts",
+  "typescript/copy-overwrite/scripts",
+  "expo/copy-overwrite/scripts",
+] as const;
+
+/**
+ * `check-threshold-ratchet.mjs` and its two sibling modules are materialized
+ * from `plugins/src/base/hooks/`, where they also RUN as agent-time hooks. A
+ * `./lib/` import there would have to resolve inside the plugin payload, which
+ * is a larger change than this one; until that happens they keep their own
+ * guard and are excused here by name rather than by a pattern that would also
+ * excuse a future offender silently.
+ */
+const MATERIALIZED_FROM_HOOKS = new Set([
+  "check-threshold-ratchet.mjs",
+  "threshold-ratchet-compare.mjs",
+  "threshold-ratchet-families.mjs",
+]);
+
+/**
+ * Guard spellings that are wrong, each matched by shape rather than by exact
+ * text so a reformat cannot slip one past.
+ */
+const DEFECTIVE_GUARDS: readonly { name: string; pattern: RegExp }[] = [
+  {
+    name: "import.meta.url === pathToFileURL(process.argv[1]).href",
+    pattern: /pathToFileURL\(\s*process\.argv\[1\]\s*\)/u,
+  },
+  {
+    name: "fileURLToPath(import.meta.url) === resolve(process.argv[1])",
+    pattern: /fileURLToPath\(\s*import\.meta\.url\s*\)\s*===/u,
+  },
+  {
+    name: 'process.argv[1].endsWith("<basename>")',
+    pattern: /process\.argv\[1\]\??\.endsWith\(/u,
+  },
+];
+
+/**
+ * Read a repo-relative text file.
+ * @param relativePath - Repo-relative path.
+ * @returns File contents.
+ */
+const read = (relativePath: string): string =>
+  fs.readFileSync(path.join(REPO_ROOT, relativePath), "utf-8");
+
+/**
+ * The materialized copy of the helper in one lane.
+ * @param lane - Project-type lane.
+ * @returns Repo-relative path of that lane's copy.
+ */
+const laneCopy = (lane: string): string =>
+  `${lane}/copy-overwrite/scripts/lib/invoked-as-script.mjs`;
+
+/**
+ * The defective guards a single shipped module carries, if any.
+ *
+ * The helper itself is excused by DECLARING the export rather than by path, so
+ * a rename or a duplicate copy of it reds instead of being waved through — its
+ * prose quotes every defective spelling by name, which is the point of the
+ * prose and would otherwise flag it.
+ * @param relativePath - Repo-relative path of a shipped `.mjs`.
+ * @returns One description per defective guard found; empty when swept clean.
+ */
+const guardOffences = (relativePath: string): string[] => {
+  const contents = read(relativePath);
+  if (contents.includes("export function invokedAsScript")) return [];
+  return DEFECTIVE_GUARDS.filter(guard => guard.pattern.test(contents)).map(
+    guard => `${relativePath} — ${guard.name}`
+  );
+};
+
+/**
+ * Every `.mjs` file directly under a shipped script tree, recursively.
+ * @param relativeDir - Repo-relative directory.
+ * @returns Repo-relative paths of the `.mjs` files found.
+ */
+const shippedModules = (relativeDir: string): string[] => {
+  const root = path.join(REPO_ROOT, relativeDir);
+  const entries = fs.readdirSync(root, {
+    recursive: true,
+    withFileTypes: true,
+  });
+  return entries
+    .filter(entry => entry.isFile() && entry.name.endsWith(".mjs"))
+    .map(entry =>
+      path.relative(REPO_ROOT, path.join(entry.parentPath, entry.name))
+    );
+};
+
+describe("invokedAsScript", () => {
+  it("is true for the module node was asked to run", () => {
+    const file = path.join(REPO_ROOT, CANONICAL_REL);
+    expect(invokedAsScript(pathToFileURL(file).href, file)).toBe(true);
+  });
+
+  it("is true through a symlink to the entry point — the whole point", () => {
+    // The failing case in the wild. Every Lisa-driven agent works in a git
+    // worktree and macOS resolves /tmp through a symlink, so this is the
+    // ordinary path, not an exotic one.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "invoked-as-script-"));
+    const real = path.join(dir, "real.mjs");
+    const link = path.join(dir, "link.mjs");
+    fs.writeFileSync(real, "export default 1;\n");
+    fs.symlinkSync(real, link);
+
+    // `import.meta.url` is always the REAL path — node resolves ESM through
+    // realpath — so the module URL is built from the realpath here, exactly as
+    // node would hand it to the module. argv[1] is the symlink the caller
+    // typed. Realpathing the tmpdir too is not incidental: on macOS it is
+    // itself reached through /private, which is the same class of mismatch.
+    expect(
+      invokedAsScript(pathToFileURL(fs.realpathSync(real)).href, link)
+    ).toBe(true);
+  });
+
+  it("is false for a module that was merely imported", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "invoked-as-script-"));
+    const entry = path.join(dir, "entry.mjs");
+    const other = path.join(dir, "other.mjs");
+    fs.writeFileSync(entry, "export default 1;\n");
+    fs.writeFileSync(other, "export default 2;\n");
+
+    expect(invokedAsScript(pathToFileURL(other).href, entry)).toBe(false);
+  });
+
+  it("is false when nothing was asked to run", () => {
+    // `node -e`, `--print` and the REPL leave argv[1] undefined. The naive
+    // `realpathSync(process.argv[1])` the obvious fix reaches for throws
+    // ENOENT here, turning a silent no-op into a hard crash. Held in a typed
+    // variable rather than passed as a literal, because the runtime value this
+    // pins is exactly what `process.argv[1]` is in those three modes.
+    const absentArgv: string | undefined = process.argv[99];
+    expect(invokedAsScript(ANY_MODULE_URL, absentArgv)).toBe(false);
+    expect(invokedAsScript(ANY_MODULE_URL, "")).toBe(false);
+  });
+
+  it("is false — not throwing — when argv[1] cannot be resolved", () => {
+    const missing = path.join(os.tmpdir(), "definitely-not-here-9f3c.mjs");
+    expect(() => invokedAsScript(ANY_MODULE_URL, missing)).not.toThrow();
+    expect(invokedAsScript(ANY_MODULE_URL, missing)).toBe(false);
+  });
+
+  it("takes moduleUrl first and required, so a call site cannot be written wrong", () => {
+    // A defaulted `import.meta.url` inside a SHARED module resolves to the
+    // helper itself, which is never anybody's argv[1] — so a forgetful caller
+    // would get `false` forever, silently reinstating the exact fail-open
+    // defect this module removes.
+    expect(invokedAsScript.length).toBe(1);
+  });
+});
+
+describe("shared entry guard wiring", () => {
+  it("materializes byte-identical copies into every lane that imports it", () => {
+    // Compared with the ownership header stripped, using the generator's own
+    // stripper, so "the copy minus its stamp" has exactly one definition.
+    const canonical = read(CANONICAL_REL);
+    for (const lane of HELPER_LANES) {
+      const copy = laneCopy(lane);
+      expect(withoutOwnershipHeader(read(copy), copy), copy).toBe(canonical);
+    }
+  });
+
+  it("stamps the ownership header on every copy, and on no canonical source", () => {
+    // The stripping above keeps passing if the stamp silently stops being
+    // written, so the stamp gets its own assertion in both directions. The
+    // canonical file is the one maintainers edit; telling it that it will be
+    // overwritten would be false.
+    for (const lane of HELPER_LANES) {
+      expect(hasOwnershipHeader(read(laneCopy(lane))), laneCopy(lane)).toBe(
+        true
+      );
+    }
+    expect(hasOwnershipHeader(read(CANONICAL_REL))).toBe(false);
+  });
+
+  it("leaves no hand-rolled entry guard in any shipped .mjs", () => {
+    const subjects = SHIPPED_SCRIPT_DIRS.flatMap(shippedModules).filter(
+      relativePath =>
+        !MATERIALIZED_FROM_HOOKS.has(path.basename(relativePath)) &&
+        !read(relativePath).includes("export function invokedAsScript")
+    );
+    const offenders = subjects.flatMap(guardOffences);
+    const swept = subjects.length;
+    // A rename or a moved tree would empty the sweep and let it pass by
+    // testing nothing, which is the failure mode this whole file exists for.
+    expect(swept).toBeGreaterThan(10);
+    expect(offenders).toEqual([]);
+  });
+
+  it("bites: a planted defective guard is caught by the same sweep", () => {
+    // The negative above is only worth its runtime if it can fail. Rather than
+    // trusting that, feed the patterns the exact text they must reject.
+    const planted =
+      "if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();";
+    const caught = DEFECTIVE_GUARDS.filter(guard =>
+      guard.pattern.test(planted)
+    );
+    expect(caught.map(guard => guard.name)).toContain(
+      "import.meta.url === pathToFileURL(process.argv[1]).href"
+    );
+    expect(
+      DEFECTIVE_GUARDS.some(guard =>
+        guard.pattern.test(
+          'const direct = process.argv[1]?.endsWith("check-thing.mjs");'
+        )
+      )
+    ).toBe(true);
+    expect(
+      DEFECTIVE_GUARDS.some(guard =>
+        guard.pattern.test(
+          "const direct = fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);"
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("does not flag the accepted spelling", () => {
+    // Minimality counterweight: a sweep that rejects everything would pass the
+    // bite control above and still be useless.
+    const accepted = "if (invokedAsScript(import.meta.url)) main();\n";
+    expect(
+      DEFECTIVE_GUARDS.filter(guard => guard.pattern.test(accepted))
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/scripts/invoked-as-script.test.ts
+++ b/tests/unit/scripts/invoked-as-script.test.ts
@@ -131,6 +131,24 @@ const shippedModules = (relativeDir: string): string[] => {
     );
 };
 
+/**
+ * A throwaway module plus a symlink pointing at it.
+ *
+ * Both spellings are returned because which one each side carries is the whole
+ * subject: node hands the module its REAL path by default and its SYMLINKED
+ * path under `--preserve-symlinks-main`, while `argv[1]` is always whatever the
+ * caller typed.
+ * @returns The module's real path and the symlink to it.
+ */
+const symlinkedModule = (): { real: string; link: string } => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "invoked-as-script-"));
+  const real = path.join(dir, "real.mjs");
+  const link = path.join(dir, "link.mjs");
+  fs.writeFileSync(real, "export default 1;\n");
+  fs.symlinkSync(real, link);
+  return { real, link };
+};
+
 describe("invokedAsScript", () => {
   it("is true for the module node was asked to run", () => {
     const file = path.join(REPO_ROOT, CANONICAL_REL);
@@ -141,11 +159,7 @@ describe("invokedAsScript", () => {
     // The failing case in the wild. Every Lisa-driven agent works in a git
     // worktree and macOS resolves /tmp through a symlink, so this is the
     // ordinary path, not an exotic one.
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "invoked-as-script-"));
-    const real = path.join(dir, "real.mjs");
-    const link = path.join(dir, "link.mjs");
-    fs.writeFileSync(real, "export default 1;\n");
-    fs.symlinkSync(real, link);
+    const { real, link } = symlinkedModule();
 
     // `import.meta.url` is always the REAL path — node resolves ESM through
     // realpath — so the module URL is built from the realpath here, exactly as
@@ -157,11 +171,23 @@ describe("invokedAsScript", () => {
     ).toBe(true);
   });
 
+  it("is true when moduleUrl KEEPS the symlink, as --preserve-symlinks-main leaves it", () => {
+    // "`import.meta.url` is always the real path" holds by default and fails
+    // under `--preserve-symlinks-main`, which tells node not to resolve the main
+    // entry. Realpathing only argv[1] then compares a real path against a
+    // symlinked one and answers false for an entry point that WAS invoked
+    // directly — the same fail-open this module exists to remove, on the flag
+    // that most looks like it should not matter. Measured against a real
+    // symlinked entry point: true normally, false under the flag.
+    const { link } = symlinkedModule();
+
+    // BOTH sides carry the symlinked spelling, which is what the flag produces.
+    expect(invokedAsScript(pathToFileURL(link).href, link)).toBe(true);
+  });
+
   it("is false for a module that was merely imported", () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "invoked-as-script-"));
-    const entry = path.join(dir, "entry.mjs");
-    const other = path.join(dir, "other.mjs");
-    fs.writeFileSync(entry, "export default 1;\n");
+    const { real: entry } = symlinkedModule();
+    const other = path.join(path.dirname(entry), "other.mjs");
     fs.writeFileSync(other, "export default 2;\n");
 
     expect(invokedAsScript(pathToFileURL(other).href, entry)).toBe(false);

--- a/typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs
+++ b/typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs
@@ -80,7 +80,7 @@
  * @module scripts/check-nightly-e2e-health
  */
 
-import { pathToFileURL } from "node:url";
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 /**
  * Contract version of the gate, asserted by the reusable workflow against its
@@ -2368,9 +2368,6 @@ async function writeOutputs(machine) {
   );
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   await main(process.argv.slice(2));
 }

--- a/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
+++ b/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
@@ -191,7 +191,8 @@
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 /** Repo-relative path of the per-repo declaration file. */
 export const DECLARATION_PATH = ".github/required-checks.json";
@@ -1253,9 +1254,6 @@ function main(argv) {
   }
 }
 
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   main(process.argv.slice(2));
 }

--- a/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
+++ b/typescript/copy-overwrite/scripts/check-verification-coverage.mjs
@@ -27,7 +27,8 @@
  * @module scripts/check-verification-coverage
  */
 import { execSync } from "node:child_process";
-import { pathToFileURL } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const BEHAVIORAL_TYPES = new Set(["feat", "fix"]);
 const EXEMPT_LABEL = "verification-exempt";
@@ -237,10 +238,7 @@ async function main() {
 }
 
 // Run only when invoked directly — importing for tests must have no side effects.
-if (
-  process.argv[1] &&
-  import.meta.url === pathToFileURL(process.argv[1]).href
-) {
+if (invokedAsScript(import.meta.url)) {
   main().catch(error => {
     console.error(`[verification-coverage] FAIL: ${error.message}`);
     process.exit(1);

--- a/typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -10,9 +10,15 @@
  *
  * The obvious spelling is `import.meta.url === pathToFileURL(process.argv[1]).href`,
  * and it is wrong in a way that cannot be seen in review. `import.meta.url` is
- * always the REAL path — node resolves ESM through `realpath` unless
- * `--preserve-symlinks` is set — while `argv[1]` is whatever spelling the caller
- * typed. Reached through a symlinked checkout, a symlinked bin shim, or a
+ * normally the REAL path — node resolves ESM through `realpath` unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever spelling the caller typed. Naming only the first of those two
+ * flags is what let a second instance of this very defect survive review here:
+ * `--preserve-symlinks-main` is a SEPARATE flag that applies to the entry
+ * module specifically, which is exactly the module this guard runs in, so it is
+ * the one that matters most and the one easiest to leave out. See the section
+ * on realpathing both sides below.
+ * Reached through a symlinked checkout, a symlinked bin shim, or a
  * `/tmp` path on macOS (`/tmp` is itself a symlink to `/private/tmp`), the two
  * differ, the guard is false, `main()` never runs, and the process exits 0
  * having done nothing.

--- a/typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -1,0 +1,76 @@
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
+/**
+ * invoked-as-script — the one implementation of "was this module run as the CLI
+ * entry point?", shared by every guarded `.mjs` entry point Lisa ships.
+ *
+ * @remarks
+ * ## Why this is shared rather than copied
+ *
+ * The obvious spelling is `import.meta.url === pathToFileURL(process.argv[1]).href`,
+ * and it is wrong in a way that cannot be seen in review. `import.meta.url` is
+ * always the REAL path — node resolves ESM through `realpath` unless
+ * `--preserve-symlinks` is set — while `argv[1]` is whatever spelling the caller
+ * typed. Reached through a symlinked checkout, a symlinked bin shim, or a
+ * `/tmp` path on macOS (`/tmp` is itself a symlink to `/private/tmp`), the two
+ * differ, the guard is false, `main()` never runs, and the process exits 0
+ * having done nothing.
+ *
+ * That failure mode is not symmetric. A no-op GENERATOR usually fails closed —
+ * whatever consumes its output notices the missing artifact. A no-op CHECK
+ * fails **OPEN**: it prints nothing, exits 0, and the npm script "succeeds", so
+ * a gate that is meant to block a merge silently stops having an opinion. Every
+ * `check-*.mjs` in this tree is in the second category, and git worktrees —
+ * which every Lisa-driven agent uses — put a symlinked path on that code path
+ * as a matter of routine.
+ *
+ * ## `moduleUrl` is REQUIRED, and is the FIRST parameter
+ *
+ * A deliberate deviation from the obvious signature
+ * `invokedAsScript(argv1 = process.argv[1], moduleUrl = import.meta.url)`. A
+ * defaulted `import.meta.url` inside a SHARED module resolves to *this* file,
+ * which is never anybody's `process.argv[1]` — so a caller that forgot the
+ * second argument would get `false` forever and no-op silently. That is exactly
+ * the fail-open defect this module exists to remove, re-introduced by its own
+ * convenience default. Making it required and first means a call site cannot be
+ * written wrong.
+ *
+ * ## Why ANY resolution error returns false
+ *
+ * `realpathSync` throws ENOENT, EACCES, ELOOP and ENOTDIR, not just ENOENT. A
+ * fallback that narrows to ENOENT and then compares `resolve(argv1)` reinstates
+ * the un-normalized comparison the realpath exists to avoid, so the symlink
+ * defect survives on precisely the path meant to be the safety net.
+ *
+ * Returning `false` on an unresolvable `argv[1]` is sound rather than merely
+ * convenient: node resolved and LOADED the entry point from that path moments
+ * earlier, so a path that cannot be resolved now is not the path this module
+ * was loaded through. Comparing an unnormalized spelling instead would answer
+ * "maybe" with a confident "yes".
+ *
+ * @module scripts/lib/invoked-as-script
+ */
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * `import.meta.url` is already the REAL path, so `argv[1]` is realpath'd before
+ * comparison — see the module remarks for why a raw comparison silently answers
+ * "no" under a symlinked path.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  // `node -e`, `node --eval`, `node --print` and the REPL leave `argv[1]`
+  // undefined. Nothing was asked to run, so nothing should.
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+  } catch {
+    return false;
+  }
+}

--- a/typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs
+++ b/typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs
@@ -49,6 +49,19 @@
  * was loaded through. Comparing an unnormalized spelling instead would answer
  * "maybe" with a confident "yes".
  *
+ * ## Why BOTH sides are realpath'd, not just `argv[1]`
+ *
+ * "`import.meta.url` is always the real path" is true by default and false under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry.
+ * Normalizing only `argv[1]` then compares a real path against a symlinked one
+ * and answers `false` for an entry point that WAS invoked directly — the same
+ * fail-open this module exists to remove, reappearing on the flag that most
+ * looks like it should not matter. Measured: a symlinked entry point reports
+ * `true` normally and `false` under the flag.
+ *
+ * Realpathing both sides is free in the ordinary case, where `moduleUrl` is
+ * already canonical and `realpathSync` is the identity.
+ *
  * @module scripts/lib/invoked-as-script
  */
 import { realpathSync } from "node:fs";
@@ -57,9 +70,10 @@ import { fileURLToPath } from "node:url";
 /**
  * True when `moduleUrl` names the module node was asked to run.
  *
- * `import.meta.url` is already the REAL path, so `argv[1]` is realpath'd before
- * comparison — see the module remarks for why a raw comparison silently answers
- * "no" under a symlinked path.
+ * Both sides are realpath'd before comparison — see the module remarks for why a
+ * raw comparison silently answers "no" under a symlinked path, and why
+ * normalizing only `argv[1]` leaves the same hole open under
+ * `--preserve-symlinks-main`.
  * @param {string} moduleUrl - The caller's own `import.meta.url`.
  * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
  * @returns {boolean} Whether the caller should run its CLI body.
@@ -69,7 +83,7 @@ export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
   // undefined. Nothing was asked to run, so nothing should.
   if (!argv1) return false;
   try {
-    return realpathSync(argv1) === fileURLToPath(moduleUrl);
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

Ships the two shared modules Lisa's own `copy-overwrite` scripts import, and routes the consumers through them. Both modules were authored **only downstream**, so the scripts Lisa ships could not use them and `lisa apply` erased every repo that wired them up on the next `bun install` — the delivery mechanism described in #2577.

This unblocks two downstream PRs that are otherwise unlandable: `TunnlAI/frontend#536` (TUN-602) and `TunnlAI/frontend#559` (TUN-601).

The two halves ship together on purpose. Updating the consumers without shipping the modules breaks every consuming repo at import time, and shipping the modules without the consumers leaves the defects in place.

## 1. `scripts/lib/invoked-as-script.mjs` — the shared ESM entry guard

Every shipped entry point ended in some spelling of:

```js
if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();
```

`import.meta.url` is always the REAL path — node resolves ESM through `realpath` — while `argv[1]` is whatever spelling the caller typed. Under a symlinked checkout, a symlinked bin shim, or a macOS `/tmp` path, the two differ, the guard is false, `main()` never runs, and **the process exits 0 having checked nothing**.

Every one of these scripts is a gate, so that is a gate that quietly stops having an opinion — no failure, no log, no downstream signal. Git worktrees, which every Lisa-driven agent uses, put a symlinked path on that code path routinely.

**Distribution.** Materialized into `all`, `typescript` and `expo` from one canonical source, following the threshold-ratchet precedent already in `build-plugins.sh`. Downstream every lane collapses into one `scripts/` directory, so a single copy serves them all; in this repo the lanes are separate trees and Lisa's own unit tests import the lane copies directly, so a lane with a consumer must carry the helper or the import cannot resolve at all. Byte-equality against the canonical source and the ownership-header stamp are both pinned by test.

**Adopted by** ten shipped entry points across the three lanes, plus four of Lisa's own `scripts/*.mjs` — the last so the canonical source has a live consumer rather than only a build step.

`check-nightly-e2e-health.mjs` was found by the new sweep, not by grep: the file carries emoji, and macOS `grep` reports zero matches in such a file rather than scanning it, so every earlier survey read it as already clean.

**Deliberately not converted:** `check-threshold-ratchet.mjs` and its two sibling modules. They are materialized from `plugins/src/base/hooks/`, where they also RUN as agent-time hooks, so a `./lib/` import there would have to resolve inside the plugin payload. That is a larger change. They are excused **by name** in the sweep rather than by a pattern that would also excuse a future offender silently.

## 2. `expo/copy-overwrite/scripts/bdd/markdown-cell.mjs` — the cell escaper

`cell` in `bdd/render.mjs` and `escapeCell` in `classify-maestro-failures.mjs` were two module-private copies that had already drifted from each other, and neither could be reached by a unit test. Both leaked:

- `.replace(/\|/g, "\\|")` escapes one pipe at a time, so an **even** backslash run before a pipe still leaves a live column separator — `\\|` is an escaped backslash followed by a live pipe. Measured leaking at runs 2, 4, 6 and 8.
- `/\r?\n/` matches a CR only when an LF follows, so a lone `\r` survives. CommonMark reads a lone CR as a line ending, which ends the **row** rather than the cell: one record becomes two, every column after it read against the wrong header.

The shipped escaper handles the backslash run as a whole and escapes only when the run leaves the pipe unprotected — the same parity rule `hasUnescapedPipe` measures. The two contract predicates ship beside it so "table safe" has one definition rather than one per test.

## Testing

Both suites **sweep the property rather than sampling instances**. That is not stylistic: the escaper's first fix named two instances, fixed exactly those two, shipped a fully green suite, and still leaked at every even backslash run — with the correct yardstick sitting in the same file, unused.

Each sweep carries a **bite control** proving it can fail (fed the exact text it must reject) and a **minimality control** proving it does not reject everything; the escaper adds idempotency coverage, which catches an escaper that grows the run on each pass.

- `tests/unit/scripts/invoked-as-script.test.ts` — 11 cases: helper behavior including the symlink case and the `node -e` / unresolvable-path cases, lane byte-equality and header parity, plus a repo-wide sweep for hand-rolled guards.
- `tests/unit/scripts/bdd-markdown-cell.test.ts` — 34 cases: named instances, a backslash-run sweep to depth 16 in three positions, every CommonMark line ending in three positions, idempotency, minimality, the yardstick's own parity rule, and a drift guard that no inline escaper reappears under the expo scripts tree.

Four test fixtures vendor these scripts into throwaway `scripts/` trees and needed the new modules vendored too; without them they died on `ERR_MODULE_NOT_FOUND`, which reads back as a gate failure rather than a missing fixture file.

**Local verification:** full pre-push suite green — 11,987 unit + 338 integration tests, `lint`, `typecheck`, generated-artifact check, plugin parity and routing gates.

## Review round (CodeRabbit)

CodeRabbit found a real fail-open in the helper itself and it is fixed, not dismissed. Under `--preserve-symlinks-main`, node leaves the **symlink** in `import.meta.url` for the entry module, so realpathing only `argv[1]` compares a real path against a symlinked one and returns `false` for an entry point that WAS invoked directly — this module's own failure mode, inside the module shipped to close it.

Reproduced against a real symlinked script before fixing:

```
node link.mjs                            -> guard says: true
node --preserve-symlinks-main link.mjs   -> guard says: false   (before)
node --preserve-symlinks-main link.mjs   -> guard says: true    (after)
```

Fixed by realpathing both sides, inside the existing `catch`. The docblock also named only `--preserve-symlinks`, which is the incomplete claim that let the hole survive review — `--preserve-symlinks-main` is a separate flag applying to the entry module specifically. Both are now named.

Coverage is a **subprocess** bite control, not a unit proxy: it spawns node twice against a script reached through a symlink (plain, then flagged) and asserts on **output**, because a no-op guard exits 0 too. Reverting the fix gives the vacuous-green signature exactly — `expected '' to be 'RAN'` with status 0.

## Not addressed, deliberately

SonarCloud's five super-linear regexes and two over-complexity functions in `classify-maestro-failures.mjs`. All six regexes in that file are line-scoped over **repo-authored Maestro YAML**, not log output, so the hang premise does not hold; and the two value-capture patterns cannot be made linear without changing behavior on malformed input. Both belong in separate work.

The remaining hand-rolled guard in `check-threshold-ratchet.mjs` is filed as #2582, with the measured no-op from #2531 as evidence.

Work-Item: CodySwannGT/lisa#2580
