### PR TITLE
fix(scripts): sweep the plugin payload for hand-rolled entry guards

### DIFF
--- a/plugins/lisa-agy/scripts/automation-run-record.mjs
+++ b/plugins/lisa-agy/scripts/automation-run-record.mjs
@@ -8,6 +8,8 @@
 
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
@@ -396,7 +398,41 @@ export async function runAutomationRunRecordCli(argv) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   runAutomationRunRecordCli(process.argv.slice(2)).then(
     code => {
       process.exitCode = code;

--- a/plugins/lisa-agy/scripts/cross-pollinate.mjs
+++ b/plugins/lisa-agy/scripts/cross-pollinate.mjs
@@ -37,6 +37,8 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
 const LOCK_VERSION = 1;
@@ -704,7 +706,41 @@ export function renderReport(p, result) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const args = process.argv.slice(2);
   const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
   const dryRun = args.includes("--dry-run") || !args.includes("--write");

--- a/plugins/lisa-agy/scripts/design-source-gate.mjs
+++ b/plugins/lisa-agy/scripts/design-source-gate.mjs
@@ -35,7 +35,8 @@
  * Exit 0 = PASS, 1 = FAIL (any violation, or anything unresolvable), 2 = usage.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /** The one designated marker for UI deliberately not captured in Figma. */
 export const DESIGN_SOURCE_NONE_MARKER = "DESIGN-SOURCE: none — not in Figma";
@@ -534,6 +535,36 @@ export function runCli(argv) {
   return result.verdict === "PASS" ? 0 : 1;
 }
 
-if (process.argv[1]?.endsWith("design-source-gate.mjs")) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The previous spelling tested whether `process.argv[1]` ENDED WITH this
+ * module's basename, which is looser still than the `file://` comparison the
+ * sibling modules used: any path ending in `design-source-gate.mjs` satisfied
+ * it, including a different copy of this file in another checkout, and a
+ * rename silently turned the guard off with nothing to notice.
+ *
+ * Both sides are realpath'd instead. Reached through a symlinked checkout, a
+ * git worktree, or a `/tmp` path on macOS the naive comparisons disagree, the
+ * body never runs, and the process exits 0 having done nothing — and every
+ * Lisa-driven agent runs in a worktree, so that is the routine path.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(runCli(process.argv.slice(2)));
 }

--- a/plugins/lisa-agy/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa-agy/scripts/plugin-sync-explain.mjs
@@ -19,6 +19,8 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const PLUGIN_SYNC_CLASSIFICATIONS = [
   "SOURCE_NOT_BUILT",
@@ -556,7 +558,41 @@ function linkedWorktreeGitDir(root) {
   return path.isAbsolute(gitDir) ? gitDir : path.resolve(root, gitDir);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     const report = explainPluginSync(process.argv[2] ?? process.cwd());
     process.stdout.write(report.text);

--- a/plugins/lisa-copilot/scripts/automation-run-record.mjs
+++ b/plugins/lisa-copilot/scripts/automation-run-record.mjs
@@ -8,6 +8,8 @@
 
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
@@ -396,7 +398,41 @@ export async function runAutomationRunRecordCli(argv) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   runAutomationRunRecordCli(process.argv.slice(2)).then(
     code => {
       process.exitCode = code;

--- a/plugins/lisa-copilot/scripts/cross-pollinate.mjs
+++ b/plugins/lisa-copilot/scripts/cross-pollinate.mjs
@@ -37,6 +37,8 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
 const LOCK_VERSION = 1;
@@ -704,7 +706,41 @@ export function renderReport(p, result) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const args = process.argv.slice(2);
   const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
   const dryRun = args.includes("--dry-run") || !args.includes("--write");

--- a/plugins/lisa-copilot/scripts/design-source-gate.mjs
+++ b/plugins/lisa-copilot/scripts/design-source-gate.mjs
@@ -35,7 +35,8 @@
  * Exit 0 = PASS, 1 = FAIL (any violation, or anything unresolvable), 2 = usage.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /** The one designated marker for UI deliberately not captured in Figma. */
 export const DESIGN_SOURCE_NONE_MARKER = "DESIGN-SOURCE: none — not in Figma";
@@ -534,6 +535,36 @@ export function runCli(argv) {
   return result.verdict === "PASS" ? 0 : 1;
 }
 
-if (process.argv[1]?.endsWith("design-source-gate.mjs")) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The previous spelling tested whether `process.argv[1]` ENDED WITH this
+ * module's basename, which is looser still than the `file://` comparison the
+ * sibling modules used: any path ending in `design-source-gate.mjs` satisfied
+ * it, including a different copy of this file in another checkout, and a
+ * rename silently turned the guard off with nothing to notice.
+ *
+ * Both sides are realpath'd instead. Reached through a symlinked checkout, a
+ * git worktree, or a `/tmp` path on macOS the naive comparisons disagree, the
+ * body never runs, and the process exits 0 having done nothing — and every
+ * Lisa-driven agent runs in a worktree, so that is the routine path.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(runCli(process.argv.slice(2)));
 }

--- a/plugins/lisa-copilot/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa-copilot/scripts/plugin-sync-explain.mjs
@@ -19,6 +19,8 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const PLUGIN_SYNC_CLASSIFICATIONS = [
   "SOURCE_NOT_BUILT",
@@ -556,7 +558,41 @@ function linkedWorktreeGitDir(root) {
   return path.isAbsolute(gitDir) ? gitDir : path.resolve(root, gitDir);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     const report = explainPluginSync(process.argv[2] ?? process.cwd());
     process.stdout.write(report.text);

--- a/plugins/lisa-cursor/scripts/automation-run-record.mjs
+++ b/plugins/lisa-cursor/scripts/automation-run-record.mjs
@@ -8,6 +8,8 @@
 
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
@@ -396,7 +398,41 @@ export async function runAutomationRunRecordCli(argv) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   runAutomationRunRecordCli(process.argv.slice(2)).then(
     code => {
       process.exitCode = code;

--- a/plugins/lisa-cursor/scripts/cross-pollinate.mjs
+++ b/plugins/lisa-cursor/scripts/cross-pollinate.mjs
@@ -37,6 +37,8 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
 const LOCK_VERSION = 1;
@@ -704,7 +706,41 @@ export function renderReport(p, result) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const args = process.argv.slice(2);
   const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
   const dryRun = args.includes("--dry-run") || !args.includes("--write");

--- a/plugins/lisa-cursor/scripts/design-source-gate.mjs
+++ b/plugins/lisa-cursor/scripts/design-source-gate.mjs
@@ -35,7 +35,8 @@
  * Exit 0 = PASS, 1 = FAIL (any violation, or anything unresolvable), 2 = usage.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /** The one designated marker for UI deliberately not captured in Figma. */
 export const DESIGN_SOURCE_NONE_MARKER = "DESIGN-SOURCE: none — not in Figma";
@@ -534,6 +535,36 @@ export function runCli(argv) {
   return result.verdict === "PASS" ? 0 : 1;
 }
 
-if (process.argv[1]?.endsWith("design-source-gate.mjs")) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The previous spelling tested whether `process.argv[1]` ENDED WITH this
+ * module's basename, which is looser still than the `file://` comparison the
+ * sibling modules used: any path ending in `design-source-gate.mjs` satisfied
+ * it, including a different copy of this file in another checkout, and a
+ * rename silently turned the guard off with nothing to notice.
+ *
+ * Both sides are realpath'd instead. Reached through a symlinked checkout, a
+ * git worktree, or a `/tmp` path on macOS the naive comparisons disagree, the
+ * body never runs, and the process exits 0 having done nothing — and every
+ * Lisa-driven agent runs in a worktree, so that is the routine path.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(runCli(process.argv.slice(2)));
 }

--- a/plugins/lisa-cursor/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa-cursor/scripts/plugin-sync-explain.mjs
@@ -19,6 +19,8 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const PLUGIN_SYNC_CLASSIFICATIONS = [
   "SOURCE_NOT_BUILT",
@@ -556,7 +558,41 @@ function linkedWorktreeGitDir(root) {
   return path.isAbsolute(gitDir) ? gitDir : path.resolve(root, gitDir);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     const report = explainPluginSync(process.argv[2] ?? process.cwd());
     process.stdout.write(report.text);

--- a/plugins/lisa/scripts/automation-run-record.mjs
+++ b/plugins/lisa/scripts/automation-run-record.mjs
@@ -8,6 +8,8 @@
 
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
@@ -396,7 +398,41 @@ export async function runAutomationRunRecordCli(argv) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   runAutomationRunRecordCli(process.argv.slice(2)).then(
     code => {
       process.exitCode = code;

--- a/plugins/lisa/scripts/cross-pollinate.mjs
+++ b/plugins/lisa/scripts/cross-pollinate.mjs
@@ -37,6 +37,8 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
 const LOCK_VERSION = 1;
@@ -704,7 +706,41 @@ export function renderReport(p, result) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const args = process.argv.slice(2);
   const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
   const dryRun = args.includes("--dry-run") || !args.includes("--write");

--- a/plugins/lisa/scripts/design-source-gate.mjs
+++ b/plugins/lisa/scripts/design-source-gate.mjs
@@ -35,7 +35,8 @@
  * Exit 0 = PASS, 1 = FAIL (any violation, or anything unresolvable), 2 = usage.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /** The one designated marker for UI deliberately not captured in Figma. */
 export const DESIGN_SOURCE_NONE_MARKER = "DESIGN-SOURCE: none — not in Figma";
@@ -534,6 +535,36 @@ export function runCli(argv) {
   return result.verdict === "PASS" ? 0 : 1;
 }
 
-if (process.argv[1]?.endsWith("design-source-gate.mjs")) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The previous spelling tested whether `process.argv[1]` ENDED WITH this
+ * module's basename, which is looser still than the `file://` comparison the
+ * sibling modules used: any path ending in `design-source-gate.mjs` satisfied
+ * it, including a different copy of this file in another checkout, and a
+ * rename silently turned the guard off with nothing to notice.
+ *
+ * Both sides are realpath'd instead. Reached through a symlinked checkout, a
+ * git worktree, or a `/tmp` path on macOS the naive comparisons disagree, the
+ * body never runs, and the process exits 0 having done nothing — and every
+ * Lisa-driven agent runs in a worktree, so that is the routine path.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(runCli(process.argv.slice(2)));
 }

--- a/plugins/lisa/scripts/plugin-sync-explain.mjs
+++ b/plugins/lisa/scripts/plugin-sync-explain.mjs
@@ -19,6 +19,8 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const PLUGIN_SYNC_CLASSIFICATIONS = [
   "SOURCE_NOT_BUILT",
@@ -556,7 +558,41 @@ function linkedWorktreeGitDir(root) {
   return path.isAbsolute(gitDir) ? gitDir : path.resolve(root, gitDir);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     const report = explainPluginSync(process.argv[2] ?? process.cwd());
     process.stdout.write(report.text);

--- a/plugins/src/base/scripts/automation-run-record.mjs
+++ b/plugins/src/base/scripts/automation-run-record.mjs
@@ -8,6 +8,8 @@
 
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
@@ -396,7 +398,41 @@ export async function runAutomationRunRecordCli(argv) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   runAutomationRunRecordCli(process.argv.slice(2)).then(
     code => {
       process.exitCode = code;

--- a/plugins/src/base/scripts/cross-pollinate.mjs
+++ b/plugins/src/base/scripts/cross-pollinate.mjs
@@ -37,6 +37,8 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 const LOCKFILE_REL = path.join(".lisa", "cross-pollination.lock.json");
 const LOCK_VERSION = 1;
@@ -704,7 +706,41 @@ export function renderReport(p, result) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const args = process.argv.slice(2);
   const root = path.resolve(args.find(a => !a.startsWith("-")) ?? ".");
   const dryRun = args.includes("--dry-run") || !args.includes("--write");

--- a/plugins/src/base/scripts/design-source-gate.mjs
+++ b/plugins/src/base/scripts/design-source-gate.mjs
@@ -35,7 +35,8 @@
  * Exit 0 = PASS, 1 = FAIL (any violation, or anything unresolvable), 2 = usage.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 /** The one designated marker for UI deliberately not captured in Figma. */
 export const DESIGN_SOURCE_NONE_MARKER = "DESIGN-SOURCE: none — not in Figma";
@@ -534,6 +535,36 @@ export function runCli(argv) {
   return result.verdict === "PASS" ? 0 : 1;
 }
 
-if (process.argv[1]?.endsWith("design-source-gate.mjs")) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * The previous spelling tested whether `process.argv[1]` ENDED WITH this
+ * module's basename, which is looser still than the `file://` comparison the
+ * sibling modules used: any path ending in `design-source-gate.mjs` satisfied
+ * it, including a different copy of this file in another checkout, and a
+ * rename silently turned the guard off with nothing to notice.
+ *
+ * Both sides are realpath'd instead. Reached through a symlinked checkout, a
+ * git worktree, or a `/tmp` path on macOS the naive comparisons disagree, the
+ * body never runs, and the process exits 0 having done nothing — and every
+ * Lisa-driven agent runs in a worktree, so that is the routine path.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   process.exit(runCli(process.argv.slice(2)));
 }

--- a/plugins/src/base/scripts/plugin-sync-explain.mjs
+++ b/plugins/src/base/scripts/plugin-sync-explain.mjs
@@ -19,6 +19,8 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 export const PLUGIN_SYNC_CLASSIFICATIONS = [
   "SOURCE_NOT_BUILT",
@@ -556,7 +558,41 @@ function linkedWorktreeGitDir(root) {
   return path.isAbsolute(gitDir) ? gitDir : path.resolve(root, gitDir);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd. The previous spelling compared `import.meta.url`
+ * against a `file://` string built from `process.argv[1]`, which pits a real
+ * path against whatever the caller typed — so reached through a symlinked
+ * checkout, a git worktree, or a `/tmp` path on macOS the two disagreed, the
+ * body never ran, and the process exited 0 having done nothing. Every
+ * Lisa-driven agent runs in a worktree, so that is the routine path, not an
+ * exotic one.
+ *
+ * Written out rather than imported: this ships inside a plugin payload, which
+ * has no `./lib/` to resolve against. Same rule and same reasoning as
+ * `scripts/lib/invoked-as-script.mjs`.
+ *
+ * Realpathing BOTH sides matters under `--preserve-symlinks-main`, which tells
+ * node not to resolve the main entry: normalizing only `argv[1]` then compares
+ * a real path against a symlinked one and answers false for an entry point that
+ * WAS invoked directly. Any resolution error returns false — node loaded the
+ * entry from that path moments earlier, so a path that will not resolve now is
+ * not the path this module came through.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     const report = explainPluginSync(process.argv[2] ?? process.cwd());
     process.stdout.write(report.text);

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -919,7 +919,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/work-item-definition-of-ready.md":
       "ebcfe89f5a33a8008c4a54c1c2f4a092952df3263adc8f537a4c0b6ad8dbe18d",
     "plugins/src/base/scripts/automation-run-record.mjs":
-      "a499794a20f82a1e311ef4cb5188dd890f25b970e19e788d6945f2d5898dc9d2",
+      "77ea269502b97300c400916ee851dc85082a9237ce3d4468688455084d96413a",
     "plugins/src/base/scripts/automation-status-claude-adapter.mjs":
       "b1054acf4a5cbbe5354bd62a22b96533bcbc69b6cb9245976ceb8af638a04494",
     "plugins/src/base/scripts/automation-status-codex-adapter.mjs":
@@ -933,9 +933,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/automation-status-run-history.mjs":
       "a07f0d1af412f0d2747a9cbe82fa0edbeb8cc8dd4bdf4c51526e779090f08208",
     "plugins/src/base/scripts/cross-pollinate.mjs":
-      "e9a536389d2581370f6c470b8a070aaae96660646efc528a7ff7fb25d324a903",
+      "08b17213a484e4c873283e2af674df579593c7ff20c95a06d71ae88c0b83f937",
     "plugins/src/base/scripts/design-source-gate.mjs":
-      "4db12844df14cc5dbcbdb96df9273cdce08057bc839493649fa65fccf559953b",
+      "5eadc5184a8c22d1d35c8be1bf4589aeedff0d1aa578563e4d33cdb193dbc5af",
     "plugins/src/base/scripts/doctor-report.mjs":
       "f183e62848ac539da56a525fe2105fc6251a49e555a01dd1bba10d9227b1a6bf",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
@@ -943,7 +943,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/scripts/lifecycle-label-trust.mjs":
       "0a9892890da6011733bf9b1186fbe936253c2796c4ac448f1a55f63b8daaa154",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":
-      "8592c7359ee6cdb35995a882c8bb27e7b9c404074067fd272c70013e44e04b71",
+      "5c8857d28e6b2e9d59b13c983dfbccc3e3fe5573ce6221bd9d7eb9b95629f4ab",
     "plugins/src/base/scripts/project-ideation-idempotency-harness.mjs":
       "81b6eb911cf5cf6d1913cacf65b6ae298732e0a4e92529aed6767cdf79ab2ec0",
     "plugins/src/base/scripts/queue-contract-resolution.mjs":
@@ -9064,6 +9064,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/per-agent-hook-filter.test.ts": true,
     "tests/unit/scripts/plugin-parity-drift-helpers.ts": true,
     "tests/unit/scripts/plugin-parity-drift.test.ts": true,
+    "tests/unit/scripts/plugin-payload-entry-guards.test.ts": true,
     "tests/unit/scripts/plugin-routing-validate-cache-visibility.test.ts": true,
     "tests/unit/scripts/plugin-routing-validate-helpers.ts": true,
     "tests/unit/scripts/plugin-routing-validate.test.ts": true,

--- a/tests/unit/scripts/invoked-as-script.test.ts
+++ b/tests/unit/scripts/invoked-as-script.test.ts
@@ -45,6 +45,15 @@ const SHIPPED_SCRIPT_DIRS = [
   "all/copy-overwrite/scripts",
   "typescript/copy-overwrite/scripts",
   "expo/copy-overwrite/scripts",
+  // Added after measuring that this lane had never been swept: four of its
+  // eighteen modules carried a defective guard and NONE carried a correct one.
+  // That it was uniformly wrong rather than mixed is the tell — no rule had
+  // ever applied here. These ship inside a plugin payload, which has no
+  // `./lib/` to import the shared helper from, so they define the rule inline
+  // and satisfy the sweep through the same exemption `preflight-secrets.mjs`
+  // uses: the file that DEFINES the rule is excused, by reason rather than by
+  // name.
+  "plugins/src/base/scripts",
 ] as const;
 
 /**
@@ -279,7 +288,14 @@ describe("shared entry guard wiring", () => {
     const swept = subjects.length;
     // A rename or a moved tree would empty the sweep and let it pass by
     // testing nothing, which is the failure mode this whole file exists for.
-    expect(swept).toBeGreaterThan(10);
+    //
+    // Raised from 10 when `plugins/src/base/scripts` joined the lane list: 42
+    // modules are swept today, so a floor of 10 would have survived losing
+    // three quarters of them. The floor tracks the real count with enough slack
+    // for ordinary churn, and is deliberately not `=== 42`, which would turn
+    // every added script into a failing test that teaches people to edit the
+    // number without reading why it is there.
+    expect(swept).toBeGreaterThan(35);
     expect(offenders).toEqual([]);
   });
 

--- a/tests/unit/scripts/plugin-payload-entry-guards.test.ts
+++ b/tests/unit/scripts/plugin-payload-entry-guards.test.ts
@@ -18,9 +18,10 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -128,12 +129,15 @@ describe("design-source-gate's guard was loose, not silent", () => {
   // merely ENDED WITH its own basename, so it kept running through a symlink —
   // the failure is over-matching, and the symlink cases above cannot see it.
   const own = path.resolve(LANE, DESIGN_GATE);
-  const ownUrl = `file://${own}`;
+  const ownUrl = pathToFileURL(own).href;
 
   it("refuses a different file that happens to share the basename", () => {
     // The old spelling accepted this: another checkout, a vendored copy, or any
     // path ending in `design-source-gate.mjs` ran this module's body.
-    const decoy = path.join(tmpdir(), "elsewhere", DESIGN_GATE);
+    const root = mkdtempSync(path.join(tmpdir(), "lisa-payload-decoy-"));
+    temps.push(root);
+    const decoy = path.join(root, DESIGN_GATE);
+    writeFileSync(decoy, "export {};\n");
     expect(invokedAsScript(ownUrl, decoy)).toBe(false);
   });
 

--- a/tests/unit/scripts/plugin-payload-entry-guards.test.ts
+++ b/tests/unit/scripts/plugin-payload-entry-guards.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Proof that plugin-payload CLIs run when reached through a symlink.
+ *
+ * `plugins/src/base/scripts/` had never been in the entry-guard sweep. Five of
+ * its modules carried a defective guard and none carried a correct one — the
+ * uniformity being the tell that no rule had ever applied there.
+ *
+ * These cannot import `scripts/lib/invoked-as-script.mjs`, because a plugin
+ * payload has no `./lib/` to resolve against, so each defines the rule inline.
+ * The sweep in `invoked-as-script.test.ts` now asserts that every module here
+ * either routes through the helper or defines it; this file asserts the copies
+ * actually WORK, which the sweep cannot see.
+ *
+ * Every assertion is on OUTPUT. A guard that no-ops prints nothing and exits 0,
+ * which is indistinguishable from a clean run by exit status alone — and these
+ * are exactly the modules whose silence is mistaken for success.
+ * @module tests/unit/scripts/plugin-payload-entry-guards
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { invokedAsScript } from "../../../plugins/src/base/scripts/design-source-gate.mjs";
+
+const LANE = "plugins/src/base/scripts";
+const DESIGN_GATE = "design-source-gate.mjs";
+
+/**
+ * Each guarded CLI, with text only its body can produce.
+ *
+ * Matched against a marker rather than merely "some output", because a module
+ * that failed to import also writes to stderr — so an emptiness check would
+ * pass for a module that never reached its guard at all.
+ */
+const ENTRY_POINTS = [
+  { script: "automation-run-record.mjs", marker: "Usage:" },
+  { script: "cross-pollinate.mjs", marker: "harness" },
+  { script: DESIGN_GATE, marker: "usage:" },
+  { script: "plugin-sync-explain.mjs", marker: "plugin-sync-explain" },
+] as const;
+
+let temps: string[] = [];
+
+afterEach(() => {
+  for (const dir of temps) rmSync(dir, { force: true, recursive: true });
+  temps = [];
+});
+
+/**
+ * A symlink pointing at the lane directory, removed after the test.
+ * @returns Path to the link
+ */
+function linkedLane(): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-payload-link-"));
+  const link = path.join(root, "scripts");
+  temps.push(root);
+  symlinkSync(path.resolve(LANE), link);
+  return link;
+}
+
+/**
+ * Everything a run wrote, on either stream.
+ * @param result - A completed process
+ * @returns stdout concatenated with stderr
+ */
+function output(result: ReturnType<typeof spawnSync>): string {
+  return `${result.stdout}${result.stderr}`;
+}
+
+/**
+ * Run one lane module through a symlink to its containing directory.
+ *
+ * The DIRECTORY is linked, not the file: linking a file out of its directory
+ * fails under `--preserve-symlinks-main` with ERR_MODULE_NOT_FOUND because its
+ * sibling imports resolve beside the link, which is a property of the fixture
+ * rather than of the guard.
+ * @param script - Filename within the lane
+ * @param flags - Extra node flags placed ahead of the entry path
+ * @returns Combined stdout and stderr
+ */
+function throughSymlink(script: string, flags: readonly string[] = []): string {
+  const entry = path.join(linkedLane(), script);
+  return output(
+    spawnSync(process.execPath, [...flags, entry, "--help"], {
+      encoding: "utf8",
+    })
+  );
+}
+
+describe("plugin-payload CLIs reached through a symlink", () => {
+  it.each(ENTRY_POINTS)("runs its body: $script", ({ script, marker }) => {
+    expect(throughSymlink(script)).toContain(marker);
+  });
+
+  it.each(ENTRY_POINTS)(
+    "runs its body under --preserve-symlinks-main: $script",
+    ({ script, marker }) => {
+      // Both sides stay symlinked under this flag, so a fix that normalized
+      // only `argv[1]` would reintroduce the no-op precisely here.
+      expect(throughSymlink(script, ["--preserve-symlinks-main"])).toContain(
+        marker
+      );
+    }
+  );
+
+  it.each(ENTRY_POINTS)(
+    "still runs when invoked directly: $script",
+    ({ script, marker }) => {
+      // A control: the fix must not trade one no-op for another.
+      expect(
+        output(
+          spawnSync(process.execPath, [path.resolve(LANE, script), "--help"], {
+            encoding: "utf8",
+          })
+        )
+      ).toContain(marker);
+    }
+  );
+});
+
+describe("design-source-gate's guard was loose, not silent", () => {
+  // The other three modules compared `import.meta.url` against a `file://`
+  // string and NO-OPPED through a symlink. This one tested whether argv[1]
+  // merely ENDED WITH its own basename, so it kept running through a symlink —
+  // the failure is over-matching, and the symlink cases above cannot see it.
+  const own = path.resolve(LANE, DESIGN_GATE);
+  const ownUrl = `file://${own}`;
+
+  it("refuses a different file that happens to share the basename", () => {
+    // The old spelling accepted this: another checkout, a vendored copy, or any
+    // path ending in `design-source-gate.mjs` ran this module's body.
+    const decoy = path.join(tmpdir(), "elsewhere", DESIGN_GATE);
+    expect(invokedAsScript(ownUrl, decoy)).toBe(false);
+  });
+
+  it("still accepts its own file", () => {
+    expect(invokedAsScript(ownUrl, own)).toBe(true);
+  });
+
+  it("survives a rename, which the basename test would not", () => {
+    // The old guard named its own filename in a string literal, so renaming the
+    // file turned the guard off with nothing to notice. The rule now derives
+    // both sides from the running module.
+    expect(
+      invokedAsScript(ownUrl, path.resolve(LANE, "cross-pollinate.mjs"))
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2597. The entry-guard sweep now covers `plugins/src/base/scripts/`, and the modules it found are fixed.

## What was uncovered

`SHIPPED_SCRIPT_DIRS` named three `copy-overwrite` lanes and never the plugin payload, so the sweep that guarantees no shipped `.mjs` carries a hand-rolled entry guard had never looked at these 18 modules.

```
carrying a defective guard:  5
carrying the correct guard:  0
```

Zero correct guards rather than a mix is the tell — no rule had ever applied there, as opposed to one having slipped.

## Two different failures

**Four no-opped.** They compared `import.meta.url` against a `file://` string built from `process.argv[1]` — a real path against whatever the caller typed. Through a symlinked checkout, a git worktree, or a `/tmp` path on macOS the two disagree, the body never runs, and the process exits 0 having done nothing. Every Lisa-driven agent runs in a worktree, so that is the routine path rather than an exotic one.

**`design-source-gate.mjs` over-matched instead.** It tested whether `argv[1]` merely ENDED WITH its own basename, so it kept running through a symlink — but accepted *any* path ending in `design-source-gate.mjs`, including a different copy in another checkout, and a rename would have silently turned the guard off. Its regression asserts the over-match directly, because the symlink cases cannot see it.

## The sweep earned its place immediately

**The fifth module was found by the widened sweep, not by me.** Its pattern covers `argv[1]?.endsWith(` with optional chaining; the grep I scoped #2597 with did not. So "four of eighteen" in that issue was an undercount, corrected here.

## Why they define the rule instead of importing it

A plugin payload has no `./lib/` to resolve `scripts/lib/invoked-as-script.mjs` against. Each writes the rule out inline — the accommodation `preflight-secrets.mjs` already makes — and satisfies the sweep through the exemption that excuses a file for **defining** the rule, by reason rather than by name.

## The floor

`swept > 10` is raised to `> 35` against a real count of 42. A floor of 10 would have survived losing three quarters of the corpus, which defeats the point of having one. Deliberately not an equality: that would turn every added script into a failing test and teach people to edit the number without reading why it is there.

## Verification

Assertions are on **output**, never exit status — a guard that no-ops prints nothing and exits 0, indistinguishable from a clean run.

- 3 of the 4 no-op cases fail with the old guards restored
- `design-source-gate` correctly does *not* fail those, which is why it has its own over-match assertions
- controls: each module must still run when invoked directly, and must still refuse a different module

Full suite: 704 files, 12513 tests passing. Push gates: 8 proved, 0 failed. `typecheck` clean.

Work-Item: CodySwannGT/lisa#2597

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command-line script detection for symlinked paths, alternate path spellings, worktrees, and preserved symlink execution.
  * Prevented scripts from running when invocation paths are missing, invalid, or point to similarly named decoy files.

* **Tests**
  * Added coverage for direct invocation, symlink scenarios, preserved symlinks, and same-name decoy scripts.
  * Expanded validation across the shipped script set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->