### PR TITLE
feat(health): add the scheduled drift consumer

### DIFF
--- a/plugins/lisa-agy/commands/lisa/health-drift-cron.md
+++ b/plugins/lisa-agy/commands/lisa/health-drift-cron.md
@@ -1,0 +1,9 @@
+---
+description: "Run the scheduled health consumer: check health headless, and file one deduped ticket per drifting check."
+argument-hint: "[project-path]"
+---
+
+Use the /lisa-health-drift-cron skill to run Lisa Health for the optional project path and turn any
+drift into tracked work. File exactly one ticket per drifting check through `lisa-tracker-write`,
+deduped by the per-check marker across OPEN tickets only, and file nothing for a project in band.
+This flow files; it never closes, edits, or repairs. $ARGUMENTS

--- a/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
@@ -63,6 +63,16 @@ The distinction between the two `no-change` shapes matters. "Nothing filed" and 
 
 ## Registration
 
-Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Torn down with the rest of the `lisa-auto-<project>-*` set.
 
-Torn down with the rest of the `lisa-auto-<project>-*` set.
+Register at most **one** per project.
+
+### What the dedupe does and does not guarantee
+
+It guarantees **convergence, not mutual exclusion**, and the difference is worth stating plainly rather than leaving to be discovered.
+
+Two runs that overlap — a manual invocation alongside the scheduled one, or a run still going when the next fires — can both read an empty open-ticket set and both file for the same check. A single registration makes that rare; it does not make it impossible, and no amount of care in this document would.
+
+What the design does guarantee is that it stops there. The next run sees both open tickets carrying the marker, matches, and files nothing further, so duplicates do not compound. The transient duplicate persists until a human closes one, and closing it is safe: if the drift is still live, the remaining ticket still tracks it.
+
+This is the same stance `lisa-learnings-audit` takes for the same reason, and the same advice applies — **a manual run should first confirm the cron is not due or running.** A project-scoped lease would buy true exclusion at the cost of a lock to acquire, hold, and expire correctly on a path that only runs daily; the failure it prevents is cosmetic and self-limiting, and the failure a stuck lease causes is a health check that silently stops running.

