### PR TITLE
fix(gates): run one command once, however many gates name it

### DIFF
--- a/all/copy-overwrite/scripts/lisa-run-gates.mjs
+++ b/all/copy-overwrite/scripts/lisa-run-gates.mjs
@@ -336,17 +336,48 @@ export function runGates({
   const results = [];
   let blocked = false;
 
+  // One command proves every gate that names it, so it runs once.
+  //
+  // Two gates legitimately share a prover: a coverage-instrumented suite proves
+  // `test-correctness` by passing and `coverage-adequacy` by clearing its
+  // threshold. Running it twice cannot prove more than running it once, and it
+  // is not merely wasteful — measured here, the second run of an identical
+  // `test:cov` failed seconds after the first passed. A red that means nothing
+  // costs the register the same trust a false pass does, because it teaches
+  // whoever reads it to retry rather than look.
+  const proved = new Map();
+
   // Each verdict is printed as it is reached, not batched at the end: a push
   // gate can run for minutes, and an operator watching a hook needs to know
   // which gate is being proved right now, not only what the tally was.
   for (const gate of resolved) {
-    const outcome = blocked
-      ? { state: STATE.NOT_RUN, detail: "not run", code: null }
-      : (classifyStatic(gate) ?? execute(gate, exec));
-    results.push({ ...gate, ...outcome });
+    // A shared result is honoured even once blocked. The command genuinely ran
+    // and its answer is known, so reporting NOT-RUN here would understate what
+    // was proved — the mirror image of overstating it, and just as untrue.
+    const shared = gate.command ? proved.get(gate.command) : undefined;
+    const outcome = shared
+      ? {
+          ...shared.outcome,
+          detail: `${shared.outcome.detail} (proved by the ${shared.id} run)`,
+        }
+      : blocked
+        ? { state: STATE.NOT_RUN, detail: "not run", code: null }
+        : (classifyStatic(gate) ?? execute(gate, exec));
+
+    // Only an execution is shareable. A skip reason comes from this gate's own
+    // `needs`, so another gate naming the same command may still be able to run.
+    if (!shared && gate.command && outcome.code !== null) {
+      proved.set(gate.command, { id: gate.id, outcome });
+    }
+
+    results.push({ ...gate, ...outcome, provedBy: shared?.id ?? null });
     out(formatLine(outcome.state, gate, outcome.detail));
     const unproved =
       outcome.state === STATE.FAILED || outcome.state === STATE.UNPROVABLE;
+    // The strictest level wins when gates share a prover. Letting a required
+    // gate inherit only the pass, or letting a failure count only against the
+    // optional gate that ran first, would be the original defect again: a
+    // required gate satisfied by a run that failed.
     if (unproved && gate.level === "required") blocked = true;
   }
 

--- a/all/copy-overwrite/scripts/lisa-run-gates.mjs
+++ b/all/copy-overwrite/scripts/lisa-run-gates.mjs
@@ -312,6 +312,49 @@ function summarise(result) {
 }
 
 /**
+ * Reach one gate's verdict, and report how it was reached.
+ *
+ * The order of the three sources is the whole content of this function. A
+ * gate's own skip is decided first, because a skip comes from `needs` — a
+ * missing tool, an absent credential — which is a fact about this gate and not
+ * about the command. A gate that cannot run must say so rather than inherit a
+ * verdict from a sibling that could.
+ *
+ * A shared result is honoured next, and honoured even once the run is blocked.
+ * The command genuinely ran and its answer is known, so reporting NOT-RUN there
+ * would understate what was proved — the mirror image of overstating it, and
+ * just as untrue.
+ * @param {GateOutcome} gate The resolved gate.
+ * @param {{proved: Map<string, object>, blocked: boolean, exec: Function}} ctx Run state.
+ * @returns {{outcome: object, shared: object|undefined, ran: boolean}} The verdict.
+ */
+function verdictFor(gate, { proved, blocked, exec }) {
+  const own = classifyStatic(gate);
+  if (own) return { outcome: own, shared: undefined, ran: false };
+
+  const shared = gate.command ? proved.get(gate.command) : undefined;
+  if (shared) {
+    return {
+      outcome: {
+        ...shared.outcome,
+        detail: `${shared.outcome.detail} (proved by the ${shared.id} run)`,
+      },
+      shared,
+      ran: false,
+    };
+  }
+
+  if (blocked) {
+    return {
+      outcome: { state: STATE.NOT_RUN, detail: "not run", code: null },
+      shared: undefined,
+      ran: false,
+    };
+  }
+  return { outcome: execute(gate, exec), shared: undefined, ran: true };
+}
+
+/**
  * Run every gate declared at one moment.
  *
  * `exec` is injected rather than imported so tests never spawn a process, and
@@ -351,22 +394,19 @@ export function runGates({
   // gate can run for minutes, and an operator watching a hook needs to know
   // which gate is being proved right now, not only what the tally was.
   for (const gate of resolved) {
-    // A shared result is honoured even once blocked. The command genuinely ran
-    // and its answer is known, so reporting NOT-RUN here would understate what
-    // was proved — the mirror image of overstating it, and just as untrue.
-    const shared = gate.command ? proved.get(gate.command) : undefined;
-    const outcome = shared
-      ? {
-          ...shared.outcome,
-          detail: `${shared.outcome.detail} (proved by the ${shared.id} run)`,
-        }
-      : blocked
-        ? { state: STATE.NOT_RUN, detail: "not run", code: null }
-        : (classifyStatic(gate) ?? execute(gate, exec));
+    const { outcome, shared, ran } = verdictFor(gate, {
+      proved,
+      blocked,
+      exec,
+    });
 
-    // Only an execution is shareable. A skip reason comes from this gate's own
-    // `needs`, so another gate naming the same command may still be able to run.
-    if (!shared && gate.command && outcome.code !== null) {
+    // Only what this iteration actually executed is shareable, and `ran` says
+    // so explicitly rather than being inferred from the exit code. `execute`
+    // reports `code: null` for a command killed by a signal, so an exit-code
+    // test would treat a terminated run as never having happened and send the
+    // next gate to run it again — re-running a whole suite an operator has
+    // just interrupted.
+    if (ran && gate.command) {
       proved.set(gate.command, { id: gate.id, outcome });
     }
 

--- a/docs/design/gates-and-policy.md
+++ b/docs/design/gates-and-policy.md
@@ -10,7 +10,7 @@ Tracking issue: CodySwannGT/lisa#2579.
 
 Every decision below is downstream of one failure mode: **a check reporting
 satisfied without having proved anything.** It has appeared in this repository in
-at least five distinct forms, each found only after it had already let something
+at least six distinct forms, each found only after it had already let something
 through:
 
 | form | evidence |
@@ -20,6 +20,7 @@ through:
 | advisory-and-confusable | a not-required `🧪 Run Tests` beside the required `🧪 Run Unit Tests` merged red on two PRs (#2485) |
 | passing-with-no-work | `passWithNoTests: true` ships in five stack configs, so a unit-test gate can report green having run zero tests |
 | declared-but-uncallable | `secrets.require` was documented as a startup assertion whose only caller was a bash line inside a SKILL.md |
+| verified-then-invalidated | gates ran alphabetically, so `artifact-freshness` proved the evidence manifest current and `code-style` then reformatted the sources it hashes — a PASSED verdict about a tree that was not the tree committed (#2590) |
 
 The rule that falls out, and the one to apply when a new case is ambiguous:
 

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -272,6 +272,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "c705d400f51a3a08ada085fc1107c3dce558f9a717528fc1fe9315aa6b97a5e6",
     "e00f16cdc399c8ee61c7a3972469fbb4b662e0fff00bd9d3d6910f3f27a5f04c",
     "e429308896cf0450b2e5dfae9a580dde1a8da351503998c07ca3506e8b2ffdce",
+    "ed643bb28356e9c3f7e351227e690763d6b5e275a78d232cd9dba2d1fc55cffe",
   ]),
   "scripts/lisa-schema-validate.mjs": Object.freeze([
     "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -270,6 +270,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/lisa-run-gates.mjs": Object.freeze([
     "235c541534fc0eca510135ac39b9fbd196965fbeb54d42a09fbf052da1c925cd",
     "c705d400f51a3a08ada085fc1107c3dce558f9a717528fc1fe9315aa6b97a5e6",
+    "d078570b2a7964eb481cd05e118e2a6559968020392c6e570d90cec8f20c5487",
     "e00f16cdc399c8ee61c7a3972469fbb4b662e0fff00bd9d3d6910f3f27a5f04c",
     "e429308896cf0450b2e5dfae9a580dde1a8da351503998c07ca3506e8b2ffdce",
     "ed643bb28356e9c3f7e351227e690763d6b5e275a78d232cd9dba2d1fc55cffe",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -35,7 +35,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-reconcile-policy.mjs":
       "3c062d0b79961a9a93a822507e893dcdaa71d65d735557727d20464c2489d812",
     "all/copy-overwrite/scripts/lisa-run-gates.mjs":
-      "235c541534fc0eca510135ac39b9fbd196965fbeb54d42a09fbf052da1c925cd",
+      "ed643bb28356e9c3f7e351227e690763d6b5e275a78d232cd9dba2d1fc55cffe",
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs":
       "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
@@ -9046,6 +9046,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/lisa-run-gates-conditional-floor.test.ts": true,
     "tests/unit/scripts/lisa-run-gates-fixtures.ts": true,
     "tests/unit/scripts/lisa-run-gates-floor.test.ts": true,
+    "tests/unit/scripts/lisa-run-gates-shared-prover.test.ts": true,
     "tests/unit/scripts/lisa-run-gates.test.ts": true,
     "tests/unit/scripts/lisa-work-item.test.ts": true,
     "tests/unit/scripts/maestro-flake-classification.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -35,7 +35,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-reconcile-policy.mjs":
       "3c062d0b79961a9a93a822507e893dcdaa71d65d735557727d20464c2489d812",
     "all/copy-overwrite/scripts/lisa-run-gates.mjs":
-      "ed643bb28356e9c3f7e351227e690763d6b5e275a78d232cd9dba2d1fc55cffe",
+      "d078570b2a7964eb481cd05e118e2a6559968020392c6e570d90cec8f20c5487",
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs":
       "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":

--- a/tests/unit/scripts/lisa-run-gates-fixtures.ts
+++ b/tests/unit/scripts/lisa-run-gates-fixtures.ts
@@ -32,6 +32,8 @@ export type GateOutcome = {
   state: string;
   detail: string;
   code: number | null;
+  /** The gate whose run proved this one, when they share a command. */
+  provedBy: string | null;
 };
 
 /** What `runGates` reports about a whole moment. */
@@ -98,4 +100,42 @@ export function runCli(
   } finally {
     rmSync(root, { force: true, recursive: true });
   }
+}
+
+/**
+ * A recording executor that answers from a fixed map of command → exit code.
+ * @param codes Exit code per command; anything unlisted passes.
+ * @returns The executor plus the commands it was actually asked to run.
+ */
+export function stubExec(codes: Record<string, number | null>): {
+  exec: (command: string) => number | null;
+  calls: string[];
+} {
+  const calls: string[] = [];
+  return {
+    calls,
+    exec: (command: string): number | null => {
+      // A recorder exists to accumulate. Rebinding a new array each call would
+      // make `calls` a snapshot the caller already holds, so it would record
+      // nothing — the mutation is the whole mechanism, confined to this stub.
+      // eslint-disable-next-line functional/immutable-data -- accumulating is the mechanism
+      calls.push(command);
+      const code = codes[command];
+      // `=== undefined`, never `?? 0`: a stubbed `null` means "killed by a
+      // signal", and `??` would quietly turn that into a passing gate —
+      // reproducing inside the test harness the exact defect under test.
+      return code === undefined ? 0 : code;
+    },
+  };
+}
+
+/**
+ * Collects the runner's operator-facing output for assertion.
+ * @returns The collected lines plus the sink to hand the runner.
+ */
+export function sink(): { lines: string[]; out: (line: string) => void } {
+  const lines: string[] = [];
+  // Accumulates for the same reason `stubExec` does; see the note there.
+  // eslint-disable-next-line functional/immutable-data -- accumulating is the mechanism
+  return { lines, out: (line: string) => lines.push(line) };
 }

