### PR TITLE
fix: four verified fail-open defects from backlog triage

### DIFF
--- a/.claude-pr/.husky/commit-msg
+++ b/.claude-pr/.husky/commit-msg
@@ -35,9 +35,16 @@ JIRA_KEY=$(echo "$BRANCH_NAME" | grep -E "(^|/)($JIRA_PROJECT_KEY)-[0-9]+" | gre
 if [ -n "$JIRA_KEY" ]; then
   # Read the current commit message
   COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+# `printf '%s\n'`, never `echo "$COMMIT_MSG"`. Under a POSIX/XSI `echo` the
+# backslash escapes are interpreted, and `\c` means "stop output here" — so a
+# message containing `\copy`, `\cite`, or a Windows path like `C:\config` is
+# silently truncated at that point before grep ever sees it. The
+# `Co-Authored-By:` trailer is always the last line, so it is always the part
+# lost, and the hook then rejects a commit whose trailer is present and
+# correctly formatted while pointing the author at the trailer.
   
   # Check if the Jira key is already in the commit message
-  if ! echo "$COMMIT_MSG" | grep -q "\[$JIRA_KEY\]"; then
+  if ! printf '%s\n' "$COMMIT_MSG" | grep -q "\[$JIRA_KEY\]"; then
     # Append the Jira key to the commit message
     echo "$COMMIT_MSG [$JIRA_KEY]" > "$COMMIT_MSG_FILE"
     echo "🎫 Auto-appended Jira key: [$JIRA_KEY]"
@@ -70,13 +77,13 @@ fi
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
 
 # Skip AI co-authorship check for merge commits (e.g., from git pull)
-if echo "$COMMIT_MSG" | grep -qE "^Merge (branch|pull request|remote-tracking)"; then
+if printf '%s\n' "$COMMIT_MSG" | grep -qE "^Merge (branch|pull request|remote-tracking)"; then
   echo "🔀 Merge commit detected, skipping AI co-authorship check"
   exit 0
 fi
 
 # Skip AI co-authorship check for automated release commits (e.g., from standard-version in CI)
-if echo "$COMMIT_MSG" | grep -qE "^chore\(release\):"; then
+if printf '%s\n' "$COMMIT_MSG" | grep -qE "^chore\(release\):"; then
   echo "🚀 Release commit detected, skipping AI co-authorship check"
   exit 0
 fi
@@ -86,7 +93,7 @@ echo "🤖 Checking for AI co-authorship..."
 # Accept attribution from any supported coding agent (Claude or Codex),
 # case-insensitively. Claude Code emits "Co-Authored-By: Claude"; the Codex CLI
 # emits "Co-authored-by: Codex <noreply@openai.com>".
-if ! echo "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex)"; then
+if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex)"; then
   echo ""
   echo "❌ Commit message must include AI co-authorship!"
   echo ""

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -64,15 +64,22 @@ fi
 
 # Check for Co-Authored-By line (skip for merge commits)
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+# `printf '%s\n'`, never `echo "$COMMIT_MSG"`. Under a POSIX/XSI `echo` the
+# backslash escapes are interpreted, and `\c` means "stop output here" — so a
+# message containing `\copy`, `\cite`, or a Windows path like `C:\config` is
+# silently truncated at that point before grep ever sees it. The
+# `Co-Authored-By:` trailer is always the last line, so it is always the part
+# lost, and the hook then rejects a commit whose trailer is present and
+# correctly formatted while pointing the author at the trailer.
 
 # Skip AI co-authorship check for merge commits (e.g., from git pull)
-if echo "$COMMIT_MSG" | grep -qE "^Merge (branch|pull request|remote-tracking)"; then
+if printf '%s\n' "$COMMIT_MSG" | grep -qE "^Merge (branch|pull request|remote-tracking)"; then
   echo "🔀 Merge commit detected, skipping AI co-authorship check"
   exit 0
 fi
 
 # Skip AI co-authorship check for automated release commits (e.g., from standard-version in CI)
-if echo "$COMMIT_MSG" | grep -qE "^chore\(release\):"; then
+if printf '%s\n' "$COMMIT_MSG" | grep -qE "^chore\(release\):"; then
   echo "🚀 Release commit detected, skipping AI co-authorship check"
   exit 0
 fi
@@ -83,7 +90,7 @@ echo "🤖 Checking for AI co-authorship..."
 # Claude Code emits "Co-Authored-By: Claude"; Codex can emit
 # "Co-authored-by: Codex <noreply@openai.com>"; OpenCode-authored commits
 # should identify OpenCode and include model/effort metadata trailers.
-if ! echo "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex|OpenCode)"; then
+if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex|OpenCode)"; then
   echo ""
   echo "❌ Commit message must include AI co-authorship!"
   echo ""
@@ -106,15 +113,15 @@ if ! echo "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex|OpenCode)"; 
   exit 1
 fi
 
-if echo "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*OpenCode"; then
+if printf '%s\n' "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*OpenCode"; then
   missing_opencode_metadata=0
-  if ! echo "$COMMIT_MSG" | grep -Eiq "^AI-Agent:[[:space:]]*OpenCode[[:space:]]*$"; then
+  if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "^AI-Agent:[[:space:]]*OpenCode[[:space:]]*$"; then
     missing_opencode_metadata=1
   fi
-  if ! echo "$COMMIT_MSG" | grep -Eiq "^AI-Model:[[:space:]]*[^[:space:]].*$"; then
+  if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "^AI-Model:[[:space:]]*[^[:space:]].*$"; then
     missing_opencode_metadata=1
   fi