--- a/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: lisa-health-drift-cron
+description: "Scheduled health consumer. Runs Lisa Health headless, and for each check that has drifted files exactly one tracker ticket through lisa-tracker-write, deduped by a per-check marker across OPEN tickets only. Files nothing for a project in band. Use for the lisa-auto-<project>-health-drift automation registered when health.schedule is set."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Lisa Health Drift Cron: $ARGUMENTS
+
+Consumer #3 of the health layer: the cron. A health check you have to remember to run is a health check that goes stale, so this one runs on a schedule and turns drift into **tracked work** rather than silent decay.
+
+It **files**. It never closes, edits, or repairs. Disposal belongs to humans and the Implement factory.
+
+## Why idempotency is the whole job
+
+A nightly cron that refiles the same drift every night is worse than no cron at all, because it teaches everyone to ignore the tickets it files. Every rule below exists to make *"the same drift"* a decidable question, and the decision is not made in this prose — it is made by `planDriftTickets` in `src/health/drift-tickets.ts`, which is unit-tested against each of these cases.
+
+**Do not reimplement the dedupe here.** Call the planner and act on its answer. A second implementation in prose is a second implementation to drift.
+
+## Phase 1 — Run the health check headless
+
+```bash
+lisa health --json
+```
+
+Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+
+If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
+
+## Phase 2 — Read the OPEN tickets only
+
+Fetch the tracker's **open** items carrying the drift marker prefix `lisa-health-drift`.
+
+**Open only, and this is load-bearing.** A closed ticket must not suppress live drift: if it did, closing a ticket without fixing anything would make that drift invisible forever, which is exactly the silent decay this consumer exists to prevent. Suppression should be a configured declaration visible in a diff — turn the check off in config — not a side effect of somebody tidying a backlog.
+
+The planner enforces this by construction: it accepts an `openTickets` list and has no notion of a closed one. Passing closed tickets defeats the design, and the parameter is named to say so.
+
+## Phase 3 — Plan
+
+Feed the findings and the open tickets to `planDriftTickets`. It returns:
+
+- `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
+- `alreadyTracked` — drift that an open ticket already covers, with the ticket id
+
+Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+
+Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
+
+## Phase 4 — File
+
+For each entry in `file`, invoke **`/lisa-tracker-write`** with its title and body. **Never call a vendor writer (`lisa-github-write-issue` / `lisa-jira-write-ticket` / `lisa-linear-write-issue`) directly** — routing through the shim is what makes the tracker switchable per project.
+
+The body already contains the marker. Do not strip it, and do not add a second one: the next run finds the ticket by that exact string.
+
+## Run outcome
+
+Per the automation runbook contract, end with exactly one outcome and a one-line operator-readable summary:
+
+- **no-change** — the project is in band, or every drifting check is already tracked. Say which: `no-change — in band, nothing filed.` versus `no-change — 2 drifting checks, both already tracked (#41, #42).`
+- **change-proved** — tickets were filed. `change-proved — filed 1 drift ticket: coverage-floor (#57).`
+- **recovery-required** — the health run failed, or a write failed. Name what a human must do.
+
+The distinction between the two `no-change` shapes matters. "Nothing filed" and "nothing wrong" are different facts, and collapsing them hides a project whose drift is real and simply already on somebody's list.
+
+## Registration
+
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+
+Torn down with the rest of the `lisa-auto-<project>-*` set.

--- a/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
@@ -18,11 +18,11 @@ A nightly cron that refiles the same drift every night is worse than no cron at 
 
 ## Phase 1 — Run the health check headless
 
-```bash
-lisa health --json
-```
+Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directly and do not invent flags for it: `lisa health` takes `[path]`, `--prepare-agentic`, and `--agentic-evaluation`, and nothing else. There is no `--json` — the persisted result IS the command's stdout, and an unknown option makes commander exit non-zero, so a guessed flag turns the first phase of a scheduled run into a failure nobody is watching.
 
-Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
+
+Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 

--- a/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
@@ -43,6 +43,8 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 
 Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
+The collapse is not tidiness. The marker cannot tell two findings for one check apart, so filing both would self-duplicate on the very FIRST run — before any second run exists to blame. `file.length + alreadyTracked.length` therefore counts distinct drifting checks, which is fewer than the drifting findings whenever a run reports one check twice.
+
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 
 ## Phase 4 — File

--- a/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md
@@ -22,7 +22,7 @@ Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directl
 
 Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
 
-Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Do not reconstruct, merge, or summarize findings; the result is passed to Phase 3 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 
@@ -41,7 +41,7 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 - `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
 - `alreadyTracked` — drift that an open ticket already covers, with the ticket id
 
-Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 

--- a/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/SKILL.md
@@ -197,6 +197,16 @@ closed by the next run's dedupe or the human), not mutual exclusion; manual
 runs should first confirm the cron is not due or running. Tear-down removes
 it with the rest of the `lisa-auto-<project>-*` set.
 
+**Optional automation — the health cron.** When `health.schedule` in
+`.lisa.config.json` is `daily` or `weekly` (default **off**, which registers
+nothing), additionally create `lisa-auto-<project>-health-drift` running
+`/lisa:health-drift-cron` at that cadence. It runs Lisa Health headless and,
+for each check that has drifted, files exactly one ticket through
+`lisa-tracker-write`. A project in band files nothing. Register at most ONE per
+project: the per-check marker dedupe converges under a single scheduled runner,
+and two concurrent runs can both observe an empty open-ticket set and both
+file. Tear-down removes it with the rest of the `lisa-auto-<project>-*` set.
+
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The
 `exploratory-prds` automation uses the same PRD source queue and pressure roles reported by

--- a/plugins/lisa-copilot/commands/lisa/health-drift-cron.md
+++ b/plugins/lisa-copilot/commands/lisa/health-drift-cron.md
@@ -1,0 +1,9 @@
+---
+description: "Run the scheduled health consumer: check health headless, and file one deduped ticket per drifting check."
+argument-hint: "[project-path]"
+---
+
+Use the /lisa-health-drift-cron skill to run Lisa Health for the optional project path and turn any
+drift into tracked work. File exactly one ticket per drifting check through `lisa-tracker-write`,
+deduped by the per-check marker across OPEN tickets only, and file nothing for a project in band.
+This flow files; it never closes, edits, or repairs. $ARGUMENTS

--- a/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
@@ -63,6 +63,16 @@ The distinction between the two `no-change` shapes matters. "Nothing filed" and 
 
 ## Registration
 
-Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Torn down with the rest of the `lisa-auto-<project>-*` set.
 
-Torn down with the rest of the `lisa-auto-<project>-*` set.
+Register at most **one** per project.
+
+### What the dedupe does and does not guarantee
+
+It guarantees **convergence, not mutual exclusion**, and the difference is worth stating plainly rather than leaving to be discovered.
+
+Two runs that overlap — a manual invocation alongside the scheduled one, or a run still going when the next fires — can both read an empty open-ticket set and both file for the same check. A single registration makes that rare; it does not make it impossible, and no amount of care in this document would.
+
+What the design does guarantee is that it stops there. The next run sees both open tickets carrying the marker, matches, and files nothing further, so duplicates do not compound. The transient duplicate persists until a human closes one, and closing it is safe: if the drift is still live, the remaining ticket still tracks it.
+
+This is the same stance `lisa-learnings-audit` takes for the same reason, and the same advice applies — **a manual run should first confirm the cron is not due or running.** A project-scoped lease would buy true exclusion at the cost of a lock to acquire, hold, and expire correctly on a path that only runs daily; the failure it prevents is cosmetic and self-limiting, and the failure a stuck lease causes is a health check that silently stops running.

--- a/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: lisa-health-drift-cron
+description: "Scheduled health consumer. Runs Lisa Health headless, and for each check that has drifted files exactly one tracker ticket through lisa-tracker-write, deduped by a per-check marker across OPEN tickets only. Files nothing for a project in band. Use for the lisa-auto-<project>-health-drift automation registered when health.schedule is set."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Lisa Health Drift Cron: $ARGUMENTS
+
+Consumer #3 of the health layer: the cron. A health check you have to remember to run is a health check that goes stale, so this one runs on a schedule and turns drift into **tracked work** rather than silent decay.
+
+It **files**. It never closes, edits, or repairs. Disposal belongs to humans and the Implement factory.
+
+## Why idempotency is the whole job
+
+A nightly cron that refiles the same drift every night is worse than no cron at all, because it teaches everyone to ignore the tickets it files. Every rule below exists to make *"the same drift"* a decidable question, and the decision is not made in this prose — it is made by `planDriftTickets` in `src/health/drift-tickets.ts`, which is unit-tested against each of these cases.
+
+**Do not reimplement the dedupe here.** Call the planner and act on its answer. A second implementation in prose is a second implementation to drift.
+
+## Phase 1 — Run the health check headless
+
+```bash
+lisa health --json
+```
+
+Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+
+If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
+
+## Phase 2 — Read the OPEN tickets only
+
+Fetch the tracker's **open** items carrying the drift marker prefix `lisa-health-drift`.
+
+**Open only, and this is load-bearing.** A closed ticket must not suppress live drift: if it did, closing a ticket without fixing anything would make that drift invisible forever, which is exactly the silent decay this consumer exists to prevent. Suppression should be a configured declaration visible in a diff — turn the check off in config — not a side effect of somebody tidying a backlog.
+
+The planner enforces this by construction: it accepts an `openTickets` list and has no notion of a closed one. Passing closed tickets defeats the design, and the parameter is named to say so.
+
+## Phase 3 — Plan
+
+Feed the findings and the open tickets to `planDriftTickets`. It returns:
+
+- `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
+- `alreadyTracked` — drift that an open ticket already covers, with the ticket id
+
+Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+
+Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
+
+## Phase 4 — File
+
+For each entry in `file`, invoke **`/lisa-tracker-write`** with its title and body. **Never call a vendor writer (`lisa-github-write-issue` / `lisa-jira-write-ticket` / `lisa-linear-write-issue`) directly** — routing through the shim is what makes the tracker switchable per project.
+
+The body already contains the marker. Do not strip it, and do not add a second one: the next run finds the ticket by that exact string.
+
+## Run outcome
+
+Per the automation runbook contract, end with exactly one outcome and a one-line operator-readable summary:
+
+- **no-change** — the project is in band, or every drifting check is already tracked. Say which: `no-change — in band, nothing filed.` versus `no-change — 2 drifting checks, both already tracked (#41, #42).`
+- **change-proved** — tickets were filed. `change-proved — filed 1 drift ticket: coverage-floor (#57).`
+- **recovery-required** — the health run failed, or a write failed. Name what a human must do.
+
+The distinction between the two `no-change` shapes matters. "Nothing filed" and "nothing wrong" are different facts, and collapsing them hides a project whose drift is real and simply already on somebody's list.
+
+## Registration
+
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+
+Torn down with the rest of the `lisa-auto-<project>-*` set.

--- a/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
@@ -18,11 +18,11 @@ A nightly cron that refiles the same drift every night is worse than no cron at 
 
 ## Phase 1 — Run the health check headless
 
-```bash
-lisa health --json
-```
+Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directly and do not invent flags for it: `lisa health` takes `[path]`, `--prepare-agentic`, and `--agentic-evaluation`, and nothing else. There is no `--json` — the persisted result IS the command's stdout, and an unknown option makes commander exit non-zero, so a guessed flag turns the first phase of a scheduled run into a failure nobody is watching.
 
-Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
+
+Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 

--- a/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
@@ -43,6 +43,8 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 
 Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
+The collapse is not tidiness. The marker cannot tell two findings for one check apart, so filing both would self-duplicate on the very FIRST run — before any second run exists to blame. `file.length + alreadyTracked.length` therefore counts distinct drifting checks, which is fewer than the drifting findings whenever a run reports one check twice.
+
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 
 ## Phase 4 — File

--- a/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md
@@ -22,7 +22,7 @@ Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directl
 
 Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
 
-Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Do not reconstruct, merge, or summarize findings; the result is passed to Phase 3 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 
@@ -41,7 +41,7 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 - `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
 - `alreadyTracked` — drift that an open ticket already covers, with the ticket id
 
-Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/SKILL.md
@@ -197,6 +197,16 @@ closed by the next run's dedupe or the human), not mutual exclusion; manual
 runs should first confirm the cron is not due or running. Tear-down removes
 it with the rest of the `lisa-auto-<project>-*` set.
 
+**Optional automation — the health cron.** When `health.schedule` in
+`.lisa.config.json` is `daily` or `weekly` (default **off**, which registers
+nothing), additionally create `lisa-auto-<project>-health-drift` running
+`/lisa:health-drift-cron` at that cadence. It runs Lisa Health headless and,
+for each check that has drifted, files exactly one ticket through
+`lisa-tracker-write`. A project in band files nothing. Register at most ONE per
+project: the per-check marker dedupe converges under a single scheduled runner,
+and two concurrent runs can both observe an empty open-ticket set and both
+file. Tear-down removes it with the rest of the `lisa-auto-<project>-*` set.
+
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The
 `exploratory-prds` automation uses the same PRD source queue and pressure roles reported by

--- a/plugins/lisa-cursor/commands/lisa/health-drift-cron.md
+++ b/plugins/lisa-cursor/commands/lisa/health-drift-cron.md
@@ -1,0 +1,9 @@
+---
+description: "Run the scheduled health consumer: check health headless, and file one deduped ticket per drifting check."
+argument-hint: "[project-path]"
+---
+
+Use the /lisa-health-drift-cron skill to run Lisa Health for the optional project path and turn any
+drift into tracked work. File exactly one ticket per drifting check through `lisa-tracker-write`,
+deduped by the per-check marker across OPEN tickets only, and file nothing for a project in band.
+This flow files; it never closes, edits, or repairs. $ARGUMENTS

--- a/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
@@ -63,6 +63,16 @@ The distinction between the two `no-change` shapes matters. "Nothing filed" and 
 
 ## Registration
 
-Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Torn down with the rest of the `lisa-auto-<project>-*` set.
 
-Torn down with the rest of the `lisa-auto-<project>-*` set.
+Register at most **one** per project.
+
+### What the dedupe does and does not guarantee
+
+It guarantees **convergence, not mutual exclusion**, and the difference is worth stating plainly rather than leaving to be discovered.
+
+Two runs that overlap — a manual invocation alongside the scheduled one, or a run still going when the next fires — can both read an empty open-ticket set and both file for the same check. A single registration makes that rare; it does not make it impossible, and no amount of care in this document would.
+
+What the design does guarantee is that it stops there. The next run sees both open tickets carrying the marker, matches, and files nothing further, so duplicates do not compound. The transient duplicate persists until a human closes one, and closing it is safe: if the drift is still live, the remaining ticket still tracks it.
+
+This is the same stance `lisa-learnings-audit` takes for the same reason, and the same advice applies — **a manual run should first confirm the cron is not due or running.** A project-scoped lease would buy true exclusion at the cost of a lock to acquire, hold, and expire correctly on a path that only runs daily; the failure it prevents is cosmetic and self-limiting, and the failure a stuck lease causes is a health check that silently stops running.

--- a/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: lisa-health-drift-cron
+description: "Scheduled health consumer. Runs Lisa Health headless, and for each check that has drifted files exactly one tracker ticket through lisa-tracker-write, deduped by a per-check marker across OPEN tickets only. Files nothing for a project in band. Use for the lisa-auto-<project>-health-drift automation registered when health.schedule is set."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Lisa Health Drift Cron: $ARGUMENTS
+
+Consumer #3 of the health layer: the cron. A health check you have to remember to run is a health check that goes stale, so this one runs on a schedule and turns drift into **tracked work** rather than silent decay.
+
+It **files**. It never closes, edits, or repairs. Disposal belongs to humans and the Implement factory.
+
+## Why idempotency is the whole job
+
+A nightly cron that refiles the same drift every night is worse than no cron at all, because it teaches everyone to ignore the tickets it files. Every rule below exists to make *"the same drift"* a decidable question, and the decision is not made in this prose — it is made by `planDriftTickets` in `src/health/drift-tickets.ts`, which is unit-tested against each of these cases.
+
+**Do not reimplement the dedupe here.** Call the planner and act on its answer. A second implementation in prose is a second implementation to drift.
+
+## Phase 1 — Run the health check headless
+
+```bash
+lisa health --json
+```
+
+Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+
+If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
+
+## Phase 2 — Read the OPEN tickets only
+
+Fetch the tracker's **open** items carrying the drift marker prefix `lisa-health-drift`.
+
+**Open only, and this is load-bearing.** A closed ticket must not suppress live drift: if it did, closing a ticket without fixing anything would make that drift invisible forever, which is exactly the silent decay this consumer exists to prevent. Suppression should be a configured declaration visible in a diff — turn the check off in config — not a side effect of somebody tidying a backlog.
+
+The planner enforces this by construction: it accepts an `openTickets` list and has no notion of a closed one. Passing closed tickets defeats the design, and the parameter is named to say so.
+
+## Phase 3 — Plan
+
+Feed the findings and the open tickets to `planDriftTickets`. It returns:
+
+- `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
+- `alreadyTracked` — drift that an open ticket already covers, with the ticket id
+
+Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+
+Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
+
+## Phase 4 — File
+
+For each entry in `file`, invoke **`/lisa-tracker-write`** with its title and body. **Never call a vendor writer (`lisa-github-write-issue` / `lisa-jira-write-ticket` / `lisa-linear-write-issue`) directly** — routing through the shim is what makes the tracker switchable per project.
+
+The body already contains the marker. Do not strip it, and do not add a second one: the next run finds the ticket by that exact string.
+
+## Run outcome
+
+Per the automation runbook contract, end with exactly one outcome and a one-line operator-readable summary:
+
+- **no-change** — the project is in band, or every drifting check is already tracked. Say which: `no-change — in band, nothing filed.` versus `no-change — 2 drifting checks, both already tracked (#41, #42).`
+- **change-proved** — tickets were filed. `change-proved — filed 1 drift ticket: coverage-floor (#57).`
+- **recovery-required** — the health run failed, or a write failed. Name what a human must do.
+
+The distinction between the two `no-change` shapes matters. "Nothing filed" and "nothing wrong" are different facts, and collapsing them hides a project whose drift is real and simply already on somebody's list.
+
+## Registration
+
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+
+Torn down with the rest of the `lisa-auto-<project>-*` set.

--- a/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
@@ -18,11 +18,11 @@ A nightly cron that refiles the same drift every night is worse than no cron at 
 
 ## Phase 1 — Run the health check headless
 
-```bash
-lisa health --json
-```
+Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directly and do not invent flags for it: `lisa health` takes `[path]`, `--prepare-agentic`, and `--agentic-evaluation`, and nothing else. There is no `--json` — the persisted result IS the command's stdout, and an unknown option makes commander exit non-zero, so a guessed flag turns the first phase of a scheduled run into a failure nobody is watching.
 
-Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
+
+Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 

--- a/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
@@ -43,6 +43,8 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 
 Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
+The collapse is not tidiness. The marker cannot tell two findings for one check apart, so filing both would self-duplicate on the very FIRST run — before any second run exists to blame. `file.length + alreadyTracked.length` therefore counts distinct drifting checks, which is fewer than the drifting findings whenever a run reports one check twice.
+
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 
 ## Phase 4 — File

--- a/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md
@@ -22,7 +22,7 @@ Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directl
 
 Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
 
-Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Do not reconstruct, merge, or summarize findings; the result is passed to Phase 3 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 
@@ -41,7 +41,7 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 - `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
 - `alreadyTracked` — drift that an open ticket already covers, with the ticket id
 
-Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/SKILL.md
@@ -197,6 +197,16 @@ closed by the next run's dedupe or the human), not mutual exclusion; manual
 runs should first confirm the cron is not due or running. Tear-down removes
 it with the rest of the `lisa-auto-<project>-*` set.
 
+**Optional automation — the health cron.** When `health.schedule` in
+`.lisa.config.json` is `daily` or `weekly` (default **off**, which registers
+nothing), additionally create `lisa-auto-<project>-health-drift` running
+`/lisa:health-drift-cron` at that cadence. It runs Lisa Health headless and,
+for each check that has drifted, files exactly one ticket through
+`lisa-tracker-write`. A project in band files nothing. Register at most ONE per
+project: the per-check marker dedupe converges under a single scheduled runner,
+and two concurrent runs can both observe an empty open-ticket set and both
+file. Tear-down removes it with the rest of the `lisa-auto-<project>-*` set.
+
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The
 `exploratory-prds` automation uses the same PRD source queue and pressure roles reported by

--- a/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
@@ -63,6 +63,16 @@ The distinction between the two `no-change` shapes matters. "Nothing filed" and 
 
 ## Registration
 
-Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Torn down with the rest of the `lisa-auto-<project>-*` set.
 
-Torn down with the rest of the `lisa-auto-<project>-*` set.
+Register at most **one** per project.
+
+### What the dedupe does and does not guarantee
+
+It guarantees **convergence, not mutual exclusion**, and the difference is worth stating plainly rather than leaving to be discovered.
+
+Two runs that overlap — a manual invocation alongside the scheduled one, or a run still going when the next fires — can both read an empty open-ticket set and both file for the same check. A single registration makes that rare; it does not make it impossible, and no amount of care in this document would.
+
+What the design does guarantee is that it stops there. The next run sees both open tickets carrying the marker, matches, and files nothing further, so duplicates do not compound. The transient duplicate persists until a human closes one, and closing it is safe: if the drift is still live, the remaining ticket still tracks it.
+
+This is the same stance `lisa-learnings-audit` takes for the same reason, and the same advice applies — **a manual run should first confirm the cron is not due or running.** A project-scoped lease would buy true exclusion at the cost of a lock to acquire, hold, and expire correctly on a path that only runs daily; the failure it prevents is cosmetic and self-limiting, and the failure a stuck lease causes is a health check that silently stops running.

--- a/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
@@ -18,11 +18,11 @@ A nightly cron that refiles the same drift every night is worse than no cron at 
 
 ## Phase 1 — Run the health check headless
 
-```bash
-lisa health --json
-```
+Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directly and do not invent flags for it: `lisa health` takes `[path]`, `--prepare-agentic`, and `--agentic-evaluation`, and nothing else. There is no `--json` — the persisted result IS the command's stdout, and an unknown option makes commander exit non-zero, so a guessed flag turns the first phase of a scheduled run into a failure nobody is watching.
 
-Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
+
+Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
@@ -43,6 +43,8 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 
 Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
+The collapse is not tidiness. The marker cannot tell two findings for one check apart, so filing both would self-duplicate on the very FIRST run — before any second run exists to blame. `file.length + alreadyTracked.length` therefore counts distinct drifting checks, which is fewer than the drifting findings whenever a run reports one check twice.
+
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 
 ## Phase 4 — File

--- a/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: lisa-health-drift-cron
+description: "Scheduled health consumer"
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Lisa Health Drift Cron: $ARGUMENTS
+
+Consumer #3 of the health layer: the cron. A health check you have to remember to run is a health check that goes stale, so this one runs on a schedule and turns drift into **tracked work** rather than silent decay.
+
+It **files**. It never closes, edits, or repairs. Disposal belongs to humans and the Implement factory.
+
+## Why idempotency is the whole job
+
+A nightly cron that refiles the same drift every night is worse than no cron at all, because it teaches everyone to ignore the tickets it files. Every rule below exists to make *"the same drift"* a decidable question, and the decision is not made in this prose — it is made by `planDriftTickets` in `src/health/drift-tickets.ts`, which is unit-tested against each of these cases.
+
+**Do not reimplement the dedupe here.** Call the planner and act on its answer. A second implementation in prose is a second implementation to drift.
+
+## Phase 1 — Run the health check headless
+
+```bash
+lisa health --json
+```
+
+Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+
+If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
+
+## Phase 2 — Read the OPEN tickets only
+
+Fetch the tracker's **open** items carrying the drift marker prefix `lisa-health-drift`.
+
+**Open only, and this is load-bearing.** A closed ticket must not suppress live drift: if it did, closing a ticket without fixing anything would make that drift invisible forever, which is exactly the silent decay this consumer exists to prevent. Suppression should be a configured declaration visible in a diff — turn the check off in config — not a side effect of somebody tidying a backlog.
+
+The planner enforces this by construction: it accepts an `openTickets` list and has no notion of a closed one. Passing closed tickets defeats the design, and the parameter is named to say so.
+
+## Phase 3 — Plan
+
+Feed the findings and the open tickets to `planDriftTickets`. It returns:
+
+- `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
+- `alreadyTracked` — drift that an open ticket already covers, with the ticket id
+
+Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+
+Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
+
+## Phase 4 — File
+
+For each entry in `file`, invoke **`/lisa-tracker-write`** with its title and body. **Never call a vendor writer (`lisa-github-write-issue` / `lisa-jira-write-ticket` / `lisa-linear-write-issue`) directly** — routing through the shim is what makes the tracker switchable per project.
+
+The body already contains the marker. Do not strip it, and do not add a second one: the next run finds the ticket by that exact string.
+
+## Run outcome
+
+Per the automation runbook contract, end with exactly one outcome and a one-line operator-readable summary:
+
+- **no-change** — the project is in band, or every drifting check is already tracked. Say which: `no-change — in band, nothing filed.` versus `no-change — 2 drifting checks, both already tracked (#41, #42).`
+- **change-proved** — tickets were filed. `change-proved — filed 1 drift ticket: coverage-floor (#57).`
+- **recovery-required** — the health run failed, or a write failed. Name what a human must do.
+
+The distinction between the two `no-change` shapes matters. "Nothing filed" and "nothing wrong" are different facts, and collapsing them hides a project whose drift is real and simply already on somebody's list.
+
+## Registration
+
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+
+Torn down with the rest of the `lisa-auto-<project>-*` set.

--- a/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md
@@ -22,7 +22,7 @@ Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directl
 
 Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
 
-Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Do not reconstruct, merge, or summarize findings; the result is passed to Phase 3 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 
@@ -41,7 +41,7 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 - `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
 - `alreadyTracked` — drift that an open ticket already covers, with the ticket id
 
-Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/agents/openai.yaml
+++ b/plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Health Drift Cron"
+short_description: "Scheduled health consumer"
+default_prompt:
+  - "Use $lisa-health-drift-cron: Scheduled health consumer."

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/SKILL.md
@@ -197,6 +197,16 @@ closed by the next run's dedupe or the human), not mutual exclusion; manual
 runs should first confirm the cron is not due or running. Tear-down removes
 it with the rest of the `lisa-auto-<project>-*` set.
 
+**Optional automation — the health cron.** When `health.schedule` in
+`.lisa.config.json` is `daily` or `weekly` (default **off**, which registers
+nothing), additionally create `lisa-auto-<project>-health-drift` running
+`/lisa:health-drift-cron` at that cadence. It runs Lisa Health headless and,
+for each check that has drifted, files exactly one ticket through
+`lisa-tracker-write`. A project in band files nothing. Register at most ONE per
+project: the per-check marker dedupe converges under a single scheduled runner,
+and two concurrent runs can both observe an empty open-ticket set and both
+file. Tear-down removes it with the rest of the `lisa-auto-<project>-*` set.
+
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The
 `exploratory-prds` automation uses the same PRD source queue and pressure roles reported by

--- a/plugins/lisa/commands/health-drift-cron.md
+++ b/plugins/lisa/commands/health-drift-cron.md
@@ -1,0 +1,9 @@
+---
+description: "Run the scheduled health consumer: check health headless, and file one deduped ticket per drifting check."
+argument-hint: "[project-path]"
+---
+
+Use the /lisa-health-drift-cron skill to run Lisa Health for the optional project path and turn any
+drift into tracked work. File exactly one ticket per drifting check through `lisa-tracker-write`,
+deduped by the per-check marker across OPEN tickets only, and file nothing for a project in band.
+This flow files; it never closes, edits, or repairs. $ARGUMENTS

--- a/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
@@ -63,6 +63,16 @@ The distinction between the two `no-change` shapes matters. "Nothing filed" and 
 
 ## Registration
 
-Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Torn down with the rest of the `lisa-auto-<project>-*` set.
 
-Torn down with the rest of the `lisa-auto-<project>-*` set.
+Register at most **one** per project.
+
+### What the dedupe does and does not guarantee
+
+It guarantees **convergence, not mutual exclusion**, and the difference is worth stating plainly rather than leaving to be discovered.
+
+Two runs that overlap — a manual invocation alongside the scheduled one, or a run still going when the next fires — can both read an empty open-ticket set and both file for the same check. A single registration makes that rare; it does not make it impossible, and no amount of care in this document would.
+
+What the design does guarantee is that it stops there. The next run sees both open tickets carrying the marker, matches, and files nothing further, so duplicates do not compound. The transient duplicate persists until a human closes one, and closing it is safe: if the drift is still live, the remaining ticket still tracks it.
+
+This is the same stance `lisa-learnings-audit` takes for the same reason, and the same advice applies — **a manual run should first confirm the cron is not due or running.** A project-scoped lease would buy true exclusion at the cost of a lock to acquire, hold, and expire correctly on a path that only runs daily; the failure it prevents is cosmetic and self-limiting, and the failure a stuck lease causes is a health check that silently stops running.

--- a/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: lisa-health-drift-cron
+description: "Scheduled health consumer. Runs Lisa Health headless, and for each check that has drifted files exactly one tracker ticket through lisa-tracker-write, deduped by a per-check marker across OPEN tickets only. Files nothing for a project in band. Use for the lisa-auto-<project>-health-drift automation registered when health.schedule is set."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Lisa Health Drift Cron: $ARGUMENTS
+
+Consumer #3 of the health layer: the cron. A health check you have to remember to run is a health check that goes stale, so this one runs on a schedule and turns drift into **tracked work** rather than silent decay.
+
+It **files**. It never closes, edits, or repairs. Disposal belongs to humans and the Implement factory.
+
+## Why idempotency is the whole job
+
+A nightly cron that refiles the same drift every night is worse than no cron at all, because it teaches everyone to ignore the tickets it files. Every rule below exists to make *"the same drift"* a decidable question, and the decision is not made in this prose — it is made by `planDriftTickets` in `src/health/drift-tickets.ts`, which is unit-tested against each of these cases.
+
+**Do not reimplement the dedupe here.** Call the planner and act on its answer. A second implementation in prose is a second implementation to drift.
+
+## Phase 1 — Run the health check headless
+
+```bash
+lisa health --json
+```
+
+Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+
+If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
+
+## Phase 2 — Read the OPEN tickets only
+
+Fetch the tracker's **open** items carrying the drift marker prefix `lisa-health-drift`.
+
+**Open only, and this is load-bearing.** A closed ticket must not suppress live drift: if it did, closing a ticket without fixing anything would make that drift invisible forever, which is exactly the silent decay this consumer exists to prevent. Suppression should be a configured declaration visible in a diff — turn the check off in config — not a side effect of somebody tidying a backlog.
+
+The planner enforces this by construction: it accepts an `openTickets` list and has no notion of a closed one. Passing closed tickets defeats the design, and the parameter is named to say so.
+
+## Phase 3 — Plan
+
+Feed the findings and the open tickets to `planDriftTickets`. It returns:
+
+- `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
+- `alreadyTracked` — drift that an open ticket already covers, with the ticket id
+
+Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+
+Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
+
+## Phase 4 — File
+
+For each entry in `file`, invoke **`/lisa-tracker-write`** with its title and body. **Never call a vendor writer (`lisa-github-write-issue` / `lisa-jira-write-ticket` / `lisa-linear-write-issue`) directly** — routing through the shim is what makes the tracker switchable per project.
+
+The body already contains the marker. Do not strip it, and do not add a second one: the next run finds the ticket by that exact string.
+
+## Run outcome
+
+Per the automation runbook contract, end with exactly one outcome and a one-line operator-readable summary:
+
+- **no-change** — the project is in band, or every drifting check is already tracked. Say which: `no-change — in band, nothing filed.` versus `no-change — 2 drifting checks, both already tracked (#41, #42).`
+- **change-proved** — tickets were filed. `change-proved — filed 1 drift ticket: coverage-floor (#57).`
+- **recovery-required** — the health run failed, or a write failed. Name what a human must do.
+
+The distinction between the two `no-change` shapes matters. "Nothing filed" and "nothing wrong" are different facts, and collapsing them hides a project whose drift is real and simply already on somebody's list.
+
+## Registration
+
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+
+Torn down with the rest of the `lisa-auto-<project>-*` set.

--- a/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
@@ -18,11 +18,11 @@ A nightly cron that refiles the same drift every night is worse than no cron at 
 
 ## Phase 1 — Run the health check headless
 
-```bash
-lisa health --json
-```
+Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directly and do not invent flags for it: `lisa health` takes `[path]`, `--prepare-agentic`, and `--agentic-evaluation`, and nothing else. There is no `--json` — the persisted result IS the command's stdout, and an unknown option makes commander exit non-zero, so a guessed flag turns the first phase of a scheduled run into a failure nobody is watching.
 
-Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
+
+Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 

--- a/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
@@ -43,6 +43,8 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 
 Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
+The collapse is not tidiness. The marker cannot tell two findings for one check apart, so filing both would self-duplicate on the very FIRST run — before any second run exists to blame. `file.length + alreadyTracked.length` therefore counts distinct drifting checks, which is fewer than the drifting findings whenever a run reports one check twice.
+
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 
 ## Phase 4 — File

--- a/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/lisa/skills/lisa-health-drift-cron/SKILL.md
@@ -22,7 +22,7 @@ Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directl
 
 Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
 
-Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Do not reconstruct, merge, or summarize findings; the result is passed to Phase 3 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 
@@ -41,7 +41,7 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 - `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
 - `alreadyTracked` — drift that an open ticket already covers, with the ticket id
 
-Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 

--- a/plugins/lisa/skills/lisa-health-drift-cron/agents/openai.yaml
+++ b/plugins/lisa/skills/lisa-health-drift-cron/agents/openai.yaml
@@ -1,0 +1,4 @@
+display_name: "Health Drift Cron"
+short_description: "Scheduled health consumer"
+default_prompt:
+  - "Use $lisa-health-drift-cron: Scheduled health consumer."

--- a/plugins/lisa/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-automations/SKILL.md
@@ -197,6 +197,16 @@ closed by the next run's dedupe or the human), not mutual exclusion; manual
 runs should first confirm the cron is not due or running. Tear-down removes
 it with the rest of the `lisa-auto-<project>-*` set.
 
+**Optional automation — the health cron.** When `health.schedule` in
+`.lisa.config.json` is `daily` or `weekly` (default **off**, which registers
+nothing), additionally create `lisa-auto-<project>-health-drift` running
+`/lisa:health-drift-cron` at that cadence. It runs Lisa Health headless and,
+for each check that has drifted, files exactly one ticket through
+`lisa-tracker-write`. A project in band files nothing. Register at most ONE per
+project: the per-check marker dedupe converges under a single scheduled runner,
+and two concurrent runs can both observe an empty open-ticket set and both
+file. Tear-down removes it with the rest of the `lisa-auto-<project>-*` set.
+
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The
 `exploratory-prds` automation uses the same PRD source queue and pressure roles reported by

--- a/plugins/src/base/commands/health-drift-cron.md
+++ b/plugins/src/base/commands/health-drift-cron.md
@@ -1,0 +1,9 @@
+---
+description: "Run the scheduled health consumer: check health headless, and file one deduped ticket per drifting check."
+argument-hint: "[project-path]"
+---
+
+Use the /lisa-health-drift-cron skill to run Lisa Health for the optional project path and turn any
+drift into tracked work. File exactly one ticket per drifting check through `lisa-tracker-write`,
+deduped by the per-check marker across OPEN tickets only, and file nothing for a project in band.
+This flow files; it never closes, edits, or repairs. $ARGUMENTS

--- a/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
@@ -63,6 +63,16 @@ The distinction between the two `no-change` shapes matters. "Nothing filed" and 
 
 ## Registration
 
-Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Torn down with the rest of the `lisa-auto-<project>-*` set.
 
-Torn down with the rest of the `lisa-auto-<project>-*` set.
+Register at most **one** per project.
+
+### What the dedupe does and does not guarantee
+
+It guarantees **convergence, not mutual exclusion**, and the difference is worth stating plainly rather than leaving to be discovered.
+
+Two runs that overlap — a manual invocation alongside the scheduled one, or a run still going when the next fires — can both read an empty open-ticket set and both file for the same check. A single registration makes that rare; it does not make it impossible, and no amount of care in this document would.
+
+What the design does guarantee is that it stops there. The next run sees both open tickets carrying the marker, matches, and files nothing further, so duplicates do not compound. The transient duplicate persists until a human closes one, and closing it is safe: if the drift is still live, the remaining ticket still tracks it.
+
+This is the same stance `lisa-learnings-audit` takes for the same reason, and the same advice applies — **a manual run should first confirm the cron is not due or running.** A project-scoped lease would buy true exclusion at the cost of a lock to acquire, hold, and expire correctly on a path that only runs daily; the failure it prevents is cosmetic and self-limiting, and the failure a stuck lease causes is a health check that silently stops running.

--- a/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: lisa-health-drift-cron
+description: "Scheduled health consumer. Runs Lisa Health headless, and for each check that has drifted files exactly one tracker ticket through lisa-tracker-write, deduped by a per-check marker across OPEN tickets only. Files nothing for a project in band. Use for the lisa-auto-<project>-health-drift automation registered when health.schedule is set."
+allowed-tools: ["Skill", "Bash", "Read"]
+---
+
+# Lisa Health Drift Cron: $ARGUMENTS
+
+Consumer #3 of the health layer: the cron. A health check you have to remember to run is a health check that goes stale, so this one runs on a schedule and turns drift into **tracked work** rather than silent decay.
+
+It **files**. It never closes, edits, or repairs. Disposal belongs to humans and the Implement factory.
+
+## Why idempotency is the whole job
+
+A nightly cron that refiles the same drift every night is worse than no cron at all, because it teaches everyone to ignore the tickets it files. Every rule below exists to make *"the same drift"* a decidable question, and the decision is not made in this prose — it is made by `planDriftTickets` in `src/health/drift-tickets.ts`, which is unit-tested against each of these cases.
+
+**Do not reimplement the dedupe here.** Call the planner and act on its answer. A second implementation in prose is a second implementation to drift.
+
+## Phase 1 — Run the health check headless
+
+```bash
+lisa health --json
+```
+
+Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+
+If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
+
+## Phase 2 — Read the OPEN tickets only
+
+Fetch the tracker's **open** items carrying the drift marker prefix `lisa-health-drift`.
+
+**Open only, and this is load-bearing.** A closed ticket must not suppress live drift: if it did, closing a ticket without fixing anything would make that drift invisible forever, which is exactly the silent decay this consumer exists to prevent. Suppression should be a configured declaration visible in a diff — turn the check off in config — not a side effect of somebody tidying a backlog.
+
+The planner enforces this by construction: it accepts an `openTickets` list and has no notion of a closed one. Passing closed tickets defeats the design, and the parameter is named to say so.
+
+## Phase 3 — Plan
+
+Feed the findings and the open tickets to `planDriftTickets`. It returns:
+
+- `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
+- `alreadyTracked` — drift that an open ticket already covers, with the ticket id
+
+Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+
+Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
+
+## Phase 4 — File
+
+For each entry in `file`, invoke **`/lisa-tracker-write`** with its title and body. **Never call a vendor writer (`lisa-github-write-issue` / `lisa-jira-write-ticket` / `lisa-linear-write-issue`) directly** — routing through the shim is what makes the tracker switchable per project.
+
+The body already contains the marker. Do not strip it, and do not add a second one: the next run finds the ticket by that exact string.
+
+## Run outcome
+
+Per the automation runbook contract, end with exactly one outcome and a one-line operator-readable summary:
+
+- **no-change** — the project is in band, or every drifting check is already tracked. Say which: `no-change — in band, nothing filed.` versus `no-change — 2 drifting checks, both already tracked (#41, #42).`
+- **change-proved** — tickets were filed. `change-proved — filed 1 drift ticket: coverage-floor (#57).`
+- **recovery-required** — the health run failed, or a write failed. Name what a human must do.
+
+The distinction between the two `no-change` shapes matters. "Nothing filed" and "nothing wrong" are different facts, and collapsing them hides a project whose drift is real and simply already on somebody's list.
+
+## Registration
+
+Registered as `lisa-auto-<project>-health-drift` when `health.schedule` is set to `daily` or `weekly` in `.lisa.config.json`. `off` (the default) registers nothing. Register at most **one** per project: the marker dedupe converges under a single scheduled runner, and two concurrent runs can both observe an empty open-ticket set and both file.
+
+Torn down with the rest of the `lisa-auto-<project>-*` set.

--- a/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
@@ -18,11 +18,11 @@ A nightly cron that refiles the same drift every night is worse than no cron at 
 
 ## Phase 1 — Run the health check headless
 
-```bash
-lisa health --json
-```
+Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directly and do not invent flags for it: `lisa health` takes `[path]`, `--prepare-agentic`, and `--agentic-evaluation`, and nothing else. There is no `--json` — the persisted result IS the command's stdout, and an unknown option makes commander exit non-zero, so a guessed flag turns the first phase of a scheduled run into a failure nobody is watching.
 
-Persisted to `.lisa/health/latest.json` by the CLI, as `/lisa:health` does. Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
+
+Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 

--- a/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
@@ -43,6 +43,8 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 
 Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
+The collapse is not tidiness. The marker cannot tell two findings for one check apart, so filing both would self-duplicate on the very FIRST run — before any second run exists to blame. `file.length + alreadyTracked.length` therefore counts distinct drifting checks, which is fewer than the drifting findings whenever a run reports one check twice.
+
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 
 ## Phase 4 — File

--- a/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
+++ b/plugins/src/base/skills/lisa-health-drift-cron/SKILL.md
@@ -22,7 +22,7 @@ Invoke **`/lisa-health`** and use the JSON it emits. Do not call the CLI directl
 
 Routing through the skill also means the bounded harness-review step and its cleanup stay in one place rather than being re-described here and drifting.
 
-Do not reconstruct, merge, or summarize findings; the result is the input to Phase 2 verbatim.
+Do not reconstruct, merge, or summarize findings; the result is passed to Phase 3 verbatim.
 
 If the run itself fails, that is a **recovery-required** outcome. Report it and stop. Do not file a drift ticket about a health check that did not complete — a run that could not measure has not found drift, and saying otherwise is the same defect the health layer exists to catch.
 
@@ -41,7 +41,7 @@ Feed the findings and the open tickets to `planDriftTickets`. It returns:
 - `file` — one entry per drifting check with no open ticket, carrying `title`, `body`, and `marker`
 - `alreadyTracked` — drift that an open ticket already covers, with the ticket id
 
-Every drifting finding lands in exactly one of the two, so a run reporting "nothing to do" is asserting it looked at all of them.
+Every unique drifting check lands in exactly one of the two after duplicate findings for the same check are collapsed, so a run reporting "nothing to do" is asserting it looked at all of them.
 
 Dedupe is per **check**, not per drift set. Fingerprinting the whole finding set would mean one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route.
 

--- a/plugins/src/base/skills/lisa-setup-automations/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-automations/SKILL.md
@@ -197,6 +197,16 @@ closed by the next run's dedupe or the human), not mutual exclusion; manual
 runs should first confirm the cron is not due or running. Tear-down removes
 it with the rest of the `lisa-auto-<project>-*` set.
 
+**Optional automation — the health cron.** When `health.schedule` in
+`.lisa.config.json` is `daily` or `weekly` (default **off**, which registers
+nothing), additionally create `lisa-auto-<project>-health-drift` running
+`/lisa:health-drift-cron` at that cadence. It runs Lisa Health headless and,
+for each check that has drifted, files exactly one ticket through
+`lisa-tracker-write`. A project in band files nothing. Register at most ONE per
+project: the per-check marker dedupe converges under a single scheduled runner,
+and two concurrent runs can both observe an empty open-ticket set and both
+file. Tear-down removes it with the rest of the `lisa-auto-<project>-*` set.
+
 **Exploratory PRD pressure gate.** `auto-start-prds=true` means "create PRDs in the ready PRD
 lifecycle when the PRD queue has capacity," not "always create a new ready PRD." The
 `exploratory-prds` automation uses the same PRD source queue and pressure roles reported by

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1053,7 +1053,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md":
       "262f8a1bcfad4c5dd4456cfaaf1b71abf9697a0da588966e58ff491acd3c17e8",
     "plugins/src/base/skills/lisa-health-drift-cron/SKILL.md":
-      "adbfa470e2c7d80b4dfd131761e21512c36b7f739e60c2e7682b90d358410190",
+      "2c0976dbf1e245654320259e56012f3357242ff67612a193fedb7bf94bb02737",
     "plugins/src/base/skills/lisa-health/SKILL.md":
       "dfdb08a863e78bff42671793dcec29cfae0654db18ebf66a4aa77aeb56ddb775",
     "plugins/src/base/skills/lisa-implement/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1053,7 +1053,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md":
       "262f8a1bcfad4c5dd4456cfaaf1b71abf9697a0da588966e58ff491acd3c17e8",
     "plugins/src/base/skills/lisa-health-drift-cron/SKILL.md":
-      "2c0976dbf1e245654320259e56012f3357242ff67612a193fedb7bf94bb02737",
+      "3706c0efa572a82e0d9a8e12a4e4e009642d0507422cb31234a5b14e92b2daf3",
     "plugins/src/base/skills/lisa-health/SKILL.md":
       "dfdb08a863e78bff42671793dcec29cfae0654db18ebf66a4aa77aeb56ddb775",
     "plugins/src/base/skills/lisa-implement/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -550,6 +550,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "d1f520ffedaa1ca331c232c9e113ca8e7868a1e93028ff9d45a2bc32d7ce45e2",
     "plugins/src/base/commands/git/submit-pr.md":
       "131ba633e9bc4379e0ed63f30752076b1aa5b5552d8f542624bc8d4451135773",
+    "plugins/src/base/commands/health-drift-cron.md":
+      "bb656bdc2e03d77d6f34eeda82e05ae62bc9ca899ac14d3a1e9524875afcf954",
     "plugins/src/base/commands/health.md":
       "f74536619029160e20240c3f1eaf02b300aaecd2a649651fd8ce6bf78f881c70",
     "plugins/src/base/commands/implement.md":
@@ -1050,6 +1052,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "91c36d0a5fdc06bee1819e705d312317d42ecda67308b141f1a65b80e45bfbc0",
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md":
       "262f8a1bcfad4c5dd4456cfaaf1b71abf9697a0da588966e58ff491acd3c17e8",
+    "plugins/src/base/skills/lisa-health-drift-cron/SKILL.md":
+      "adbfa470e2c7d80b4dfd131761e21512c36b7f739e60c2e7682b90d358410190",
     "plugins/src/base/skills/lisa-health/SKILL.md":
       "dfdb08a863e78bff42671793dcec29cfae0654db18ebf66a4aa77aeb56ddb775",
     "plugins/src/base/skills/lisa-implement/SKILL.md":
@@ -1279,7 +1283,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-atlassian/SKILL.md":
       "4fa7f9a83a9998951528c8ffffa930c61b5c316b510356a3e7a90ccb9d5ca123",
     "plugins/src/base/skills/lisa-setup-automations/SKILL.md":
-      "3ad004148a54571a50df90f23abec71e8510ef3ea3562ac812f8e2e11beb157a",
+      "4bf86639bca29641686fd124d7d4b6c177775063930a309e2c33f808e33d505f",
     "plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs":
       "f639c3f174378f0068b9c9d56e59b356c6da988730a1390c61e4348b4a4073ac",
     "plugins/src/base/skills/lisa-setup-confluence/SKILL.md":
@@ -3313,6 +3317,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/commands/lisa/git/commit.md": true,
     "plugins/lisa-agy/commands/lisa/git/prune.md": true,
     "plugins/lisa-agy/commands/lisa/git/submit-pr.md": true,
+    "plugins/lisa-agy/commands/lisa/health-drift-cron.md": true,
     "plugins/lisa-agy/commands/lisa/health.md": true,
     "plugins/lisa-agy/commands/lisa/implement.md": true,
     "plugins/lisa-agy/commands/lisa/improve-harness.md": true,
@@ -3447,6 +3452,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/skills/lisa-github-verify/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-github-write-issue/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-github-write-prd/SKILL.md": true,
+    "plugins/lisa-agy/skills/lisa-health-drift-cron/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-health/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-implement/SKILL.md": true,
     "plugins/lisa-agy/skills/lisa-improve-code-complexity/SKILL.md": true,
@@ -3676,6 +3682,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/commands/lisa/git/commit.md": true,
     "plugins/lisa-copilot/commands/lisa/git/prune.md": true,
     "plugins/lisa-copilot/commands/lisa/git/submit-pr.md": true,
+    "plugins/lisa-copilot/commands/lisa/health-drift-cron.md": true,
     "plugins/lisa-copilot/commands/lisa/health.md": true,
     "plugins/lisa-copilot/commands/lisa/implement.md": true,
     "plugins/lisa-copilot/commands/lisa/improve-harness.md": true,
@@ -3916,6 +3923,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/skills/lisa-github-verify/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-github-write-issue/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-github-write-prd/SKILL.md": true,
+    "plugins/lisa-copilot/skills/lisa-health-drift-cron/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-health/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-implement/SKILL.md": true,
     "plugins/lisa-copilot/skills/lisa-improve-code-complexity/SKILL.md": true,
@@ -4130,6 +4138,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/commands/lisa/git/commit.md": true,
     "plugins/lisa-cursor/commands/lisa/git/prune.md": true,
     "plugins/lisa-cursor/commands/lisa/git/submit-pr.md": true,
+    "plugins/lisa-cursor/commands/lisa/health-drift-cron.md": true,
     "plugins/lisa-cursor/commands/lisa/health.md": true,
     "plugins/lisa-cursor/commands/lisa/implement.md": true,
     "plugins/lisa-cursor/commands/lisa/improve-harness.md": true,
@@ -4371,6 +4380,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/skills/lisa-github-verify/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-github-write-issue/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-github-write-prd/SKILL.md": true,
+    "plugins/lisa-cursor/skills/lisa-health-drift-cron/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-health/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-implement/SKILL.md": true,
     "plugins/lisa-cursor/skills/lisa-improve-code-complexity/SKILL.md": true,
@@ -6331,6 +6341,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/.codex-plugin/skills/lisa-github-write-issue/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-github-write-prd/SKILL.md": true,
     "plugins/lisa/.codex-plugin/skills/lisa-github-write-prd/agents/openai.yaml": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/SKILL.md": true,
+    "plugins/lisa/.codex-plugin/skills/lisa-health-drift-cron/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-health/SKILL.md": true,
     "plugins/lisa/.codex-plugin/skills/lisa-health/agents/openai.yaml": true,
     "plugins/lisa/.codex-plugin/skills/lisa-implement/SKILL.md": true,
@@ -6673,6 +6685,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/commands/git/commit.md": true,
     "plugins/lisa/commands/git/prune.md": true,
     "plugins/lisa/commands/git/submit-pr.md": true,
+    "plugins/lisa/commands/health-drift-cron.md": true,
     "plugins/lisa/commands/health.md": true,
     "plugins/lisa/commands/implement.md": true,
     "plugins/lisa/commands/improve-harness.md": true,
@@ -6967,6 +6980,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/skills/lisa-github-write-issue/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-github-write-prd/SKILL.md": true,
     "plugins/lisa/skills/lisa-github-write-prd/agents/openai.yaml": true,
+    "plugins/lisa/skills/lisa-health-drift-cron/SKILL.md": true,
+    "plugins/lisa/skills/lisa-health-drift-cron/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-health/SKILL.md": true,
     "plugins/lisa/skills/lisa-health/agents/openai.yaml": true,
     "plugins/lisa/skills/lisa-implement/SKILL.md": true,
@@ -7309,6 +7324,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/commands/git/commit.md": true,
     "plugins/src/base/commands/git/prune.md": true,
     "plugins/src/base/commands/git/submit-pr.md": true,
+    "plugins/src/base/commands/health-drift-cron.md": true,
     "plugins/src/base/commands/health.md": true,
     "plugins/src/base/commands/implement.md": true,
     "plugins/src/base/commands/improve-harness.md": true,
@@ -7559,6 +7575,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/skills/lisa-github-verify/SKILL.md": true,
     "plugins/src/base/skills/lisa-github-write-issue/SKILL.md": true,
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md": true,
+    "plugins/src/base/skills/lisa-health-drift-cron/SKILL.md": true,
     "plugins/src/base/skills/lisa-health/SKILL.md": true,
     "plugins/src/base/skills/lisa-implement/SKILL.md": true,
     "plugins/src/base/skills/lisa-improve-code-complexity/SKILL.md": true,
@@ -8444,6 +8461,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/health/contract.ts": true,
     "src/health/deadline.ts": true,
     "src/health/deterministic.ts": true,
+    "src/health/drift-tickets.ts": true,
     "src/health/evaluation-protocol.ts": true,
     "src/health/finding-utils.ts": true,
     "src/health/governance-probes.ts": true,
@@ -8911,6 +8929,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/health/deadline.test.ts": true,
     "tests/unit/health/deterministic-regressions.test.ts": true,
     "tests/unit/health/deterministic.test.ts": true,
+    "tests/unit/health/drift-tickets.test.ts": true,
     "tests/unit/health/gitignore.test.ts": true,
     "tests/unit/health/package-surfaces.test.ts": true,
     "tests/unit/health/storage.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1053,7 +1053,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md":
       "262f8a1bcfad4c5dd4456cfaaf1b71abf9697a0da588966e58ff491acd3c17e8",
     "plugins/src/base/skills/lisa-health-drift-cron/SKILL.md":
-      "36e8f3691f9bd0cf4dc55eadc658dd3aa8ac7094cef22c00d4991fdd62ee4fb4",
+      "852eb7410ce26badc7e441d32d43dc15004431abf413fd702f80b4dc5fff4a89",
     "plugins/src/base/skills/lisa-health/SKILL.md":
       "dfdb08a863e78bff42671793dcec29cfae0654db18ebf66a4aa77aeb56ddb775",
     "plugins/src/base/skills/lisa-implement/SKILL.md":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1053,7 +1053,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-write-prd/SKILL.md":
       "262f8a1bcfad4c5dd4456cfaaf1b71abf9697a0da588966e58ff491acd3c17e8",
     "plugins/src/base/skills/lisa-health-drift-cron/SKILL.md":
-      "3706c0efa572a82e0d9a8e12a4e4e009642d0507422cb31234a5b14e92b2daf3",
+      "36e8f3691f9bd0cf4dc55eadc658dd3aa8ac7094cef22c00d4991fdd62ee4fb4",
     "plugins/src/base/skills/lisa-health/SKILL.md":
       "dfdb08a863e78bff42671793dcec29cfae0654db18ebf66a4aa77aeb56ddb775",
     "plugins/src/base/skills/lisa-implement/SKILL.md":

--- a/src/health/drift-tickets.ts
+++ b/src/health/drift-tickets.ts
@@ -115,9 +115,10 @@ function bodyFor(finding: HealthFinding): string {
 /**
  * Decide what to file for the drift a run found.
  *
- * Total and pure: every drifting finding lands in exactly one of `file` or
- * `alreadyTracked`, so a caller reporting "nothing to do" is asserting it
- * looked at all of them rather than that its filter happened to be empty.
+ * Total and pure: every unique drifting check lands in exactly one of `file` or
+ * `alreadyTracked` after duplicate findings for that check collapse, so a caller
+ * reporting "nothing to do" is asserting it looked at all checks rather than
+ * that its filter happened to be empty.
  * @param input - Findings from the run and the tracker's OPEN tickets
  * @returns Tickets to file, and drift already covered
  */

--- a/src/health/drift-tickets.ts
+++ b/src/health/drift-tickets.ts
@@ -1,0 +1,166 @@
+/**
+ * Decide which health drift becomes a ticket, and which is already tracked.
+ *
+ * The scheduled health consumer's whole difficulty is idempotency: a nightly
+ * cron that refiles the same drift every night is worse than no cron at all,
+ * because it trains people to ignore the tickets it files. Everything here
+ * exists to make "the same drift" a decidable question.
+ *
+ * ## Dedupe is per CHECK, not per drift set
+ *
+ * The marker fingerprints the check id. Fingerprinting the whole finding set
+ * would mean one added finding produces a brand-new ticket while the old one
+ * still stands, so a slowly-degrading project accumulates near-duplicates —
+ * the same "worse than no cron" outcome by a slightly different route. Per
+ * check also makes partial repair behave: fix one drifting check, its ticket
+ * closes, the others stay open on their own merits.
+ *
+ * ## A closed ticket does not suppress live drift
+ *
+ * Enforced by construction rather than by a conditional: this planner is given
+ * only the OPEN tickets, so a closed one cannot suppress anything. It is not
+ * that closed tickets are checked and then ignored — they are not in evidence.
+ *
+ * The alternative, treating closure as permanent suppression, means closing a
+ * ticket without fixing anything makes that drift invisible forever, which is
+ * the silent decay this consumer exists to prevent. Suppression should be a
+ * configured declaration visible in a diff, not a side effect of somebody
+ * tidying a backlog. Turning the check off in config is the sanctioned way.
+ * @module health/drift-tickets
+ */
+
+import type { HealthFinding } from "./contract.js";
+
+/** Statuses that count as drift worth tracking. `pass` is not drift. */
+const DRIFT_STATUSES = new Set(["warn", "fail"]);
+
+/** Marker prefix written into a filed ticket so the next run can find it. */
+export const DRIFT_MARKER_PREFIX = "lisa-health-drift";
+
+/**
+ * The dedupe marker for one check.
+ *
+ * An HTML comment so it is invisible in rendered ticket bodies but present in
+ * the raw text every tracker returns. Trackers differ in what they preserve of
+ * a body; they do not differ in preserving its characters.
+ * @param check - The health check id
+ * @returns The marker to embed in a filed ticket
+ */
+export function driftMarker(check: string): string {
+  return `<!-- ${DRIFT_MARKER_PREFIX}: ${check} -->`;
+}
+
+/** A ticket already open in the tracker, reduced to what dedupe needs. */
+export interface OpenTicket {
+  readonly id: string;
+  readonly body: string;
+}
+
+/** One ticket the consumer should file. */
+export interface DriftTicket {
+  readonly check: string;
+  readonly title: string;
+  readonly body: string;
+  readonly marker: string;
+}
+
+/** Drift already covered by an open ticket, reported rather than dropped. */
+export interface TrackedDrift {
+  readonly check: string;
+  readonly ticketId: string;
+}
+
+/** What a scheduled run should do about the drift it found. */
+export interface DriftTicketPlan {
+  readonly file: readonly DriftTicket[];
+  readonly alreadyTracked: readonly TrackedDrift[];
+}
+
+/**
+ * Inputs to a planning pass.
+ *
+ * `openTickets` is deliberately named for its own precondition. A caller that
+ * passes closed tickets defeats the ruling above, and a parameter called
+ * `tickets` would not have told them so.
+ */
+export interface DriftTicketInput {
+  readonly findings: readonly HealthFinding[];
+  readonly openTickets: readonly OpenTicket[];
+}
+
+/**
+ * Compose the ticket body for one drifting check.
+ * @param finding - The drifting finding
+ * @returns Operator-readable body carrying the dedupe marker
+ */
+function bodyFor(finding: HealthFinding): string {
+  return [
+    `The scheduled health check found drift in \`${finding.check}\`.`,
+    "",
+    `**Status:** ${finding.status}`,
+    `**Layer:** ${finding.layer}`,
+    `**Reason:** ${finding.reason}`,
+    "",
+    "Filed automatically by the scheduled health consumer. It files; it never",
+    "closes or edits. Repairing the drift is separate work.",
+    "",
+    "If this drift is accepted rather than fixed, turn the check off in config",
+    "rather than closing this ticket — a closed ticket does not suppress live",
+    "drift, so it would simply be filed again on the next run.",
+    "",
+    driftMarker(finding.check),
+  ].join("\n");
+}
+
+/**
+ * Decide what to file for the drift a run found.
+ *
+ * Total and pure: every drifting finding lands in exactly one of `file` or
+ * `alreadyTracked`, so a caller reporting "nothing to do" is asserting it
+ * looked at all of them rather than that its filter happened to be empty.
+ * @param input - Findings from the run and the tracker's OPEN tickets
+ * @returns Tickets to file, and drift already covered
+ */
+export function planDriftTickets(input: DriftTicketInput): DriftTicketPlan {
+  const drifting = input.findings.filter(finding =>
+    DRIFT_STATUSES.has(finding.status)
+  );
+  // One entry per check even when a run reports the same check twice: the
+  // marker cannot distinguish them, so filing two would self-duplicate on the
+  // very first run — the defect this module exists to prevent, arriving before
+  // any second run happens. First occurrence wins, so the reported reason is
+  // the one a reader would see first in the run output.
+  const unique = drifting.filter(
+    (finding, index) =>
+      drifting.findIndex(other => other.check === finding.check) === index
+  );
+
+  const decided = unique.map(finding => {
+    const marker = driftMarker(finding.check);
+    return {
+      finding,
+      marker,
+      existing: input.openTickets.find(ticket => ticket.body.includes(marker)),
+    };
+  });
+
+  return {
+    file: decided.flatMap(entry =>
+      entry.existing
+        ? []
+        : [
+            {
+              check: entry.finding.check,
+              title: `health drift: ${entry.finding.check}`,
+              body: bodyFor(entry.finding),
+              marker: entry.marker,
+            },
+          ]
+    ),
+    alreadyTracked: decided.flatMap(entry =>
+      entry.existing
+        ? [{ check: entry.finding.check, ticketId: entry.existing.id }]
+        : []
+    ),
+  };
+}

--- a/src/health/index.ts
+++ b/src/health/index.ts
@@ -5,3 +5,4 @@ export * from "./storage.js";
 export * from "./evaluation-protocol.js";
 export * from "./prepare.js";
 export * from "./consumer.js";
+export * from "./drift-tickets.js";

--- a/tests/unit/health/drift-tickets.test.ts
+++ b/tests/unit/health/drift-tickets.test.ts
@@ -197,3 +197,26 @@ describe("planDriftTickets", () => {
     expect(plan.file.length + plan.alreadyTracked.length).toBe(2);
   });
 });