--- a/tests/unit/scripts/lisa-run-gates-shared-prover.test.ts
+++ b/tests/unit/scripts/lisa-run-gates-shared-prover.test.ts
@@ -33,6 +33,7 @@ const CORRECTNESS = "test-correctness";
 const SHARED_TASK = "test:cov";
 const SHARED_COMMAND = `${RUNNER} ${SHARED_TASK}`;
 const SHARED = { level: "required", run: SHARED_TASK };
+const REVIEW = "code-review";
 
 /**
  * Declare both gates at commit, at the levels a case needs.
@@ -98,6 +99,42 @@ describe("gates that share one prover", () => {
     expect(result.blocked).toBe(true);
     expect(verdict(result, COVERAGE)?.state).toBe(STATE.FAILED);
     expect(verdict(result, CORRECTNESS)?.state).toBe(STATE.FAILED);
+  });
+
+  it("does not re-run a command killed by a signal", () => {
+    // `execute` reports `code: null` for a terminated command, so inferring
+    // "did this run?" from the exit code treats a kill as never having happened
+    // — and sends the next gate to run the whole suite the operator has just
+    // interrupted. The verdicts alone cannot catch this: re-running produces
+    // the same two failures, so the assertion has to be on the executor.
+    const { result, calls } = run({ [SHARED_COMMAND]: null });
+    expect(calls).toEqual([SHARED_COMMAND]);
+    expect(verdict(result, COVERAGE)?.state).toBe(STATE.FAILED);
+    expect(verdict(result, CORRECTNESS)?.state).toBe(STATE.FAILED);
+    expect(verdict(result, CORRECTNESS)?.provedBy).toBe(COVERAGE);
+  });
+
+  it("lets a gate that cannot run say so, rather than inherit a verdict", () => {
+    // Structural, not a live regression: every skip today also resolves to a
+    // null command, so the cache lookup was already unreachable for a skipped
+    // gate. Deciding the gate's own skip *before* consulting the cache makes
+    // that correct by construction rather than by coincidence, which matters
+    // the moment a skip reason arrives that coexists with a command.
+    const { lines } = run();
+    const awaited = runGates({
+      gates: {
+        [COVERAGE]: { [COMMIT]: SHARED },
+        [REVIEW]: { [COMMIT]: { level: "required", await: "CodeRabbit" } },
+      },
+      moment: COMMIT,
+      runner: RUNNER,
+      exec: stubExec({}).exec,
+      out: () => undefined,
+    }) as GateRun;
+
+    expect(verdict(awaited, REVIEW)?.state).toBe(STATE.SKIPPED);
+    expect(verdict(awaited, REVIEW)?.provedBy).toBeNull();
+    expect(lines.join("\n")).not.toContain(REVIEW);
   });
 
   it("blocks when the required gate shares a prover with an optional one", () => {

--- a/tests/unit/scripts/lisa-run-gates-shared-prover.test.ts
+++ b/tests/unit/scripts/lisa-run-gates-shared-prover.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for gates that share one prover.
+ *
+ * Two gates legitimately name the same command: a coverage-instrumented suite
+ * proves `test-correctness` by passing and `coverage-adequacy` by clearing its
+ * threshold. One run answers both, and the assertions here are about what the
+ * runner must not do with that fact — run the command twice, or let the two
+ * gates disagree about what the single run proved.
+ *
+ * The load-bearing case is the mixed-level one. If a shared command fails and
+ * the optional gate is reached first, attributing the failure only to it would
+ * leave a required gate satisfied by a run that failed, which is the defect the
+ * whole subsystem exists to prevent, arriving through a side door.
+ * @module tests/unit/scripts/lisa-run-gates-shared-prover
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  runGates,
+  STATE,
+} from "../../../all/copy-overwrite/scripts/lisa-run-gates.mjs";
+import {
+  COMMIT,
+  type GateRun,
+  RUNNER,
+  sink,
+  stubExec,
+} from "./lisa-run-gates-fixtures.js";
+
+const COVERAGE = "coverage-adequacy";
+const CORRECTNESS = "test-correctness";
+const SHARED_TASK = "test:cov";
+const SHARED_COMMAND = `${RUNNER} ${SHARED_TASK}`;
+const SHARED = { level: "required", run: SHARED_TASK };
+
+/**
+ * Declare both gates at commit, at the levels a case needs.
+ * @param correctness - Level for `test-correctness`
+ * @returns A gates block naming one command twice
+ */
+const sharing = (correctness = "required") => ({
+  [COVERAGE]: { [COMMIT]: SHARED },
+  [CORRECTNESS]: { [COMMIT]: { level: correctness, run: SHARED_TASK } },
+});
+
+/**
+ * Run both gates against a stubbed exit code for the shared command.
+ * @param codes - Exit code per command
+ * @param correctness - Level for `test-correctness`
+ * @returns The run, the commands actually executed, and the printed lines
+ */
+function run(codes = {}, correctness = "required") {
+  const { exec, calls } = stubExec(codes);
+  const { lines, out } = sink();
+  const result = runGates({
+    gates: sharing(correctness),
+    moment: COMMIT,
+    runner: RUNNER,
+    exec,
+    out,
+  }) as GateRun;
+  return { result, calls, lines };
+}
+
+/**
+ * The verdict recorded for one gate id.
+ * @param result - A completed run
+ * @param id - Gate id
+ * @returns That gate's result entry
+ */
+const verdict = (result: GateRun, id: string) =>
+  result.results.find(entry => entry.id === id);
+
+describe("gates that share one prover", () => {
+  it("runs the shared command once, not once per gate", () => {
+    // The regression: `bun run test:cov` ran twice on every push, and on one
+    // push the second run failed seconds after the first passed. A red that
+    // means nothing costs the register the trust a false pass does.
+    const { result, calls } = run();
+    expect(calls).toEqual([SHARED_COMMAND]);
+    expect(result.total).toBe(2);
+    expect(result.passed).toHaveLength(2);
+  });
+
+  it("reports both gates proved, naming the run that proved them", () => {
+    const { result, lines } = run();
+    expect(verdict(result, COVERAGE)?.state).toBe(STATE.PASSED);
+    expect(verdict(result, CORRECTNESS)?.state).toBe(STATE.PASSED);
+    // The second gate must not read as a separate execution that happened.
+    expect(lines.join("\n")).toContain(`proved by the ${COVERAGE} run`);
+    expect(verdict(result, CORRECTNESS)?.provedBy).toBe(COVERAGE);
+  });
+
+  it("fails every gate the run was meant to prove", () => {
+    const { result, calls } = run({ [SHARED_COMMAND]: 1 });
+    expect(calls).toEqual([SHARED_COMMAND]);
+    expect(result.blocked).toBe(true);
+    expect(verdict(result, COVERAGE)?.state).toBe(STATE.FAILED);
+    expect(verdict(result, CORRECTNESS)?.state).toBe(STATE.FAILED);
+  });
+
+  it("blocks when the required gate shares a prover with an optional one", () => {
+    // `coverage-adequacy` sorts first and is optional here, so nothing blocks
+    // at the moment the command fails. The required gate reached afterwards
+    // must still inherit the failure rather than the run's mere completion.
+    const { result } = run({ [SHARED_COMMAND]: 1 }, "required");
+    const optional = runGates({
+      gates: {
+        [COVERAGE]: { [COMMIT]: { level: "optional", run: SHARED_TASK } },
+        [CORRECTNESS]: { [COMMIT]: SHARED },
+      },
+      moment: COMMIT,
+      runner: RUNNER,
+      exec: stubExec({ [SHARED_COMMAND]: 1 }).exec,
+      out: () => undefined,
+    }) as GateRun;
+
+    expect(result.blocked).toBe(true);
+    expect(optional.blocked).toBe(true);
+    expect(verdict(optional, CORRECTNESS)?.state).toBe(STATE.FAILED);
+  });
+
+  it("still runs distinct commands separately", () => {
+    // A control against over-fitting: dedupe must key on the command, not
+    // collapse every gate at a moment into one execution.
+    const { exec, calls } = stubExec({});
+    runGates({
+      gates: {
+        [COVERAGE]: { [COMMIT]: SHARED },
+        "code-style": { [COMMIT]: { level: "required", run: "lint" } },
+      },
+      moment: COMMIT,
+      runner: RUNNER,
+      exec,
+      out: () => undefined,
+    });
+    expect(calls.toSorted((left, right) => left.localeCompare(right))).toEqual([
+      `${RUNNER} lint`,
+      SHARED_COMMAND,
+    ]);
+  });
+});