-  if ! echo "$COMMIT_MSG" | grep -Eiq "^AI-Effort:[[:space:]]*[^[:space:]].*$"; then
+  if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "^AI-Effort:[[:space:]]*[^[:space:]].*$"; then
     missing_opencode_metadata=1
   fi
 

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,7 +1,7 @@
 {
   "*.{js,mjs,ts,tsx}": [
     "oxlint --fix --no-error-on-unmatched-pattern",
-    "eslint --quiet --cache --fix --no-error-on-unmatched-pattern --no-warn-ignored",
+    "eslint --quiet --cache --fix --no-error-on-unmatched-pattern --no-warn-ignored --no-config-lookup -c eslint.config.ts",
     "ast-grep scan"
   ],
   "*.{json,mjs,js,ts,jsx,tsx,html,md,mdx,css,scss,yaml,yml,graphql}": [

--- a/all/copy-overwrite/scripts/lisa-destructive-guard.mjs
+++ b/all/copy-overwrite/scripts/lisa-destructive-guard.mjs
@@ -146,11 +146,40 @@ export function classifyEnvironment(value) {
  */
 export function isDestructive(fields) {
   const capability = normalize(fields?.capability);
-  if (DESTRUCTIVE_CAPABILITIES.includes(capability)) {
+  if (isDestructiveName(capability)) {
     return true;
   }
   const summary = fields?.summary ?? {};
   return Number(summary.deleted) > 0 || Number(summary.created) > 0;
+}
+
+/**
+ * Whether a capability name declares a destructive operation.
+ *
+ * Matched per hyphen-separated segment as well as whole, because the envelope
+ * schema admits any `^[a-z][a-z0-9-]*$` while this list holds only bare verbs.
+ * A compound name — `reset-database`, `db-teardown`, `seed-all` — matched
+ * nothing and the name arm returned false.
+ *
+ * The counts arm does not save that case. It fires only when a run *reports*
+ * rows touched, so the bypass needs a compound name and a silent summary, and
+ * an operation that deletes without reporting is precisely what a destructive
+ * guard exists for. The name arm is the primary control; counts are a backstop.
+ *
+ * Segment matching, not substring matching: `presets` contains `reset` but is
+ * not a segment of it, so it stays non-destructive. `migrate-down` still
+ * matches as a whole name, since neither `migrate` nor `down` is destructive
+ * alone and promoting either would refuse ordinary forward migrations.
+ * @param {string} capability - Normalized capability name
+ * @returns {boolean} True when any part of the name is a destructive verb
+ */
+function isDestructiveName(capability) {
+  if (DESTRUCTIVE_CAPABILITIES.includes(capability)) {
+    return true;
+  }
+  return capability
+    .split("-")
+    .some(segment => DESTRUCTIVE_CAPABILITIES.includes(segment));
 }
 
 /**

--- a/all/copy-overwrite/scripts/lisa-work-item.mjs
+++ b/all/copy-overwrite/scripts/lisa-work-item.mjs
@@ -999,9 +999,48 @@ function validateLive(ref, contract = trackerContract()) {
   }
 }
 
-function textContainsBacklink(value, prUrl) {
+/**
+ * Punctuation that can hug a URL in prose or markdown, stripped before compare.
+ *
+ * A URL is recognised as a whitespace-delimited token, so anything a writer
+ * wraps around it — `<url>`, a trailing full stop, a closing bracket — would
+ * otherwise make an exact comparison fail against a backlink that is perfectly
+ * valid. Being too strict here fails closed and merely annoys; being too loose
+ * is the defect below.
+ */
+const URL_EDGES = /^[<([]+|[>)\].,;:]+$/g;
+
+/**
+ * The URLs a comment offers as backlinks, as discrete tokens.
+ * @param {string} text Comment body.
+ * @returns {string[]} Whitespace-delimited tokens, trimmed of edge punctuation.
+ */
+function backlinkTokens(text) {
+  return text.split(/\s+/).map(token => token.replace(URL_EDGES, ""));
+}
+
+/**
+ * Whether a value carries a backlink to exactly this pull request.
+ *
+ * The comparison is token equality, not containment. `value.includes(prUrl)`
+ * was a substring test against a URL ending in the PR number, so a comment
+ * linking PR #123 satisfied the gate for PR #12 — `.../pull/12` is a prefix of
+ * `.../pull/123`. That is a fail-open in the check whose entire job is proving
+ * a change is bound to its own work item, and it fails silently: the check goes
+ * green and reports the binding verified.
+ *
+ * Both native paths already compare with `===`. Only this fallback was loose,
+ * and it is the path GitHub Issues actually uses, having no native PR-link
+ * field. Exported so the comparison can be asserted directly — a permissive
+ * comparison returns `true` rather than throwing, so nothing observable changes
+ * without an assertion on the returned boolean.
+ * @param {unknown} value Comment body, or a structure containing one.
+ * @param {string} prUrl The pull request URL that must be linked.
+ * @returns {boolean} True when this exact pull request is linked.
+ */
+export function textContainsBacklink(value, prUrl) {
   if (typeof value === "string")
-    return value.includes(MARKER) && value.includes(prUrl);
+    return value.includes(MARKER) && backlinkTokens(value).includes(prUrl);
   if (Array.isArray(value))
     return value.some(item => textContainsBacklink(item, prUrl));
   if (value && typeof value === "object")

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "verify:learner-frontmatter-built": "bun run build:dist && node scripts/verify-learner-frontmatter-built.mjs",
     "verify:health-agentic": "bun run build:dist && node scripts/verify-health-agentic-built.mjs",
     "verify:health-consumer": "bun run build:dist && node scripts/verify-health-consumer-built.mjs",
-    "lint:staged": "lint-staged"
+    "lint:staged": "lint-staged --config .lintstagedrc.json"
   },
   "engines": {
     "npm": "please-use-bun",

--- a/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-copilot/hooks/threshold-ratchet.mjs
@@ -430,9 +430,49 @@ function main() {
   return 0;
 }
 
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
-if (isDirectRun) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The one implementation of this lives at `scripts/lib/invoked-as-script.mjs`,
+ * and every other shipped entry point imports it. This file cannot: it is
+ * materialized from `plugins/src/base/hooks/`, where it also runs as an
+ * agent-time hook, and a plugin payload has no `./lib/` to import from. So the
+ * rule is written out here rather than pointed at — the same accommodation
+ * `preflight-secrets.mjs` makes, for the same reason.
+ *
+ * Both sides are realpath'd. The previous spelling compared
+ * `fileURLToPath(import.meta.url)` against `path.resolve(process.argv[1])`, and
+ * `resolve` makes a path absolute without following symlinks. `import.meta.url`
+ * is the REAL path — node resolves ESM through realpath unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever the caller typed. Reached through a symlinked checkout, a git
+ * worktree, or a `/tmp` path on macOS (`/tmp` being a symlink to `/private/tmp`),
+ * the two disagreed, `main()` never ran, and the process exited 0.
+ *
+ * For a CHECK that is a fail-OPEN, not a mild degradation: no output, exit 0,
+ * the npm script "succeeds", and the ratchet silently stops having an opinion.
+ * It was measured, not theorised — every control in the #2531 promotion tests
+ * no-opped until the fixture directory was realpath'd.
+ *
+ * Realpathing BOTH sides rather than only `argv[1]` matters under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry:
+ * normalizing one side then compares a real path against a symlinked one and
+ * answers `false` for an entry point that WAS invoked directly. Any resolution
+ * error returns `false` — node loaded the entry from that path moments ago, so
+ * a path that will not resolve now is not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return fs.realpathSync(argv1) === fs.realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(main());
 }

--- a/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa-cursor/hooks/threshold-ratchet.mjs
@@ -430,9 +430,49 @@ function main() {
   return 0;
 }
 
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
-if (isDirectRun) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The one implementation of this lives at `scripts/lib/invoked-as-script.mjs`,
+ * and every other shipped entry point imports it. This file cannot: it is
+ * materialized from `plugins/src/base/hooks/`, where it also runs as an
+ * agent-time hook, and a plugin payload has no `./lib/` to import from. So the
+ * rule is written out here rather than pointed at — the same accommodation
+ * `preflight-secrets.mjs` makes, for the same reason.
+ *
+ * Both sides are realpath'd. The previous spelling compared
+ * `fileURLToPath(import.meta.url)` against `path.resolve(process.argv[1])`, and
+ * `resolve` makes a path absolute without following symlinks. `import.meta.url`
+ * is the REAL path — node resolves ESM through realpath unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever the caller typed. Reached through a symlinked checkout, a git
+ * worktree, or a `/tmp` path on macOS (`/tmp` being a symlink to `/private/tmp`),
+ * the two disagreed, `main()` never ran, and the process exited 0.
+ *
+ * For a CHECK that is a fail-OPEN, not a mild degradation: no output, exit 0,
+ * the npm script "succeeds", and the ratchet silently stops having an opinion.
+ * It was measured, not theorised — every control in the #2531 promotion tests
+ * no-opped until the fixture directory was realpath'd.
+ *
+ * Realpathing BOTH sides rather than only `argv[1]` matters under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry:
+ * normalizing one side then compares a real path against a symlinked one and
+ * answers `false` for an entry point that WAS invoked directly. Any resolution
+ * error returns `false` — node loaded the entry from that path moments ago, so
+ * a path that will not resolve now is not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return fs.realpathSync(argv1) === fs.realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(main());
 }

--- a/plugins/lisa/hooks/threshold-ratchet.mjs
+++ b/plugins/lisa/hooks/threshold-ratchet.mjs
@@ -430,9 +430,49 @@ function main() {
   return 0;
 }
 
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
-if (isDirectRun) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The one implementation of this lives at `scripts/lib/invoked-as-script.mjs`,
+ * and every other shipped entry point imports it. This file cannot: it is
+ * materialized from `plugins/src/base/hooks/`, where it also runs as an
+ * agent-time hook, and a plugin payload has no `./lib/` to import from. So the
+ * rule is written out here rather than pointed at — the same accommodation
+ * `preflight-secrets.mjs` makes, for the same reason.
+ *
+ * Both sides are realpath'd. The previous spelling compared
+ * `fileURLToPath(import.meta.url)` against `path.resolve(process.argv[1])`, and
+ * `resolve` makes a path absolute without following symlinks. `import.meta.url`
+ * is the REAL path — node resolves ESM through realpath unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever the caller typed. Reached through a symlinked checkout, a git
+ * worktree, or a `/tmp` path on macOS (`/tmp` being a symlink to `/private/tmp`),
+ * the two disagreed, `main()` never ran, and the process exited 0.
+ *
+ * For a CHECK that is a fail-OPEN, not a mild degradation: no output, exit 0,
+ * the npm script "succeeds", and the ratchet silently stops having an opinion.
+ * It was measured, not theorised — every control in the #2531 promotion tests
+ * no-opped until the fixture directory was realpath'd.
+ *
+ * Realpathing BOTH sides rather than only `argv[1]` matters under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry:
+ * normalizing one side then compares a real path against a symlinked one and
+ * answers `false` for an entry point that WAS invoked directly. Any resolution
+ * error returns `false` — node loaded the entry from that path moments ago, so
+ * a path that will not resolve now is not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return fs.realpathSync(argv1) === fs.realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(main());
 }

--- a/plugins/src/base/hooks/threshold-ratchet.mjs
+++ b/plugins/src/base/hooks/threshold-ratchet.mjs
@@ -430,9 +430,49 @@ function main() {
   return 0;
 }
 
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
-if (isDirectRun) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The one implementation of this lives at `scripts/lib/invoked-as-script.mjs`,
+ * and every other shipped entry point imports it. This file cannot: it is
+ * materialized from `plugins/src/base/hooks/`, where it also runs as an
+ * agent-time hook, and a plugin payload has no `./lib/` to import from. So the
+ * rule is written out here rather than pointed at — the same accommodation
+ * `preflight-secrets.mjs` makes, for the same reason.
+ *
+ * Both sides are realpath'd. The previous spelling compared
+ * `fileURLToPath(import.meta.url)` against `path.resolve(process.argv[1])`, and
+ * `resolve` makes a path absolute without following symlinks. `import.meta.url`
+ * is the REAL path — node resolves ESM through realpath unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever the caller typed. Reached through a symlinked checkout, a git
+ * worktree, or a `/tmp` path on macOS (`/tmp` being a symlink to `/private/tmp`),
+ * the two disagreed, `main()` never ran, and the process exited 0.
+ *
+ * For a CHECK that is a fail-OPEN, not a mild degradation: no output, exit 0,
+ * the npm script "succeeds", and the ratchet silently stops having an opinion.
+ * It was measured, not theorised — every control in the #2531 promotion tests
+ * no-opped until the fixture directory was realpath'd.
+ *
+ * Realpathing BOTH sides rather than only `argv[1]` matters under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry:
+ * normalizing one side then compares a real path against a symlinked one and
+ * answers `false` for an entry point that WAS invoked directly. Any resolution
+ * error returns `false` — node loaded the entry from that path moments ago, so
+ * a path that will not resolve now is not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return fs.realpathSync(argv1) === fs.realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(main());
 }

--- a/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/rails/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -433,9 +433,49 @@ function main() {
   return 0;
 }
 
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
-if (isDirectRun) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The one implementation of this lives at `scripts/lib/invoked-as-script.mjs`,
+ * and every other shipped entry point imports it. This file cannot: it is
+ * materialized from `plugins/src/base/hooks/`, where it also runs as an
+ * agent-time hook, and a plugin payload has no `./lib/` to import from. So the
+ * rule is written out here rather than pointed at — the same accommodation
+ * `preflight-secrets.mjs` makes, for the same reason.
+ *
+ * Both sides are realpath'd. The previous spelling compared
+ * `fileURLToPath(import.meta.url)` against `path.resolve(process.argv[1])`, and
+ * `resolve` makes a path absolute without following symlinks. `import.meta.url`
+ * is the REAL path — node resolves ESM through realpath unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever the caller typed. Reached through a symlinked checkout, a git
+ * worktree, or a `/tmp` path on macOS (`/tmp` being a symlink to `/private/tmp`),
+ * the two disagreed, `main()` never ran, and the process exited 0.
+ *
+ * For a CHECK that is a fail-OPEN, not a mild degradation: no output, exit 0,
+ * the npm script "succeeds", and the ratchet silently stops having an opinion.
+ * It was measured, not theorised — every control in the #2531 promotion tests
+ * no-opped until the fixture directory was realpath'd.
+ *
+ * Realpathing BOTH sides rather than only `argv[1]` matters under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry:
+ * normalizing one side then compares a real path against a symlinked one and
+ * answers `false` for an entry point that WAS invoked directly. Any resolution
+ * error returns `false` — node loaded the entry from that path moments ago, so
+ * a path that will not resolve now is not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return fs.realpathSync(argv1) === fs.realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(main());
 }

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -131,6 +131,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "1e46e6ca651e87e7814a4f486af5784ed2f7a8a48eadcaa7d3fef26e380929f9",
     "46b7c2213112306af9702c910a9bcf485ea0b46154e46f0afe8fb8b5b0ba6c08",
     "49dee610439f4f21aecb0420a0cc72f5d3595a36f2489970053096190b9909c4",