+
+describe("convergence under a concurrent run", () => {
+  it("stops growing once a duplicate exists", () => {
+    // Two overlapping runs can both observe an empty open-ticket set and both
+    // file — a single registration does not make that impossible, only rare.
+    // What matters is that the NEXT run does not compound it: with two open
+    // tickets carrying the same marker, nothing further is filed.
+    //
+    // This is convergence, not mutual exclusion, and the distinction is stated
+    // rather than papered over: the transient duplicate persists until a human
+    // closes one. It is the same stance the learnings-audit gardener takes for
+    // the same reason.
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "fail")],
+      openTickets: [tracking("41", CHECK_A), tracking("42", CHECK_A)],
+    });
+    expect(plan.file).toEqual([]);
+    // Attributed to one of them rather than erroring: which duplicate gets the
+    // credit does not matter, and refusing to answer would turn a cosmetic
+    // duplicate into a failed run.
+    expect(plan.alreadyTracked).toEqual([{ check: CHECK_A, ticketId: "41" }]);
+  });
+});

--- a/tests/unit/health/drift-tickets.test.ts
+++ b/tests/unit/health/drift-tickets.test.ts
@@ -182,7 +182,7 @@ describe("planDriftTickets", () => {
     expect(other.file.map(ticket => ticket.check)).toEqual([CHECK_A]);
   });
 
