### PR TITLE
fix(intake): stop the review bot writing lifecycle labels

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -57,3 +57,66 @@ issue_enrichment:
     enabled: true
   labeling:
     auto_apply_labels: true
+    # `labeling_instructions` is an ALLOWLIST: when it is present CodeRabbit
+    # suggests only from this list. That is the whole point of it being here —
+    # the classification labels below are genuinely useful, and the lifecycle
+    # family (`status:*`) is the one that must never be written by a bot.
+    #
+    # Measured five times on 2026-08-15, the fastest at EIGHT SECONDS, and once
+    # over an explicit `status:in-progress` a human had applied moments earlier.
+    # `status:done` is a TERMINAL role: the work-item gate refuses to bind or
+    # validate against a terminal item, so each of those issues blocked its own
+    # pull request until somebody noticed and stripped the label by hand.
+    #
+    # The reason it cannot be fixed with a faster/slower threshold is that the
+    # label comes from a classifier with no view of whether work happened. It is
+    # not a near-miss on an issue eight seconds old; it is the opposite of true.
+    #
+    # `human-needed` is deliberately absent too. Whether a human must rule on
+    # something is a human's call, and Lisa applies it itself through the
+    # `[lisa-human-gate]` marker at filing time.
+    labeling_instructions:
+      - label: 'type:Bug'
+        instructions: 'Apply when the issue reports incorrect behaviour in shipped code.'
+      - label: 'type:Task'
+        instructions: 'Apply to a single unit of work that is not a defect and not a user-facing story.'
+      - label: 'type:Story'
+        instructions: 'Apply when the issue describes user-facing behaviour to build.'
+      - label: 'type:Improvement'
+        instructions: 'Apply when the issue refines something that already works.'
+      - label: 'type:Epic'
+        instructions: 'Apply when the issue is a parent tracking several child items.'
+      - label: 'type:Sub-task'
+        instructions: 'Apply when the issue is a child of a larger tracked item.'
+      - label: 'points:1'
+        instructions: 'Apply for a trivial change, roughly one file and no new tests.'
+      - label: 'points:2'
+        instructions: 'Apply for a small change confined to one module.'
+      - label: 'points:3'
+        instructions: 'Apply for a change spanning a few modules with new tests.'
+      - label: 'points:5'
+        instructions: 'Apply for a change spanning several subsystems or needing design.'
+      - label: 'points:8'
+        instructions: 'Apply for a large change that should probably be split.'
+      - label: 'component:ci'
+        instructions: 'Apply when the issue concerns GitHub Actions workflows or CI configuration.'
+      - label: 'component:cli'
+        instructions: 'Apply when the issue concerns the Lisa command-line surface under src/cli.'
+      - label: 'component:docs'
+        instructions: 'Apply when the issue concerns documentation outside the wiki.'
+      - label: 'component:doctor'
+        instructions: 'Apply when the issue concerns lisa doctor or its checks.'
+      - label: 'component:plugins'
+        instructions: 'Apply when the issue concerns plugins/, agent plugins, hooks, or their generated variants.'
+      - label: 'component:skills'
+        instructions: 'Apply when the issue concerns skills or commands.'
+      - label: 'component:tests'
+        instructions: 'Apply when the issue concerns the test suites or their harnesses.'
+      - label: 'component:wiki'
+        instructions: 'Apply when the issue concerns wiki/ content.'
+      - label: 'component:wiki-cli'
+        instructions: 'Apply when the issue concerns the wiki command-line surface.'
+      - label: 'repo:lisa'
+        instructions: 'Apply to every issue filed in this repository.'
+      - label: 'self-hardening'
+        instructions: "Apply when the issue fixes a defect in Lisa's own guards, gates, or enforcement."

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8822,6 +8822,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/codex/source-authored-openai-yaml.test.ts": true,
     "tests/unit/config/ast-grep-rule-tests.test.ts": true,
     "tests/unit/config/ast-grep-template.test.ts": true,
+    "tests/unit/config/coderabbit-labeling-scope.test.ts": true,
     "tests/unit/config/eslint-ignore-wiki.test.ts": true,
     "tests/unit/config/eslint-no-unused-vars.test.ts": true,
     "tests/unit/config/eslint-plugin-phaser.test.ts": true,