--- a/tests/unit/scripts/lisa-run-gates.test.ts
+++ b/tests/unit/scripts/lisa-run-gates.test.ts
@@ -31,40 +31,10 @@ import {
   type GateRun,
   REQUIRED_AT_COMMIT,
   RUNNER,
+  sink,
+  stubExec,
   STYLE,
 } from "./lisa-run-gates-fixtures.js";
-
-/**
- * A recording executor that answers from a fixed map of command → exit code.
- * @param codes Exit code per command; anything unlisted passes.
- * @returns The executor plus the commands it was actually asked to run.
- */
-function stubExec(codes: Record<string, number | null>): {
-  exec: (command: string) => number | null;
-  calls: string[];
-} {
-  const calls: string[] = [];
-  return {
-    calls,
-    exec: (command: string): number | null => {
-      calls.push(command);
-      const code = codes[command];
-      // `=== undefined`, never `?? 0`: a stubbed `null` means "killed by a
-      // signal", and `??` would quietly turn that into a passing gate —
-      // reproducing inside the test harness the exact defect under test.
-      return code === undefined ? 0 : code;
-    },
-  };
-}
-
-/**
- * Collects the runner's operator-facing output for assertion.
- * @returns The collected lines plus the sink to hand the runner.
- */
-function sink(): { lines: string[]; out: (line: string) => void } {
-  const lines: string[] = [];
-  return { lines, out: (line: string) => lines.push(line) };
-}
 
 describe("runGates: required failures block", () => {
   const gates = {


### PR DESCRIPTION
The gate runner executed a command **once per gate that names it**, so a command shared by two gates ran twice.

```
SHARED: bun run test:cov → coverage-adequacy, test-correctness
gates at push: 8    distinct commands: 7
```

Two gates legitimately share a prover: a coverage-instrumented suite proves `test-correctness` by passing and `coverage-adequacy` by clearing its threshold. One run answers both, and running it twice cannot prove more. This ships through `all/copy-overwrite/`, so every downstream project declaring both paid a duplicated full test suite on every push.

## Not merely wasteful

On one push, the second run of an identical `bun run test:cov` **failed seconds after the first passed**:

```
  PASSED     required coverage-adequacy    bun run test:cov
  FAILED     required test-correctness     bun run test:cov (exit 1)
```

It passed on retry, and `test:cov` exits 0 standalone. The duplicate run was a flake surface that existed *only because the run was duplicated* — a gate that can fail without the thing it gates being broken. That costs the register the same trust a false pass does, because a red that means nothing teaches whoever reads it to retry rather than look.

It is not a row in the organising-defect table, though: that table is specifically about checks reporting satisfied without proving anything, and this fails the other way.

## Three rulings, all deliberate

- **Strictest level wins.** Attributing a failure only to whichever gate ran first would leave a required gate satisfied by a run that failed — the original defect through a side door.
- **A shared result is honoured even once blocked.** The command genuinely ran and its answer is known, so NOT-RUN would understate what was proved: the mirror image of overstating it, and just as untrue.
- **Only executions are shareable.** A skip comes from one gate's own `needs`, so another gate naming the same command may still be able to run.

## Verification

Proved in the real hook on this branch's own push:

```
  PASSED     required coverage-adequacy    bun run test:cov
  PASSED     required test-correctness     bun run test:cov (proved by the coverage-adequacy run)
✅ push: 8 proved, 0 failed (optional), 0 not provable here, of 8 gate(s) declared.
```

Same eight gates proved, one fewer execution.

- Full suite: 695 files, 12430 tests passing
- Push gates: 8 proved, 0 failed
- `bun run typecheck` clean

**Bite control.** Assertions are on *which commands the executor was actually asked to run*, not on verdicts alone — verdict-only assertions pass unchanged against the duplicated implementation, since running twice produces the same two verdicts.

Proven RED: 3 of 5 new tests fail without the dedupe. Stated precisely, because two do not:

- The mixed-level blocking test passes either way — the old code re-ran the command and failed again, so it still blocked. It guards against a plausible *wrong* dedupe, not against the pre-fix state.
- The distinct-commands test is green either way by design, as a control against dedupe collapsing every gate at a moment into one execution.

## Also here

A one-row addition to the organising-defect table recording **verified-then-invalidated** (#2590, merged in #2591). It missed that PR's merge and rides along.

`stubExec` and `sink` moved into the shared fixtures module so a second test file could use them, which also brought `lisa-run-gates.test.ts` back under the max-lines gate.

Work-Item: CodySwannGT/lisa#2592

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Gate checks that use the same command now run only once, reducing duplicate work.
  * Results from shared checks are reused consistently across all applicable gates.
  * Shared results remain visible in reports even when a blocking check fails.
  * Reports identify which gate originally produced a shared result.
* **Documentation**
  * Clarified the policy guidance for evidence that becomes invalid after later changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->