+    "6bcf8b88b1d5ade1aa7c7902ba12af1df7b0b13d4e69c49a24f76a92474c93ec",
     "6da00221189ed0f8a2938f15e02bcc2633d44f5f05489979fbb94202bc45a6d4",
     "e1e3f22b33267212b90f915f83821559d1a45cab5b16c7164b86bd6c7b53549b",
   ]),
@@ -168,6 +169,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/lisa-destructive-guard.mjs": Object.freeze([
     "4fb431a3c58f443e303d613934d023d9e95ddae5c42710bb7009f7c080c82a64",
     "66ade2c9cc0554c4934ed94a44563fd9d648b37cacfa9a5d31f17ac4f181e5a3",
+    "f0f3c43bbb6d1e389135b0205a051e64891e539d4272df2a87841ee82a8b7a55",
   ]),
   "scripts/lisa-enforcement-fallback.sh": Object.freeze([
     "1bec5f3c284b3febdc471487ee6a23ffb72bd4e7b293f9e26b0188f32318c722",
@@ -286,6 +288,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "4c263fef48c03b3b6c623ea8a6cd55505bfaf28197e5072226ea35f9f3d26885",
     "5eb31c284e820a51312d4484f0669128007326af55ee515923fec33700d003a1",
     "6a8be8577242588f14ab52b25b2a22b6def53aefa9513b4d3d7c49f4d8027079",
+    "83e7f1257bfee293bcdcdafef4272f40fcdca2d9e43ceb9df647c13c8277423d",
     "9223856be4618fb1e3e731b259ae5bf5328decc322f0b4a0d0fd18d6b12cd45a",
     "96a87c131606b3edd43e52485e68f8ffbf5c528cb4beb7a1185263519a9632ce",
     "ab0dede91c5c8a07984ae13aa48ec70cdcd2fa691b59617bc4b57998dc79a51c",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -9016,6 +9016,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/cross-pollinate.test.ts": true,
     "tests/unit/scripts/cursor-artifact-helpers.ts": true,
     "tests/unit/scripts/derived-artifact-staleness.test.ts": true,
+    "tests/unit/scripts/destructive-capability-compound-names.test.ts": true,
     "tests/unit/scripts/destructive-production-guard.test.ts": true,
     "tests/unit/scripts/destructive-production-unreachable.test.ts": true,
     "tests/unit/scripts/detect-stale-workflow-inputs-helpers.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -9079,6 +9079,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/state-classification.test.ts": true,
     "tests/unit/scripts/threshold-ratchet-gates.test.ts": true,
     "tests/unit/scripts/threshold-ratchet-promotion.test.ts": true,
+    "tests/unit/scripts/threshold-ratchet-symlinked-entry.test.ts": true,
     "tests/unit/scripts/threshold-ratchet-wiring.test.ts": true,
     "tests/unit/scripts/threshold-ratchet.test.ts": true,
     "tests/unit/scripts/upstream-evidence-manifest.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -13,7 +13,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
       "014a94647efc636cbce961364a82f03c1f3c1e54a55e9d21508fded88dce49c4",
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs":
-      "66ade2c9cc0554c4934ed94a44563fd9d648b37cacfa9a5d31f17ac4f181e5a3",
+      "f0f3c43bbb6d1e389135b0205a051e64891e539d4272df2a87841ee82a8b7a55",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
       "68e1b78d5d4471fadbe2eb575ae46221838217290123a9910d76dba0f1c34131",
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
@@ -39,7 +39,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs":
       "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
-      "b4e8aea72219f2c568429686a2ff1acd0da75ca26f244a66f3c4334297c8cd8e",
+      "83e7f1257bfee293bcdcdafef4272f40fcdca2d9e43ceb9df647c13c8277423d",
     "all/copy-overwrite/scripts/schemas/lisa-command-envelope.v1.schema.json":
       "d153b7c2953a30f180e38f09e98240c63327f5196eeba9bdf545e5a1f125a879",
     "all/copy-overwrite/scripts/schemas/lisa-state-contract.v1.schema.json":
@@ -711,7 +711,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/threshold-ratchet-families.mjs":
       "8fa58cc7276add0b2edf1de92bdcc32d81d840811ef0614ddc724010b59a888c",
     "plugins/src/base/hooks/threshold-ratchet.mjs":
-      "1e46e6ca651e87e7814a4f486af5784ed2f7a8a48eadcaa7d3fef26e380929f9",
+      "693b16d982635eef3c2d7564069623058c22c09a5784ccb0db5003cd55cdc637",
     "plugins/src/base/hooks/threshold-ratchet.sh":
       "b86f4d0b554e44fd119ad8a8920cd0ba6c9dbe779f7ee219d381cf0629453990",
     "plugins/src/base/hooks/ticket-sync-reminder.sh":
@@ -2039,7 +2039,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/copy-overwrite/lefthook.yml":
       "3ae82d0a6ad86708d8ceaa1f9a3bbe12ef64e8fa12a0248bed5e3180bb431c68",
     "rails/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "46b7c2213112306af9702c910a9bcf485ea0b46154e46f0afe8fb8b5b0ba6c08",
+      "6bcf8b88b1d5ade1aa7c7902ba12af1df7b0b13d4e69c49a24f76a92474c93ec",
     "rails/copy-overwrite/scripts/lisa-clean-git-env.sh":
       "d15af6f13eedbca41046070972380e69fc0af8f7d903aac12b8644389b9a0c91",
     "rails/copy-overwrite/scripts/threshold-ratchet-compare.mjs":
@@ -2249,7 +2249,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "tsconfig/typescript.json":
       "8cf66a6535640e0a723e24bdf7a2d8e58a634c451f0754875c7880811381a914",
     "typescript/copy-contents/.husky/commit-msg":
-      "3ab9b5d3c3998307be86be038b39a945f542ff425f795f305db23ceba8eb21b7",
+      "85336c4d2c5bf5e16dd1b12b8c80668363d64b22e3c2e123955cf00e357fc22d",
     "typescript/copy-contents/.husky/post-checkout":
       "f3abc4528e12d3ad2bc48b236d19f105e2817595c744156a558c62ae5551ccfb",
     "typescript/copy-contents/.husky/pre-commit":
@@ -2307,7 +2307,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
       "5af5f112ba258c4874a65c72c8bed12165e75e4df407265eb46ee9c89c4e0e53",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
-      "46b7c2213112306af9702c910a9bcf485ea0b46154e46f0afe8fb8b5b0ba6c08",
+      "6bcf8b88b1d5ade1aa7c7902ba12af1df7b0b13d4e69c49a24f76a92474c93ec",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":
       "0cddac03366644cdc99cc239e74520ac420d475b461a40a21728e43756872b07",
     "typescript/copy-overwrite/scripts/lib/invoked-as-script.mjs":
@@ -9083,6 +9083,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/upstream-evidence-manifest.test.ts": true,
     "tests/unit/scripts/vacuous-required-checks.test.ts": true,
     "tests/unit/scripts/verification-coverage.test.ts": true,
+    "tests/unit/scripts/work-item-backlink-exactness.test.ts": true,
     "tests/unit/scripts/work-item-github-failure-diagnosis.test.ts": true,
     "tests/unit/scripts/work-item-tracker-unreachable.test.ts": true,
     "tests/unit/secrets/automation-workflow.test.ts": true,

--- a/tests/unit/hooks/commit-msg.test.ts
+++ b/tests/unit/hooks/commit-msg.test.ts
@@ -23,6 +23,11 @@ import { cleanGitEnv } from "../../helpers/test-utils.js";
 
 const HOOK_PATH = path.resolve(".husky/commit-msg");
 const BASH_PATH = "/bin/bash";
+// git runs hooks through `sh`, not bash, and the two disagree about `echo`:
+// bash prints `a\cb` verbatim while sh honours the XSI meaning of `\c` and
+// stops output there. Tests that only ever run the hook under bash therefore
+// cannot see any shell-portability defect, which is how #2143 survived.
+const SH_PATH = "/bin/sh";
 const GIT_PATH = "/usr/bin/git";
 const VALID_SUBJECT = "fix: clarify hook output";
 const PASSING_COMMITLINT_BIN = "exit 0\n";
@@ -203,10 +208,14 @@ fi\n`
 /**
  * Run the real commit-msg hook against the temp project's commit message.
  * @param project - Temporary project directory.
+ * @param shell - Interpreter to run the hook under; `sh` matches what git uses.
  * @returns The completed hook process.
  */
-function runHook(project: string): ReturnType<typeof spawnSync> {
-  return spawnSync(BASH_PATH, [HOOK_PATH, "COMMIT_EDITMSG"], {
+function runHook(
+  project: string,
+  shell: string = BASH_PATH
+): ReturnType<typeof spawnSync> {
+  return spawnSync(shell, [HOOK_PATH, "COMMIT_EDITMSG"], {
     cwd: project,
     encoding: "utf8",
     env: cleanGitEnv(process.env, {
@@ -226,3 +235,44 @@ function writeBin(project: string, name: string, body: string): void {
   writeFileSync(binPath, `#!/usr/bin/env bash\n${body}`);
   chmodSync(binPath, 0o755);
 }
+
+describe("commit message content cannot break the hook's own parsing", () => {
+  const BACKSLASH_C_SUBJECT = String.raw`fix: use \copy for the bulk load`;
+
+  it("accepts a valid trailer after a subject containing an XSI escape", () => {
+    // Run under `sh`, deliberately. Under bash this passes with or without the
+    // fix, so a bash-only assertion here would be a test that cannot fail.
+    const project = createProject({
+      binName: "npx",
+      binBody: PASSING_COMMITLINT_BIN,
+      message: [
+        BACKSLASH_C_SUBJECT,
+        "",
+        WORK_ITEM_TRAILER,
+        "Co-authored-by: Claude <noreply@anthropic.com>",
+        "",
+      ].join("\n"),
+    });
+
+    const result = runHook(project, SH_PATH);
+
+    // The trailer is present and correctly formed. Rejecting here means the
+    // hook truncated the message before matching, then blamed the trailer.
+    expect(result.stdout).not.toContain("must include AI co-authorship");
+    expect(result.status).toBe(0);
+  });
+
+  it("still rejects a message that genuinely lacks a trailer", () => {
+    // The control: the fix must not turn the co-authorship gate into a pass.
+    const project = createProject({
+      binName: "npx",
+      binBody: PASSING_COMMITLINT_BIN,
+      message: `${BACKSLASH_C_SUBJECT}\n\n${WORK_ITEM_TRAILER}\n`,
+    });
+
+    const result = runHook(project, SH_PATH);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("must include AI co-authorship");
+  });
+});

--- a/tests/unit/scripts/destructive-capability-compound-names.test.ts
+++ b/tests/unit/scripts/destructive-capability-compound-names.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Tests for destructive-capability name matching.
+ *
+ * The envelope schema admits any `^[a-z][a-z0-9-]*$`, and its own description
+ * uses compound examples, while `DESTRUCTIVE_CAPABILITIES` holds only bare
+ * verbs. Matching the whole string against that list therefore classified
+ * `reset-database` as non-destructive.
+ *
+ * Every case here pairs a compound name with an **empty summary**, because that
+ * is the combination that actually bypasses the guard: the counts arm fires
+ * only when a run reports rows touched, and an operation that deletes without
+ * reporting is exactly what the guard exists for. A test that let the summary
+ * report counts would pass against the broken matcher and prove nothing.
+ * @module tests/unit/scripts/destructive-capability-compound-names
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DESTRUCTIVE_CAPABILITIES,
+  isDestructive,
+} from "../../../all/copy-overwrite/scripts/lisa-destructive-guard.mjs";
+
+/**
+ * An envelope naming a capability and reporting no work at all.
+ * @param capability - The capability name to classify
+ * @returns An envelope-shaped object with a silent summary
+ */
+const silent = (capability: string) => ({ capability, summary: {} });
+
+describe("isDestructive: compound capability names", () => {
+  it.each([
+    "reset-database",
+    "db-teardown",
+    "seed-all",
+    "truncate-tables",
+    "purge-old-events",
+    "restore-from-backup",
+  ])("classifies %s as destructive despite an empty summary", name => {
+    expect(isDestructive(silent(name))).toBe(true);
+  });
+
+  it("still classifies the bare verbs it always knew", () => {
+    for (const name of DESTRUCTIVE_CAPABILITIES) {
+      expect(isDestructive(silent(name)), name).toBe(true);
+    }
+  });
+
+  it("matches segments, not substrings", () => {
+    // `presets` contains `reset`. Segment matching is what keeps an ordinary
+    // capability from being refused; a substring test would over-refuse here,
+    // and an over-refusing guard gets disabled.
+    expect(isDestructive(silent("presets"))).toBe(false);
+    expect(isDestructive(silent("load-presets"))).toBe(false);
+    expect(isDestructive(silent("reseeded"))).toBe(false);
+  });
+
+  it("leaves ordinary read capabilities alone", () => {
+    expect(isDestructive(silent("export"))).toBe(false);
+    expect(isDestructive(silent("migrate-up"))).toBe(false);
+    expect(isDestructive(silent("health-check"))).toBe(false);
+  });
+
+  it("keeps the counts arm as a backstop for honest reporting", () => {
+    // A capability nobody named destructively is still destructive if the run
+    // says it deleted or created rows.
+    expect(
+      isDestructive({ capability: "export", summary: { deleted: 3 } })
+    ).toBe(true);
+    expect(
+      isDestructive({ capability: "export", summary: { created: 1 } })
+    ).toBe(true);
+    expect(
+      isDestructive({ capability: "export", summary: { deleted: 0 } })
+    ).toBe(false);
+  });
+
+  it("does not throw on a missing or malformed capability", () => {
+    expect(isDestructive({})).toBe(false);
+    expect(isDestructive({ capability: null })).toBe(false);
+    expect(isDestructive(undefined)).toBe(false);
+  });
+});