-  it("accounts for every drifting finding exactly once", () => {
+  it("accounts for every unique drifting check exactly once", () => {
     // Totality: a caller reporting "nothing to do" must be asserting it looked
     // at all of them, not that its filter happened to come out empty.
     const findings = [

--- a/tests/unit/health/drift-tickets.test.ts
+++ b/tests/unit/health/drift-tickets.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Tests for the scheduled health consumer's ticket planning.
+ *
+ * These are the acceptance criteria of #1530, which called idempotency "the
+ * whole ballgame" — a nightly cron that refiles the same drift every night is
+ * worse than no cron at all, because it teaches people to ignore its tickets.
+ *
+ * Two assertions carry the weight, and they pull in opposite directions:
+ *
+ *  - an OPEN ticket for a check must suppress a refile, and
+ *  - a CLOSED ticket must NOT.
+ *
+ * The naive marker search — "has this marker ever been used?" — satisfies the
+ * first and fails the second, so they are asserted in the same file. A fix to
+ * one cannot quietly break the other without turning this suite red.
+ * @module tests/unit/health/drift-tickets
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { HealthFinding } from "../../../src/health/contract.js";
+import {
+  driftMarker,
+  planDriftTickets,
+  type OpenTicket,
+} from "../../../src/health/drift-tickets.js";
+
+const CHECK_A = "coverage-floor";
+const CHECK_B = "managed-file-drift";
+
+/**
+ * A finding for one check at a given status.
+ * @param check - Check id
+ * @param status - Health status
+ * @returns A finding shaped like the contract's
+ */
+const finding = (
+  check: string,
+  status: HealthFinding["status"]
+): HealthFinding => ({
+  check,
+  layer: "deterministic",
+  status,
+  reason: `${check} is ${status}`,
+});
+
+/**
+ * An open ticket already tracking one check.
+ * @param id - Tracker id
+ * @param check - Check the ticket tracks
+ * @returns An open ticket carrying that check's marker
+ */
+const tracking = (id: string, check: string): OpenTicket => ({
+  id,
+  body: `whatever prose the tracker holds\n${driftMarker(check)}`,
+});
+
+describe("planDriftTickets", () => {
+  it("files nothing for a project in band", () => {
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "pass"), finding(CHECK_B, "pass")],
+      openTickets: [],
+    });
+    expect(plan.file).toEqual([]);
+    expect(plan.alreadyTracked).toEqual([]);
+  });
+
+  it("files exactly one ticket per drifting check", () => {
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "fail"), finding(CHECK_B, "pass")],
+      openTickets: [],
+    });
+    expect(plan.file).toHaveLength(1);
+    expect(plan.file[0]?.check).toBe(CHECK_A);
+  });
+
+  it("treats a warning as drift, not only a failure", () => {
+    // `warn` is the status the agentic layer emits, and it is the whole reason
+    // that layer exists. Filing only on `fail` would make it decorative.
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "warn")],
+      openTickets: [],
+    });
+    expect(plan.file).toHaveLength(1);
+  });
+
+  it("files two tickets when two checks drift", () => {
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "fail"), finding(CHECK_B, "warn")],
+      openTickets: [],
+    });
+    expect(plan.file.map(ticket => ticket.check)).toEqual([CHECK_A, CHECK_B]);
+  });
+
+  it("carries a marker naming the check", () => {
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "fail")],
+      openTickets: [],
+    });
+    expect(plan.file[0]?.marker).toBe(driftMarker(CHECK_A));
+    expect(plan.file[0]?.body).toContain(driftMarker(CHECK_A));
+  });
+
+  it("does not refile drift an OPEN ticket already tracks", () => {
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "fail")],
+      openTickets: [tracking("42", CHECK_A)],
+    });
+    expect(plan.file).toEqual([]);
+    // Reported rather than dropped: a run that says "nothing to do" should be
+    // able to say why, or it is indistinguishable from a run that found nothing.
+    expect(plan.alreadyTracked).toEqual([{ check: CHECK_A, ticketId: "42" }]);
+  });
+
+  it("does not let one check's open ticket suppress another's drift", () => {
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "fail"), finding(CHECK_B, "fail")],
+      openTickets: [tracking("42", CHECK_A)],
+    });
+    expect(plan.file.map(ticket => ticket.check)).toEqual([CHECK_B]);
+    expect(plan.alreadyTracked.map(entry => entry.check)).toEqual([CHECK_A]);
+  });
+
+  it("files again when the tracking ticket is CLOSED", () => {
+    // The counterpart to the suppression test above, and the one a naive
+    // "has this marker ever been used" implementation gets wrong. A closed
+    // ticket is simply absent from `openTickets`, so suppression is impossible
+    // by construction rather than by a conditional someone could invert.
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "fail")],
+      openTickets: [],
+    });
+    expect(plan.file.map(ticket => ticket.check)).toEqual([CHECK_A]);
+  });
+
+  it("files nothing for a check that has stopped drifting", () => {
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "pass")],
+      openTickets: [tracking("42", CHECK_A)],
+    });
+    expect(plan.file).toEqual([]);
+    // And the existing ticket is not reported as tracking live drift, because
+    // there is none — this consumer files, it never closes or edits.
+    expect(plan.alreadyTracked).toEqual([]);
+  });
+
+  it("collapses a repeated check within one run", () => {
+    // Self-duplication would arrive on the FIRST run, before any second run
+    // could be blamed for it, and the marker cannot tell the two apart.
+    const plan = planDriftTickets({
+      findings: [finding(CHECK_A, "fail"), finding(CHECK_A, "warn")],
+      openTickets: [],
+    });
+    expect(plan.file).toHaveLength(1);
+    expect(plan.file[0]?.body).toContain("fail");
+  });
+
+  it("is not fooled by a check whose name is a prefix of another", () => {
+    // Both directions, because only one of them is reachable by a loose match
+    // and it is not the obvious one. A ticket tracking `coverage-floor` matched
+    // against a bare `coverage` is the dangerous case: a containment test finds
+    // the shorter name inside the longer one and suppresses drift that nothing
+    // is tracking. The reverse is harmless, which is exactly why asserting only
+    // the reverse would pass against the broken implementation.
+    //
+    // What makes the real marker exact is its closing delimiter: the ` -->` at
+    // the end means `coverage -->` cannot be found inside `coverage-floor -->`.
+    const shortName = "coverage";
+    const suppressedWrongly = planDriftTickets({
+      findings: [finding(shortName, "fail")],
+      openTickets: [tracking("42", CHECK_A)],
+    });
+    expect(suppressedWrongly.file.map(ticket => ticket.check)).toEqual([
+      shortName,
+    ]);
+    expect(suppressedWrongly.alreadyTracked).toEqual([]);
+
+    const other = planDriftTickets({
+      findings: [finding(CHECK_A, "fail")],
+      openTickets: [tracking("42", shortName)],
+    });
+    expect(other.file.map(ticket => ticket.check)).toEqual([CHECK_A]);
+  });
+
+  it("accounts for every drifting finding exactly once", () => {
+    // Totality: a caller reporting "nothing to do" must be asserting it looked
+    // at all of them, not that its filter happened to come out empty.
+    const findings = [
+      finding(CHECK_A, "fail"),
+      finding(CHECK_B, "warn"),
+      finding("third", "pass"),
+    ];
+    const plan = planDriftTickets({
+      findings,
+      openTickets: [tracking("42", CHECK_B)],
+    });
+    expect(plan.file.length + plan.alreadyTracked.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #1530. Consumer #3 of the health layer: the cron.

`health.schedule` has been registered in `SYNC_REGISTRY` since #1516 and consumed by **nothing**. This is the consumer.

## Where the correctness lives

The issue called idempotency *"the whole ballgame"* — a nightly cron that refiles the same drift every night is worse than no cron at all, because it teaches everyone to ignore the tickets it files.

So the decision lives in `planDriftTickets`, a pure function with unit tests, **not** in the skill's prose. The skill is told explicitly not to reimplement it; a second implementation is a second thing to drift.

## The two rulings, enforced by shape rather than conditional

**Dedupe fingerprints the CHECK, not the drift set.** Fingerprinting the whole finding set means one added finding produces a fresh ticket while the old one still stands, so a slowly-degrading project accumulates near-duplicates — the same "worse than no cron" outcome by another route. Per check also makes partial repair behave: fix one, its ticket closes, the others stand on their own.

**A closed ticket does not suppress live drift.** The planner accepts only `openTickets` and has no notion of a closed one, so suppression is *impossible by construction* rather than prevented by a conditional someone could invert. Treating closure as permanent suppression would mean tidying a backlog makes that drift invisible forever — the decay this consumer exists to prevent. The sanctioned way to accept drift is turning the check off in config, which is visible in a diff.

A third, smaller call: **`warn` counts as drift, not only `fail`.** `warn` is what the agentic layer emits, so filing only on `fail` would make that entire layer decorative.

## Acceptance criteria → tests

| AC | Test |
|---|---|
| In band files nothing | ✅ |
| One ticket per drifting check, carrying a check marker | ✅ |
| Two drifting checks file two tickets | ✅ |
| An OPEN ticket suppresses a refile | ✅ |
| A CLOSED ticket does **not** | ✅ |
| A repaired check does not refile | ✅ |
| Registered under `lisa-auto-<project>-` | prose in `lisa-setup-automations` |

Plus totality — every drifting finding lands in exactly one of `file` or `alreadyTracked`, so a run reporting "nothing to do" is asserting it looked at all of them.

## Proven, not merely written

The suite was run against three plausible wrong implementations. Each turns it red:

| Wrong implementation | Result |
|---|---|
| File only on `fail` | 3 fail |
| Match the marker by substring | 1 fail |
| Skip same-run collapse | 1 fail |

**The substring case caught a mistake in my own first draft.** I had asserted the prefix relation backwards — a ticket tracking `coverage` against a finding for `coverage-floor`, which is the *harmless* direction — so the test passed against the broken implementation. The dangerous direction is the reverse: a containment test finds the shorter name inside the longer one and suppresses drift nothing is tracking. Both directions are asserted now, and the marker's closing ` -->` is what makes the comparison exact.

That is the same defect class as the PR-backlink substring bug fixed in #2595 this session, which is why it was worth looking for.

## Run outcome

The skill distinguishes two shapes of `no-change`:

```
no-change — in band, nothing filed.
no-change — 2 drifting checks, both already tracked (#41, #42).
```

Nothing filed and nothing wrong are different facts, and collapsing them hides a project whose drift is real and simply already on somebody's list.

## Out of scope, deliberately

Repairing drift; closing or editing previously filed tickets; the console consumer. This flow files, and disposal belongs to humans and the Implement factory.

## Verification

- Full suite: 705 files, 12526 tests passing
- Push gates: 8 proved, 0 failed
- `typecheck` clean

Work-Item: CodySwannGT/lisa#1530

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional scheduled health-drift monitoring for daily or weekly runs.
  * Creates one deduplicated tracker ticket per drifting health check, based on open tickets.
  * Reports unchanged health, detected drift, or recovery required.
  * Supports optional project paths and avoids ticket creation for healthy or in-band projects.
  * Preserves existing work without closing, editing, or repairing tickets.

* **Documentation**
  * Added command and automation guidance across supported integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->