--- a/tests/unit/config/coderabbit-labeling-scope.test.ts
+++ b/tests/unit/config/coderabbit-labeling-scope.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The review bot may enrich issues, but never write lifecycle state.
+ *
+ * `coderabbitai[bot]` stamped `status:done` on brand-new issues five times on
+ * 2026-08-15, the fastest at eight seconds, and once directly over an explicit
+ * `status:in-progress` a human had applied moments earlier. `status:done` is a
+ * TERMINAL role: the work-item gate refuses to bind or validate against a
+ * terminal item, so each of those issues blocked its own pull request until
+ * somebody stripped the label by hand.
+ *
+ * The fix is an allowlist rather than a timing threshold, because there is no
+ * safe threshold to pick — the label comes from a classifier with no view of
+ * whether work happened, so the eight-second case is not a near-miss on a true
+ * statement, it is the opposite of one.
+ *
+ * This test is the guard on the fix. The allowlist is prose in a YAML file that
+ * nothing else reads, so without an assertion the entry that reintroduces the
+ * defect is a one-line diff nobody would question.
+ * @module tests/unit/config/coderabbit-labeling-scope
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+const LIFECYCLE_PREFIX = "status:";
+/** Roles a bot must never decide, beyond the lifecycle family itself. */
+const HUMAN_ONLY_LABELS = ["human-needed"];
+
+const config = parse(readFileSync(path.resolve(".coderabbit.yml"), "utf8")) as {
+  issue_enrichment?: {
+    labeling?: {
+      auto_apply_labels?: boolean;
+      labeling_instructions?: { label?: string; instructions?: string }[];
+    };
+  };
+};
+
+const labeling = config.issue_enrichment?.labeling;
+const instructions = labeling?.labeling_instructions ?? [];
+const allowed = instructions.map(entry => entry.label ?? "");
+
+describe("CodeRabbit issue labeling", () => {
+  it("constrains auto-applied labels to an explicit allowlist", () => {
+    // The allowlist is what makes every assertion below meaningful. With
+    // `auto_apply_labels` on and no instructions, the bot may apply anything,
+    // and a test asserting "no status: in the list" would pass against an
+    // empty list while the defect ran unchanged.
+    expect(labeling?.auto_apply_labels).toBe(true);
+    expect(allowed.length).toBeGreaterThan(0);
+  });
+
+  it("allowlists no lifecycle label", () => {
+    expect(allowed.filter(label => label.startsWith(LIFECYCLE_PREFIX))).toEqual(
+      []
+    );
+  });
+
+  it("allowlists no label that is a human's judgment to make", () => {
+    for (const label of HUMAN_ONLY_LABELS) {
+      expect(allowed, label).not.toContain(label);
+    }
+  });
+
+  it("keeps the enrichment that is actually useful", () => {
+    // The blunt fix — turning auto-labelling off — would also lose these, and
+    // they are the reason the feature is on at all. Asserting they survive
+    // stops a future "just disable it" from looking like a clean fix.
+    for (const prefix of ["type:", "points:", "component:", "repo:"]) {
+      expect(
+        allowed.some(label => label.startsWith(prefix)),
+        prefix
+      ).toBe(true);
+    }
+  });
+
+  it("gives every allowlisted label an instruction", () => {
+    // An entry with no instruction tells the classifier nothing about when the
+    // label applies, so it becomes a label applied on vibes — a smaller version
+    // of the defect this file exists to prevent.
+    const silent = instructions.filter(
+      entry => (entry.instructions ?? "").trim().length === 0
+    );
+    expect(silent.map(entry => entry.label)).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2589. The review bot may enrich issues; it may no longer write lifecycle state.

## Measured five times today

| issue | interval | note |
|---|---|---|
| #2579 | ~58s | |
| #2587 | 58s | |
| #2592 | **8s** | applied *over* a human's `status:in-progress` from 8 seconds earlier |
| #2589 | — | the issue tracking this defect was itself stamped `status:done` |
| #2594 | seconds | blocked the work-item bind on an umbrella issue |

`status:done` is a **terminal** role. The work-item gate refuses to bind or validate against a terminal item, so each of these blocked its own pull request until somebody stripped the label by hand.

## Why not a timing threshold

The 8-second case rules it out, and not because 8 is small. The label comes from a classifier with **no view of whether work happened**, so a fast `status:done` is not a near-miss on a true statement — it is the opposite of one, and a slower one would be equally wrong. There is no interval that makes the answer correct.

The same case also rules out "it is filling a vacuum": an explicit `status:in-progress` was already on the issue. Whatever writes these labels is not reading the existing lifecycle state at all.

## The fix keeps what is useful

`issue_enrichment.labeling.labeling_instructions` is an **allowlist** — when present, CodeRabbit suggests only from the listed labels. So the lifecycle family is excluded *structurally* rather than by asking a classifier to show restraint, and the enrichment worth having survives:

- `type:` × 6, `points:` × 5, `component:` × 9, `repo:lisa`, `self-hardening`

Setting `auto_apply_labels: false` would also have worked, and would have thrown all of that away.

`human-needed` is excluded on the same principle: whether a human must rule on something is a human's call, and Lisa applies it itself through the `[lisa-human-gate]` marker at filing time.

Every allowlisted label was checked to exist in the repo, and every entry carries an instruction — an entry without one tells the classifier nothing about when the label applies, which is a smaller version of the same defect.

## The test, and why it exists

The allowlist is prose in a YAML file that nothing else reads. Without an assertion, the entry that reintroduces the defect is a one-line diff nobody would question.

It bites in **both** directions, proven:

- adding `status:done` back to the allowlist → *"allowlists no lifecycle label"* fails
- deleting the allowlist entirely → *"constrains auto-applied labels to an explicit allowlist"* and *"keeps the enrichment that is actually useful"* both fail

That second direction matters: "just turn labelling off" looks like a clean fix and quietly costs the enrichment, so the test refuses it too.

## What is not proven here

The schema documents `labeling_instructions` as an implicit allowlist; this PR takes that at its word. The live confirmation is the bite control from the issue — file an issue, wait 90 seconds, assert no `status:*` label — which I will run once this merges and report on #2589. If the allowlist turns out not to constrain, the fallback is `auto_apply_labels: false` and the loss of enrichment.

## Verification

- Full suite: 704 files, 12513 tests passing
- Push gates: 8 proved, 0 failed
- YAML parses; 22 allowlist entries; no `status:` prefix; no `human-needed`; all labels exist in the repo

Work-Item: CodySwannGT/lisa#2589

🤖 Generated with Claude Code