--- a/tests/unit/scripts/invoked-as-script.test.ts
+++ b/tests/unit/scripts/invoked-as-script.test.ts
@@ -48,20 +48,6 @@ const SHIPPED_SCRIPT_DIRS = [
 ] as const;
 
 /**
- * `check-threshold-ratchet.mjs` and its two sibling modules are materialized
- * from `plugins/src/base/hooks/`, where they also RUN as agent-time hooks. A
- * `./lib/` import there would have to resolve inside the plugin payload, which
- * is a larger change than this one; until that happens they keep their own
- * guard and are excused here by name rather than by a pattern that would also
- * excuse a future offender silently.
- */
-const MATERIALIZED_FROM_HOOKS = new Set([
-  "check-threshold-ratchet.mjs",
-  "threshold-ratchet-compare.mjs",
-  "threshold-ratchet-families.mjs",
-]);
-
-/**
  * Guard spellings that are wrong, each matched by shape rather than by exact
  * text so a reformat cannot slip one past.
  */
@@ -276,9 +262,17 @@ describe("shared entry guard wiring", () => {
   });
 
   it("leaves no hand-rolled entry guard in any shipped .mjs", () => {
+    // The only exemption is defining the rule rather than importing it. Three
+    // threshold-ratchet modules used to be excused BY NAME, because they are
+    // materialized from `plugins/src/base/hooks/` where a `./lib/` import
+    // cannot resolve inside the plugin payload. That exemption is retired: the
+    // one that has an entry point now writes the guard out inline, and the two
+    // sibling modules turned out to have no entry guard at all — they are
+    // imported, never invoked — so there was nothing to excuse. A name-based
+    // exemption is worth removing on its own account: it excuses a FILE rather
+    // than a reason, so it keeps excusing that file after the reason expires.
     const subjects = SHIPPED_SCRIPT_DIRS.flatMap(shippedModules).filter(
       relativePath =>
-        !MATERIALIZED_FROM_HOOKS.has(path.basename(relativePath)) &&
         !read(relativePath).includes("export function invokedAsScript")
     );
     const offenders = subjects.flatMap(guardOffences);

--- a/tests/unit/scripts/threshold-ratchet-symlinked-entry.test.ts
+++ b/tests/unit/scripts/threshold-ratchet-symlinked-entry.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Proof that the threshold ratchet actually runs when reached via a symlink.
+ *
+ * The guard compared `fileURLToPath(import.meta.url)` against
+ * `path.resolve(process.argv[1])`. `resolve` makes a path absolute without
+ * following symlinks, so the two sides disagreed, `main()` never ran, and the
+ * process exited 0 having done nothing.
+ *
+ * For a CHECK that is a fail-OPEN: no output, exit 0, the npm script
+ * "succeeds", and a gate meant to block a merge quietly stops having an
+ * opinion. Which is why every assertion here is on OUTPUT. Asserting on the
+ * exit status would pass against the broken guard — a script that never ran
+ * exits 0 exactly like one that ran and found nothing wrong.
+ *
+ * The link is to the containing DIRECTORY, not the file. Symlinking the file
+ * alone works normally but fails under `--preserve-symlinks-main` with
+ * ERR_MODULE_NOT_FOUND, because the entry is no longer realpath'd and its
+ * sibling imports resolve beside the link instead of beside the real file. That
+ * is a property of the fixture, not of the guard, and a directory link keeps
+ * the siblings reachable so the flag case measures what it claims to.
+ * @module tests/unit/scripts/threshold-ratchet-symlinked-entry
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const LANES = [
+  "typescript/copy-overwrite/scripts",
+  "rails/copy-overwrite/scripts",
+] as const;
+const SCRIPT = "check-threshold-ratchet.mjs";
+const HOOK_SOURCE = "plugins/src/base/hooks";
+const HOOK_SCRIPT = "threshold-ratchet.mjs";
+
+/** Text the body prints when invoked with no recognised argument. */
+const USAGE = "usage: threshold-ratchet.mjs";
+
+let temps: string[] = [];
+
+afterEach(() => {
+  for (const dir of temps) rmSync(dir, { force: true, recursive: true });
+  temps = [];
+});
+
+/**
+ * Invoke a shipped script through a symlink to its containing directory.
+ * @param dir - Repository-relative directory holding the script
+ * @param script - The script's filename
+ * @param flags - Extra node flags to pass ahead of the entry path
+ * @returns Combined stdout and stderr
+ */
+function throughSymlink(
+  dir: string,
+  script: string,
+  flags: readonly string[] = []
+): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-ratchet-link-"));
+  const link = path.join(root, "scripts");
+  const entry = path.join(link, script);
+  temps.push(root);
+  symlinkSync(path.resolve(dir), link);
+  return output(
+    spawnSync(process.execPath, [...flags, entry], { encoding: "utf8" })
+  );
+}
+
+/**
+ * Everything a run wrote, on either stream.
+ *
+ * Both streams together, because which one carries the proof is not the point:
+ * the question is whether the body produced anything at all.
+ * @param result - A completed process
+ * @returns stdout concatenated with stderr
+ */
+function output(result: ReturnType<typeof spawnSync>): string {
+  return `${result.stdout}${result.stderr}`;
+}
+
+describe("threshold ratchet reached through a symlink", () => {
+  it.each(LANES)("runs its body when invoked via a symlink: %s", dir => {
+    // Output, never exit status. A guard that no-ops prints nothing and exits
+    // 0, which an exit-status assertion cannot tell apart from success.
+    expect(throughSymlink(dir, SCRIPT)).toContain(USAGE);
+  });
+
+  it.each(LANES)("runs its body under --preserve-symlinks-main: %s", dir => {
+    // The flag tells node NOT to realpath the main entry, so `import.meta.url`
+    // stays symlinked too. A fix that normalized only `argv[1]` would compare a
+    // real path against a symlinked one and reintroduce the no-op here — which
+    // is why the shared helper realpaths both sides.
+    expect(throughSymlink(dir, SCRIPT, ["--preserve-symlinks-main"])).toContain(
+      USAGE
+    );
+  });
+
+  it("covers the canonical hook source the lanes are materialized from", () => {
+    expect(throughSymlink(HOOK_SOURCE, HOOK_SCRIPT)).toContain(USAGE);
+    expect(
+      throughSymlink(HOOK_SOURCE, HOOK_SCRIPT, ["--preserve-symlinks-main"])
+    ).toContain(USAGE);
+  });
+
+  it("still runs when invoked directly, with no symlink involved", () => {
+    // A control: the fix must not trade one no-op for another.
+    expect(
+      output(
+        spawnSync(process.execPath, [path.resolve(LANES[0], SCRIPT)], {
+          encoding: "utf8",
+        })
+      )
+    ).toContain(USAGE);
+  });
+});

--- a/tests/unit/scripts/work-item-backlink-exactness.test.ts
+++ b/tests/unit/scripts/work-item-backlink-exactness.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the pull-request backlink comparison.
+ *
+ * The gate proves a change is bound to its own work item, and the comment
+ * fallback compared with `includes` against a URL ending in the PR number. So a
+ * comment linking PR #123 satisfied the gate for PR #12, because `.../pull/12`
+ * is a prefix of `.../pull/123`.
+ *
+ * Every assertion here is on the returned boolean rather than on an exit code
+ * or a thrown error, because a permissive comparison returns `true` — nothing
+ * observable changes without asserting the value directly, which is why the
+ * defect survived a full suite.
+ * @module tests/unit/scripts/work-item-backlink-exactness
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { textContainsBacklink } from "../../../all/copy-overwrite/scripts/lisa-work-item.mjs";
+
+const MARKER = "[lisa-pr-link]";
+const BASE = "https://github.com/CodySwannGT/lisa/pull";
+const PR_12 = `${BASE}/12`;
+const PR_123 = `${BASE}/123`;
+const LINKS_123 = `${MARKER} ${PR_123}`;
+
+describe("textContainsBacklink", () => {
+  it("refuses a link to a pull request whose number merely starts the same", () => {
+    // The defect, stated as the assertion that failed before the fix.
+    expect(textContainsBacklink(LINKS_123, PR_12)).toBe(false);
+  });
+
+  it("accepts the pull request actually linked", () => {
+    expect(textContainsBacklink(LINKS_123, PR_123)).toBe(true);
+  });
+
+  it("refuses a longer number that merely extends the linked one", () => {
+    // The prefix relation runs both ways; only one direction was reachable
+    // through `includes`, so assert the other rather than assume it.
+    expect(textContainsBacklink(LINKS_123, `${BASE}/1234`)).toBe(false);
+  });
+
+  it("still requires the marker, not merely the URL", () => {
+    // The marker is what distinguishes a deliberate backlink from a passing
+    // mention of the pull request in prose.
+    expect(textContainsBacklink(`see ${PR_123} for context`, PR_123)).toBe(
+      false
+    );
+  });
+
+  it("tolerates punctuation a writer wraps around the URL", () => {
+    // Token equality must not be so strict that it rejects valid backlinks;
+    // failing closed here would merely annoy, but it would still be wrong.
+    expect(textContainsBacklink(`${MARKER} <${PR_123}>`, PR_123)).toBe(true);
+    expect(textContainsBacklink(`${MARKER} ${PR_123}.`, PR_123)).toBe(true);
+    expect(textContainsBacklink(`${MARKER} ${PR_123}`, PR_123)).toBe(true);
+  });
+
+  it("searches arrays and objects, as the tracker payloads require", () => {
+    expect(textContainsBacklink([{ body: LINKS_123 }], PR_123)).toBe(true);
+    expect(textContainsBacklink([{ body: LINKS_123 }], PR_12)).toBe(false);
+    expect(textContainsBacklink({ nodes: [LINKS_123] }, PR_123)).toBe(true);
+  });
+
+  it("returns false for values that carry no text at all", () => {
+    expect(textContainsBacklink(null, PR_123)).toBe(false);
+    expect(textContainsBacklink(undefined, PR_123)).toBe(false);
+    expect(textContainsBacklink(42, PR_123)).toBe(false);
+  });
+});

--- a/typescript/copy-contents/.husky/commit-msg
+++ b/typescript/copy-contents/.husky/commit-msg
@@ -54,15 +54,22 @@ fi
 
 # Check for Co-Authored-By line (skip for merge commits)
 COMMIT_MSG=$(cat "$COMMIT_MSG_FILE")
+# `printf '%s\n'`, never `echo "$COMMIT_MSG"`. Under a POSIX/XSI `echo` the
+# backslash escapes are interpreted, and `\c` means "stop output here" — so a
+# message containing `\copy`, `\cite`, or a Windows path like `C:\config` is
+# silently truncated at that point before grep ever sees it. The
+# `Co-Authored-By:` trailer is always the last line, so it is always the part
+# lost, and the hook then rejects a commit whose trailer is present and
+# correctly formatted while pointing the author at the trailer.
 
 # Skip AI co-authorship check for merge commits (e.g., from git pull)
-if echo "$COMMIT_MSG" | grep -qE "^Merge (branch|pull request|remote-tracking)"; then
+if printf '%s\n' "$COMMIT_MSG" | grep -qE "^Merge (branch|pull request|remote-tracking)"; then
   echo "🔀 Merge commit detected, skipping AI co-authorship check"
   exit 0
 fi
 
 # Skip AI co-authorship check for automated release commits (e.g., from standard-version in CI)
-if echo "$COMMIT_MSG" | grep -qE "^chore\(release\):"; then
+if printf '%s\n' "$COMMIT_MSG" | grep -qE "^chore\(release\):"; then
   echo "🚀 Release commit detected, skipping AI co-authorship check"
   exit 0
 fi
@@ -72,7 +79,7 @@ echo "🤖 Checking for AI co-authorship..."
 # Accept attribution from any supported coding agent (Claude or Codex),
 # case-insensitively. Claude Code emits "Co-Authored-By: Claude"; the Codex CLI
 # emits "Co-authored-by: Codex <noreply@openai.com>".
-if ! echo "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex)"; then
+if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex)"; then
   echo ""
   echo "❌ Commit message must include AI co-authorship!"
   echo ""

