### PR TITLE
fix(gates): run rewriting gates before the gates that verify the tree

### DIFF
--- a/all/copy-overwrite/scripts/lisa-gates.mjs
+++ b/all/copy-overwrite/scripts/lisa-gates.mjs
@@ -95,6 +95,29 @@ export const STATE_FAMILIES = ["continuous"];
 /** Keys on a gate entry that are settings rather than moments. */
 export const GATE_FIELDS = new Set(["run", "needs", "task"]);
 
+/**
+ * Registry flag: this gate's task may rewrite the working tree.
+ *
+ * It exists to order execution, because a gate that rewrites files invalidates
+ * every verdict already reached about them. Measured, not theorised: gates run
+ * alphabetically, so `artifact-freshness` proved a generated manifest current,
+ * `code-style` then ran `lint:staged` and prettier reformatted the very sources
+ * that manifest hashes, and the commit landed with a manifest describing bytes
+ * that no longer existed. The freshness gate reported PASSED about a tree that
+ * was not the tree committed — the organising defect in a new costume.
+ *
+ * So rewriters sort ahead of verifiers, and every verdict afterwards describes
+ * the bytes that actually ship.
+ *
+ * The flag is deliberately *may*, and deliberately registry-only. A project can
+ * point `format-conformance` at `format:check` (which rewrites nothing) or at
+ * `format` (which rewrites everything), and Lisa cannot tell which from here.
+ * Ordering a non-rewriter early costs nothing — order among independent gates
+ * was already arbitrary — while missing a real rewriter costs a false pass.
+ * Asking projects to declare it would put the safe answer in the hands of
+ * whoever remembers to type it, which is how the defect got here.
+ */
+
 /** Prefix marking a gate, or a config key, that this project invented. */
 export const CUSTOM_PREFIX = "x-";
 
@@ -133,6 +156,7 @@ export const REGISTRY = Object.freeze({
     summary: "Code conforms to the project's lint rules.",
     task: "lint",
     moments: COMMIT_ONWARD,
+    mayRewrite: true,
   },
   "code-style-slow": {
     label: "🐢 Slow Lint Rules",
@@ -145,6 +169,7 @@ export const REGISTRY = Object.freeze({
     summary: "Files match the project's formatter.",
     task: "format:check",
     moments: COMMIT_ONWARD,
+    mayRewrite: true,
   },
   "type-correctness": {
     label: "🔍 Type Check",
@@ -930,9 +955,16 @@ export function resolveMoment({ gates, moment, runner = "npm run" }) {
       label: definition?.label ?? id,
       work: definition?.work ?? null,
       evidence: entry.await ? mergeEvidence(entry.evidence) : null,
+      mayRewrite: definition?.mayRewrite === true,
     });
   }
-  return resolved.sort((left, right) => left.id.localeCompare(right.id));
+  // Rewriters first, then alphabetical within each group. See `mayRewrite`:
+  // a verdict reached before a formatter runs describes bytes that never ship.
+  return resolved.sort(
+    (left, right) =>
+      Number(right.mayRewrite) - Number(left.mayRewrite) ||
+      left.id.localeCompare(right.id)
+  );
 }
 
 /**

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -193,6 +193,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "cc4270e365f53c60a5eefb58a8ac8e22be184c0821fcdcc8fe67bcfc1df5e3dd",
     "dbca450e5a17133841ab015e71808feb028996f8297fda362dbeca4f07af2352",
     "e7d928c3b2d878c7a9ec9589894dfc3feaba54b8913c87be0550c34a1431ed9f",
+    "fbd68cf571985d7cfccf0f280cfe8112955849126e44d27d55ad619f9abb79ef",
   ]),
   "scripts/lisa-hooks/block-direct-issue-create.sh": Object.freeze([
     "22184f1dd1b96e818741bd4ae659446299535d7ce594817155edebac4172a7ba",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -19,7 +19,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
       "2d11968f6852ab745cba939de03c6d6cb5f413975d2cfc8fc447bdd0b218e91a",
     "all/copy-overwrite/scripts/lisa-gates.mjs":
-      "cc4270e365f53c60a5eefb58a8ac8e22be184c0821fcdcc8fe67bcfc1df5e3dd",
+      "fbd68cf571985d7cfccf0f280cfe8112955849126e44d27d55ad619f9abb79ef",
     "all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh":
       "8d1f04ef5c5da9db9190e22b37a435e118e39d6e7deafc5402b4593c8e9db2b2",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
@@ -9031,6 +9031,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/invoked-as-script.test.ts": true,
     "tests/unit/scripts/lisa-gates-evidence.test.ts": true,
     "tests/unit/scripts/lisa-gates-fixtures.ts": true,
+    "tests/unit/scripts/lisa-gates-order.test.ts": true,
     "tests/unit/scripts/lisa-gates-resolution.test.ts": true,
     "tests/unit/scripts/lisa-gates-self-config.test.ts": true,
     "tests/unit/scripts/lisa-gates.test.ts": true,

--- a/tests/unit/scripts/lisa-gates-order.test.ts
+++ b/tests/unit/scripts/lisa-gates-order.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for the order gates run in at a single moment.
+ *
+ * Order among independent gates is arbitrary, with exactly one exception: a
+ * gate that rewrites the working tree invalidates every verdict already reached
+ * about it. These assert that exception holds, and they assert it on the
+ * ordering itself rather than on whether some later gate passed — a fix that
+ * merely stopped a downstream check complaining would satisfy an exit-code
+ * assertion while leaving verdicts describing a tree that was discarded.
+ * @module tests/unit/scripts/lisa-gates-order
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  REGISTRY,
+  resolveMoment,
+} from "../../../all/copy-overwrite/scripts/lisa-gates.mjs";
+
+describe("execution order", () => {
+  /**
+   * The regression this exists for, replayed exactly.
+   *
+   * Gates ran alphabetically, so `artifact-freshness` verified a generated
+   * manifest, `code-style` then ran `lint:staged`, and prettier reformatted the
+   * sources that manifest hashes. The commit landed with the freshness gate
+   * reporting PASSED about bytes that were no longer the bytes committed.
+   *
+   * Asserting on order rather than on a later gate's exit code is the point: a
+   * fix that merely stopped the manifest check complaining would satisfy an
+   * exit-code assertion while leaving verdicts describing a discarded tree.
+   */
+  it("runs a rewriting gate before the gates that verify the tree", () => {
+    const order = resolveMoment({
+      gates: {
+        "artifact-freshness": { commit: "required" },
+        "code-style": { commit: { level: "required", run: "lint:staged" } },
+        "structural-rules": { commit: "required" },
+      },
+      moment: "commit",
+    }).map(gate => gate.id);
+
+    expect(order.indexOf("code-style")).toBeLessThan(
+      order.indexOf("artifact-freshness")
+    );
+    expect(order).toEqual([
+      "code-style",
+      "artifact-freshness",
+      "structural-rules",
+    ]);
+  });
+
+  it("holds for every moment of every gate the registry declares", () => {
+    // A gate added later with a --fix task inherits the guarantee only if the
+    // rule is general, so assert the property rather than one arrangement.
+    for (const moment of ["commit", "push", "pull-request"]) {
+      const gates = Object.fromEntries(
+        Object.entries(REGISTRY)
+          .filter(([, definition]) => definition.moments.includes(moment))
+          .map(([id]) => [id, { [moment]: "required" }])
+      );
+      const resolved = resolveMoment({ gates, moment });
+      const lastRewriter = resolved.findLastIndex(gate => gate.mayRewrite);
+      const firstVerifier = resolved.findIndex(gate => !gate.mayRewrite);
+      expect(resolved.length, moment).toBeGreaterThan(1);
+      expect(lastRewriter, moment).toBeLessThan(firstVerifier);
+    }
+  });
+
+  it("keeps ordering stable when nothing rewrites", () => {
+    const order = resolveMoment({
+      gates: {
+        "type-correctness": { push: "required" },
+        "dead-code": { push: "required" },
+      },
+      moment: "push",
+    }).map(gate => gate.id);
+    expect(order).toEqual(["dead-code", "type-correctness"]);
+  });
+});