--- a/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
+++ b/typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs
@@ -433,9 +433,49 @@ function main() {
   return 0;
 }
 
-const isDirectRun =
-  process.argv[1] &&
-  fileURLToPath(import.meta.url) === path.resolve(process.argv[1]);
-if (isDirectRun) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The one implementation of this lives at `scripts/lib/invoked-as-script.mjs`,
+ * and every other shipped entry point imports it. This file cannot: it is
+ * materialized from `plugins/src/base/hooks/`, where it also runs as an
+ * agent-time hook, and a plugin payload has no `./lib/` to import from. So the
+ * rule is written out here rather than pointed at — the same accommodation
+ * `preflight-secrets.mjs` makes, for the same reason.
+ *
+ * Both sides are realpath'd. The previous spelling compared
+ * `fileURLToPath(import.meta.url)` against `path.resolve(process.argv[1])`, and
+ * `resolve` makes a path absolute without following symlinks. `import.meta.url`
+ * is the REAL path — node resolves ESM through realpath unless
+ * `--preserve-symlinks` or `--preserve-symlinks-main` is set — while `argv[1]`
+ * is whatever the caller typed. Reached through a symlinked checkout, a git
+ * worktree, or a `/tmp` path on macOS (`/tmp` being a symlink to `/private/tmp`),
+ * the two disagreed, `main()` never ran, and the process exited 0.
+ *
+ * For a CHECK that is a fail-OPEN, not a mild degradation: no output, exit 0,
+ * the npm script "succeeds", and the ratchet silently stops having an opinion.
+ * It was measured, not theorised — every control in the #2531 promotion tests
+ * no-opped until the fixture directory was realpath'd.
+ *
+ * Realpathing BOTH sides rather than only `argv[1]` matters under
+ * `--preserve-symlinks-main`, which tells node not to resolve the main entry:
+ * normalizing one side then compares a real path against a symlinked one and
+ * answers `false` for an entry point that WAS invoked directly. Any resolution
+ * error returns `false` — node loaded the entry from that path moments ago, so
+ * a path that will not resolve now is not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return fs.realpathSync(argv1) === fs.realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(main());
 }


### PR DESCRIPTION
Four verified defects from backlog triage, one commit each, every bite control proven RED.

They travel together because the push gate requires a single work item per branch, and because each fix regenerates `upstream-evidence-manifest.ts` and `lisa-owned-hash-ledger.ts` — four simultaneously open pull requests would conflict on those by construction. Each commit carries its own `Fixes:` reference.

| # | Defect | Bite control |
|---|---|---|
| #2586 | `value.includes(prUrl)` is a substring test, so a backlink to PR **#123** satisfied PR **#12** | 2 of 7 fail before the fix |
| #2143 | `echo "$COMMIT_MSG" \| grep` truncates at `\c`, rejecting a co-authorship trailer that is present | 1 of 6 fails before the fix |
| #2584 | destructive-guard matched capability names whole, so `reset-database` classified non-destructive | 6 of 11 fail before the fix |
| #2582 | ratchet entry guard used `path.resolve`, so a symlinked path made the check no-op and exit 0 | 3 of 6 fail before the fix |

All four fail **open** — the check reports satisfied without having proved anything. That is the organising defect of the gates subsystem arriving four separate ways.

## What each assertion had to be careful about

- **#2586** asserts the returned **boolean**, not an exit code. A permissive comparison returns `true` rather than throwing, so nothing observable changes without asserting the value.
- **#2143** runs the hook under **`sh`**, not bash. Measured here: `/bin/bash` prints `a\cb` verbatim, `/bin/sh` prints `a`. Git runs hooks through `sh`, and the existing suite ran them through bash — so every shell-portability fault was invisible to it, and a test added there would have passed before and after. `runHook` now takes the interpreter.
- **#2584** pairs every compound name with an **empty summary**. The counts arm fires only when a run reports rows touched, so letting the summary report counts would pass against the broken matcher and prove nothing.
- **#2582** asserts on **output**, never exit status: a script that never ran exits 0 exactly like one that ran and found nothing wrong.