--- a/tests/unit/scripts/lisa-gates-resolution.test.ts
+++ b/tests/unit/scripts/lisa-gates-resolution.test.ts
@@ -57,6 +57,9 @@ describe("resolveMoment", () => {
         label: "🧹 Lint",
         work: null,
         evidence: null,
+        // Lint rewrites the tree when pointed at a `--fix` task, so it sorts
+        // ahead of every gate that verifies the tree. See lisa-gates-order.
+        mayRewrite: true,
       },
     ]);
   });


### PR DESCRIPTION
Gates ran alphabetically, so a gate that **rewrites** the working tree could run after gates that had already **verified** it. Every verdict reached before the rewriter then described bytes that never got committed.

## Measured on the commit immediately before this branch

```
  PASSED     required artifact-freshness   bun run check:artifacts
  PASSED     required code-style           bun run lint:staged
  PASSED     required structural-rules     bun run sg:scan
✅ commit: 3 proved, 0 failed (optional), 0 not provable here, of 3 gate(s) declared.
```

`lint:staged` is `prettier --write` + `eslint --fix`, and it applies its modifications to the commit. It reformatted the very sources that `src/core/upstream-evidence-manifest.ts` hashes — *after* `artifact-freshness` had proved that manifest current. The commit landed with a stale manifest and a green freshness gate, and the push gate caught it one moment later.

`artifact-freshness` reported PASSED about a tree that was not the tree committed. That is the organising defect of this subsystem in a new costume: a check that could not meaningfully run rendering as a check that passed.

`a` < `c` was the only reason it fired. Rename either gate and it appears or vanishes — not a property a correctness guarantee should have.

## Fix

`mayRewrite`, a registry flag, sorted ahead of verifiers; alphabetical within each group.

Deliberately *may*, and deliberately registry-only rather than project config. A project can point `format-conformance` at `format:check` (rewrites nothing) or `format` (rewrites everything), and Lisa cannot tell which from here. Ordering a non-rewriter early costs nothing — order among independent gates was already arbitrary — while missing a real rewriter costs a false pass. Asking projects to declare it would put the safe answer in the hands of whoever remembers to type it, which is how this got here.

## Verification

The fix demonstrates itself. On this branch's own commit, the order inverted and the freshness gate then verified post-format bytes:

```
  PASSED     required code-style                  bun run lint:staged
  PASSED     required artifact-freshness          bun run check:artifacts
  PASSED     required structural-rules            bun run sg:scan
```

- Full suite: 694 files, 12425 tests passing
- Push gates: 8 proved, 0 failed
- `bun run typecheck` clean

**Bite control, proven RED.** Reverting the sort fails 2 of the 3 new tests (35 → 33 passing). The third — that ordering stays stable when nothing rewrites — is green either way, as a control against over-fitting to the single arrangement that broke.

The tests assert on **order**, not on whether a downstream gate passed. A fix that merely stopped the manifest check complaining would satisfy an exit-code assertion while leaving every verdict describing a discarded tree.

Work-Item: CodySwannGT/lisa#2590

🤖 Generated with Claude Code