Each also carries controls that stay green either way, so the fixes cannot over-fire: `presets` must not classify as destructive, a genuinely missing co-authorship trailer must still be rejected, and the ratchet must still run when no symlink is involved.

## Prerequisite found while fixing #2582

Staging any linted file under `typescript/copy-overwrite/` killed the commit gate:

```
Error: Cannot find module './eslint.thresholds.json'
Require stack:
- typescript/copy-overwrite/eslint.config.ts
```

Both lint-staged and eslint discover **nested** configs, and Lisa's tree contains template configs never meant to execute here. `eslint.thresholds.json` ships create-only, so it exists only in a host project.

Measured, not inferred: staging that one file **alone** reproduces it, with no source change involved. The file is ignored by the root config anyway — eslint resolves a config *before* deciding a file is ignored.

Both are now pinned to the root config, in Lisa's own copies only. The shipped templates are untouched: a host project has no template directories, so it has nothing to discover.

## Also here

The three threshold-ratchet modules were excused from the hand-rolled-guard sweep **by name**. Retired: the one with an entry point now defines the rule inline (the accommodation `preflight-secrets.mjs` already makes, since a plugin payload has no `./lib/` to import from), and the other two turned out to have no entry guard at all — confirmed, not assumed: zero `argv[1]` references, because they are imported and never invoked.

A name-based exemption excuses a *file* rather than a *reason*, so it keeps excusing that file long after the reason expires. The sweep now excuses only files that define the rule.

## Verification

- Full suite: 698 files, 12458 tests passing
- Push gates: 8 proved, 0 failed
- `bun run typecheck` clean

Work-Item: CodySwannGT/lisa#2594

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commit-message validation now preserves backslashes and correctly handles attribution checks.
  * Backlink validation requires exact pull-request URLs, preventing partial or prefix matches.
  * Destructive actions are detected more accurately, including compound capability names.
  * Threshold checks now run reliably when launched through symlinks or equivalent paths.

* **Chores**
  * Staged linting now uses the intended ESLint configuration consistently.
  * Expanded automated coverage for commit validation, backlinks, destructive actions, and symlinked execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->