### PR TITLE
fix(test): run the .mjs suites Lisa ships nothing to collect

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -82,7 +82,7 @@ on:
         # do what you asked. `scripts/check-skipped-required-checks.mjs` reports
         # exactly this as `whitespace_in_skip_token`, and the
         # `🔒 Skipped Required Checks` job below runs it on every pull request.
-        description: 'Jobs to skip. Comma-separated with NO SPACES — tokens are matched exactly, so `lint, lint_slow` silently skips nothing beyond `lint`. (lint,lint_slow,typecheck,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,bdd_coverage,state_classification,learnings_budget,threshold_ratchet,work_item_traceability,skipped_required_checks,format,build,dead_code,sg_scan,floor_collisions,npm_security_scan,zap_baseline,github_issue)'
+        description: 'Jobs to skip. Comma-separated with NO SPACES — tokens are matched exactly, so `lint, lint_slow` silently skips nothing beyond `lint`. (lint,lint_slow,typecheck,test:unit,test:mutation,test:integration,test:e2e,maestro_e2e,playwright_e2e,e2e_coverage,bdd_coverage,state_classification,learnings_budget,threshold_ratchet,work_item_traceability,skipped_required_checks,format,build,test_node_suites,dead_code,sg_scan,floor_collisions,npm_security_scan,zap_baseline,github_issue)'
         required: false
         default: ''
         type: string
@@ -2490,6 +2490,103 @@ jobs:
             exit 0
           fi
           node scripts/lisa-work-item.mjs validate-pr
+
+  test_node_suites:
+    permissions:
+      contents: read
+    name: 🧪 Run .mjs Suites
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',test_node_suites,') }}
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 🍞 Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: 📦 Install dependencies
+        run: |
+          if [ "${{ inputs.package_manager }}" = "npm" ]; then
+            npm ci
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn install --frozen-lockfile
+          elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            bun install --frozen-lockfile
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      # Gate façade — contract and fallback rationale documented in full on the
+      # 🧹 Lint job above.
+      - name: 🎛️ Resolve the mjs-suites gate
+        id: gate
+        env:
+          GATE_ID: test-node-suites
+          FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+        run: |
+          set -euo pipefail
+          if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
+          const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
+          const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
+          if (!task) return process.stdout.write("configured=false\n");
+          const runner = (require("./.lisa.config.json").gates || {}).runner || process.env.FALLBACK_RUNNER;
+          const plain = value => /^[A-Za-z0-9:._@\/= -]+$/.test(value);
+          if (!plain(task) || !plain(runner)) { console.error(`::error::gates.${id} resolves to "${runner} ${task}", which is not a plain command.`); process.exit(1); }
+          process.stdout.write(`configured=true\nrunner=${runner}\ntask=${task}\n`); });
+          ' >> "$GITHUB_OUTPUT"
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧪 Run the mjs-suites gate
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          GATE_RUNNER: ${{ steps.gate.outputs.runner }}
+          GATE_TASK: ${{ steps.gate.outputs.task }}
+        # Deliberate word split, as on every other façade job.
+        run: $GATE_RUNNER $GATE_TASK
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧪 Run .mjs suites (lisa-test-node)
+        # DELIBERATE DIVERGENCE from the façade's fallback contract, which
+        # elsewhere reproduces "today's behavior" byte for byte for an
+        # unmigrated project.
+        #
+        # For this gate today's behavior is NOTHING — that is the defect. Lisa
+        # ships nine `.mjs` guards to every project and four more to expo
+        # consumers, and every test config Lisa ships collects only `.ts`/`.tsx`,
+        # so a consumer who writes a test beside one of those guards gets a
+        # suite that never runs and a green build saying so. Measured downstream:
+        # 37 such suites, 13 enforced by nothing, 229 stranded test cases.
+        #
+        # Preserving "nothing" would make the fix opt-in, which is the half
+        # measure this exists to avoid. So the fallback RUNS the shipped script.
+        # `test:node` is force-installed by the package templates, so it is
+        # present in any project that has applied Lisa.
+        #
+        # The script is loud about collecting zero: `node --test` exits 0 on a
+        # glob that matches nothing, so a project with genuinely no `.mjs`
+        # suites passes — but says so in the transcript rather than silently.
+        if: steps.gate.outputs.configured != 'true'
+        run: |
+          if [ -f scripts/lisa-test-node.mjs ]; then
+            node scripts/lisa-test-node.mjs
+          else
+            echo "::warning::scripts/lisa-test-node.mjs is absent — re-apply Lisa to install it. No .mjs suites were run."
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
 
   dead_code:
     permissions:

--- a/all/copy-overwrite/scripts/lisa-gates.mjs
+++ b/all/copy-overwrite/scripts/lisa-gates.mjs
@@ -42,9 +42,16 @@
  * "Review rate limited", having reviewed nothing, on two security-relevant pull
  * requests that then merged. That is the `await` form, caught by description.
  *
- * `passWithNoTests: true` ships in five stack configs, so a unit-test gate can
- * report green having run zero tests. That is the `run` form, caught by a work
- * count. No description is involved and no vendor is at fault.
+ * `passWithNoTests: true` USED TO ship in five stack configs, so a unit-test
+ * gate could report green having run zero tests. That is the `run` form, caught
+ * by a work count. No description is involved and no vendor is at fault.
+ *
+ * That flag is gone as of #2603 — from the configs AND from the six
+ * `--passWithNoTests` CLI arguments in four package templates, which overrode
+ * the configs and were the channel most consumers actually ran. The example is
+ * kept in the past tense rather than deleted: it is the clearest instance of
+ * the `run` form anyone has produced, and a reader needs to know what shape to
+ * look for, not merely that one instance was fixed.
  *
  * The response is configurable, with one exception. You may configure whether
  * to stop; you may not configure it into having been proved. A hollow result is
@@ -189,6 +196,13 @@ export const REGISTRY = Object.freeze({
     task: "test:unit",
     moments: PUSH_ONWARD,
     work: "tests run",
+  },
+  "test-node-suites": {
+    label: "🧪 Run .mjs Suites",
+    summary: "The `*.test.mjs` suites pass.",
+    task: "test:node",
+    moments: PUSH_ONWARD,
+    work: "suites collected",
   },
   "test-integration": {
     label: "🧪 Run Integration Tests",

--- a/all/copy-overwrite/scripts/lisa-test-node.mjs
+++ b/all/copy-overwrite/scripts/lisa-test-node.mjs
@@ -33,10 +33,9 @@
  * have reproduced the bug inside its own fix.
  *
  * So collection is done here, explicitly, and **the count is always printed**.
- * Zero collected is a legitimate answer — a project may simply have no such
- * tests — but it is never a silent one. Anyone reading the log can tell "ran
- * nothing" from "ran everything and all passed", which is precisely the
- * distinction that was missing.
+ * Zero collected is a failure, not a quiet pass. A project that genuinely has no
+ * such tests should disable the gate in `.lisa.config.json`, where the decision
+ * is visible and the required context is dropped instead of vacuously satisfied.
  *
  * ## What this does NOT do
  *
@@ -133,13 +132,13 @@ export function main({ write, cwd, exec } = {}) {
   out(`lisa-test-node: collected ${files.length} *.test.mjs suite(s)\n`);
   for (const file of files) out(`  ${file}\n`);
   if (!files.length) {
-    // Reported, never silent. See the module note on why zero is legitimate
-    // but must be visible.
+    // Reported, never silent, and never green: empty collection is the defect
+    // this runner exists to prevent.
     out(
       "lisa-test-node: nothing to run. This is only correct if this project " +
         "genuinely has no .mjs suites.\n"
     );
-    return 0;
+    return 1;
   }
   return exec ? run(files, exec) : run(files);
 }

--- a/all/copy-overwrite/scripts/lisa-test-node.mjs
+++ b/all/copy-overwrite/scripts/lisa-test-node.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
+/**
+ * lisa-test-node — run the `*.test.mjs` suites nothing else collects.
+ *
+ * ## Why this exists
+ *
+ * Lisa distributes guard scripts as `.mjs` — nine to every project via
+ * `all/copy-overwrite/scripts/`, four more to expo consumers — and every test
+ * config Lisa ships restricts collection to `.ts`/`.tsx`. `.mjs` is an
+ * extension those globs cannot express, so a consumer who does the responsible
+ * thing and writes a test beside one of those guards gets a suite that never
+ * runs, and a green build saying so.
+ *
+ * Measured downstream before this was written: 37 `*.test.mjs` files, 13
+ * enforced by nothing at all, 229 stranded test cases.
+ *
+ * ## Why a wrapper rather than `node --test "**\/*.test.mjs"` in a script
+ *
+ * Two reasons, both measured rather than assumed.
+ *
+ * **The glob descends into `node_modules`.** In this repository
+ * `**\/*.test.ts` matches 1175 files, 470 of them vendored. Handing that to
+ * `node --test` runs other people's suites, which at best is slow and at worst
+ * reports their failures as yours.
+ *
+ * **`node --test` exits 0 when its glob matches nothing.** Verified on
+ * v22.22.0: a pattern with no matches produces a clean run and status 0. That
+ * is the same "empty collection is a green collection" defect this script was
+ * written to end, sitting inside the tool meant to end it. A bare script would
+ * have reproduced the bug inside its own fix.
+ *
+ * So collection is done here, explicitly, and **the count is always printed**.
+ * Zero collected is a legitimate answer — a project may simply have no such
+ * tests — but it is never a silent one. Anyone reading the log can tell "ran
+ * nothing" from "ran everything and all passed", which is precisely the
+ * distinction that was missing.
+ *
+ * ## What this does NOT do
+ *
+ * It does not verify that every `*.test.mjs` on disk is reachable from a
+ * runner. That is a different question — a glob narrowed later would quietly
+ * shrink what this collects, which is exactly how the original defect arose —
+ * and it belongs to a guard that enumerates from disk independently rather
+ * than to the runner whose own glob is the thing under suspicion.
+ * @module lisa-test-node
+ */
+
+import { spawnSync } from "node:child_process";
+import { globSync, realpathSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Files matching this are candidate suites. */
+export const TEST_GLOB = "**/*.test.mjs";
+
+/**
+ * Path segments whose contents are never this project's tests.
+ *
+ * Matched as path segments, not substrings: a project directory legitimately
+ * named `distribution` must not be excluded because it starts with `dist`.
+ */
+export const EXCLUDED_SEGMENTS = Object.freeze([
+  "node_modules",
+  "dist",
+  "build",
+  ".git",
+  ".lisabak",
+  "worktrees",
+  ".worktrees",
+]);
+
+/**
+ * Whether a matched path belongs to this project rather than to a dependency,
+ * a build output, or another checkout parked inside the tree.
+ * @param {string} relativePath - Path relative to the project root.
+ * @returns {boolean} True when the file is this project's own test.
+ */
+export function isOwnTest(relativePath) {
+  return !relativePath
+    .split(path.sep)
+    .some(segment => EXCLUDED_SEGMENTS.includes(segment));
+}
+
+/**
+ * The suites this runner will execute, sorted for a stable transcript.
+ * @param {string} [cwd] - Project root to search.
+ * @returns {string[]} Project-relative paths.
+ */
+export function collect(cwd = process.cwd()) {
+  return globSync(TEST_GLOB, { cwd })
+    .filter(isOwnTest)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+/**
+ * Run the collected suites.
+ *
+ * The file list is passed explicitly rather than as a glob, so what runs is
+ * exactly what was reported as collected — the log cannot describe one set
+ * while the runner executes another.
+ * @param {string[]} files - Suites to run.
+ * @param {Function} [exec] - Spawner, injected for tests.
+ * @returns {number} Exit status.
+ */
+export function run(files, exec = spawnSync) {
+  const result = exec(process.execPath, ["--test", ...files], {
+    stdio: "inherit",
+  });
+  // A signal-killed child reports a null status. Treating that as 0 would call
+  // an interrupted run a pass, which is the defect this file exists to remove.
+  return typeof result.status === "number" ? result.status : 1;
+}
+
+/**
+ * CLI entry point.
+ *
+ * The writer and the project root are injected rather than reached for, so a
+ * test can assert what the transcript SAYS without redirecting the real stdout
+ * or changing the process working directory. The empty case is the one that
+ * has to be asserted on output, so making that assertable is the point.
+ * @param {object} [io] - Injection seam.
+ * @param {Function} [io.write] - Line sink; defaults to stdout.
+ * @param {string} [io.cwd] - Project root to search.
+ * @param {Function} [io.exec] - Spawner passed through to {@link run}.
+ * @returns {number} Exit status.
+ */
+export function main({ write, cwd, exec } = {}) {
+  const out = write ?? (text => process.stdout.write(text));
+  const files = collect(cwd);
+  out(`lisa-test-node: collected ${files.length} *.test.mjs suite(s)\n`);
+  for (const file of files) out(`  ${file}\n`);
+  if (!files.length) {
+    // Reported, never silent. See the module note on why zero is legitimate
+    // but must be visible.
+    out(
+      "lisa-test-node: nothing to run. This is only correct if this project " +
+        "genuinely has no .mjs suites.\n"
+    );
+    return 0;
+  }
+  return exec ? run(files, exec) : run(files);
+}
+
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd: `import.meta.url` is the real path while
+ * `argv[1]` is whatever the caller typed, so through a symlinked checkout, a
+ * git worktree, or a `/tmp` path on macOS a raw comparison is false and the
+ * body never runs — for a test runner, exiting 0 having run nothing.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the CLI body should run.
+ */
+export function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
+  process.exit(main());
+}

--- a/cdk/package-lisa/package.lisa.json
+++ b/cdk/package-lisa/package.lisa.json
@@ -8,12 +8,13 @@
       "prepare": "husky install || true",
       "test": "vitest run",
       "test:unit": "vitest run --exclude='**/integration/**'",
-      "test:integration": "vitest run tests/integration --passWithNoTests",
+      "test:integration": "vitest run tests/integration",
       "test:cov": "vitest run --coverage",
       "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "vitest",
       "lint": "oxlint && eslint . --quiet",
-      "lint:fix": "oxlint --fix && eslint . --fix"
+      "lint:fix": "oxlint --fix && eslint . --fix",
+      "test:node": "node scripts/lisa-test-node.mjs"
     },
     "dependencies": {
       "aws-cdk-github-oidc": "^2.4.1",

--- a/docs/design/gates-and-policy.md
+++ b/docs/design/gates-and-policy.md
@@ -20,7 +20,7 @@ through:
 | advisory-and-confusable | a not-required `🧪 Run Tests` beside the required `🧪 Run Unit Tests` merged red on two PRs (#2485) |
 | passing-with-no-work | `passWithNoTests: true` shipped in five stack configs AND as six `--passWithNoTests` CLI arguments in four package templates, which overrode the configs — so a unit-test gate reported green having run zero tests (removed from both channels, #2603) |
 | declared-but-uncallable | `secrets.require` was documented as a startup assertion whose only caller was a bash line inside a SKILL.md |
-| enforced-off-the-path | 23 of 37 `.test.mjs` suites downstream were wired only into `.husky/pre-push.local` (measured); a pre-push hook cannot run on the merge path — auto-merge, a UI merge, a CI-side change, a `[skip ci]` commit — so a pass/fail guard would have called them protected. The count is measured; the non-firing is inferred from how git hooks work, not observed |
+| enforced-off-the-path | 23 of 37 `.test.mjs` suites downstream were wired only into `.husky/pre-push.local` (measured); a pre-push hook cannot run where no local push happens — auto-merge, a merge performed in the UI, a change committed CI-side — so a pass/fail guard would have called them protected. The count is measured; the non-firing is inferred from how git hooks work, not observed. (`[skip ci]` is the converse and does NOT belong here: the hook fires, CI does not — a gap in the other direction) |
 | verified-then-invalidated | gates ran alphabetically, so `artifact-freshness` proved the evidence manifest current and `code-style` then reformatted the sources it hashes — a PASSED verdict about a tree that was not the tree committed (#2590) |
 
 The rule that falls out, and the one to apply when a new case is ambiguous:

--- a/docs/design/gates-and-policy.md
+++ b/docs/design/gates-and-policy.md
@@ -246,6 +246,33 @@ That rule earned itself before shipping: three contexts currently required on
 produce no derived context, so a ruleset regenerated from config alone would
 have dropped them.
 
+## A template change lands on a schedule nobody chose
+
+Consumer `package.json` scripts are Lisa-managed through the `package-lisa`
+merge, and `bun install` runs `lisa apply` in the consumer repos. So a template
+edit does not reach a project when someone decides to take it — it reaches them
+at **the next arbitrary developer's or agent's install**, mid-session, to
+somebody who never read the pull request.
+
+That is fine when the change is additive. It is not fine when the change removes
+a tolerance, which is exactly the shape of "no backward compatibility" work:
+deleting `--passWithNoTests` from four package templates changes what a green
+build means, for four repositories, at an unpredictable moment.
+
+**So verify the blast radius is empty BEFORE merging, not after.** For #2603 that
+meant enumerating every consumer's integration-test collection and confirming
+none was empty — four repositories, measured, before the flag was removed. Had
+one been empty, the correct response was to stage its declaration first and
+merge second, not to merge and let it be discovered at install time.
+
+The residual risk is honest and worth naming: a consumer that appears *later*
+with an empty collection meets the change at install time with no warning. A
+measured-empty blast radius is a statement about the consumers that exist today,
+not a property of the change.
+
+Credit for the principle to the session that measured it rather than to this
+document.
+
 ## The interface is the evidence shape
 
 A task name is not an interface. If Lisa standardises only *how to invoke*, the

--- a/docs/design/gates-and-policy.md
+++ b/docs/design/gates-and-policy.md
@@ -10,7 +10,7 @@ Tracking issue: CodySwannGT/lisa#2579.
 
 Every decision below is downstream of one failure mode: **a check reporting
 satisfied without having proved anything.** It has appeared in this repository in
-at least six distinct forms, each found only after it had already let something
+at least seven distinct forms, each found only after it had already let something
 through:
 
 | form | evidence |
@@ -18,8 +18,9 @@ through:
 | required-and-skipped | GitHub counts a SKIPPED required check as SATISFIED, so a job named in `skip_jobs` reports green having run zero steps |
 | required-and-hollow | a required `CodeRabbit` context posted `success` with description `Review rate limited`, having reviewed nothing, on two security-relevant PRs that merged (#2497) |
 | advisory-and-confusable | a not-required `🧪 Run Tests` beside the required `🧪 Run Unit Tests` merged red on two PRs (#2485) |
-| passing-with-no-work | `passWithNoTests: true` ships in five stack configs, so a unit-test gate can report green having run zero tests |
+| passing-with-no-work | `passWithNoTests: true` shipped in five stack configs AND as six `--passWithNoTests` CLI arguments in four package templates, which overrode the configs — so a unit-test gate reported green having run zero tests (removed from both channels, #2603) |
 | declared-but-uncallable | `secrets.require` was documented as a startup assertion whose only caller was a bash line inside a SKILL.md |
+| enforced-off-the-path | a `.test.mjs` suite wired only into `.husky/pre-push.local` is real and does bite, but a pre-push hook never fires for auto-merge, a UI merge, a CI-side change, or a `[skip ci]` commit — measured downstream at 23 of 37 suites, which a pass/fail guard would have called protected |
 | verified-then-invalidated | gates ran alphabetically, so `artifact-freshness` proved the evidence manifest current and `code-style` then reformatted the sources it hashes — a PASSED verdict about a tree that was not the tree committed (#2590) |
 
 The rule that falls out, and the one to apply when a new case is ambiguous:

--- a/docs/design/gates-and-policy.md
+++ b/docs/design/gates-and-policy.md
@@ -20,7 +20,7 @@ through:
 | advisory-and-confusable | a not-required `🧪 Run Tests` beside the required `🧪 Run Unit Tests` merged red on two PRs (#2485) |
 | passing-with-no-work | `passWithNoTests: true` shipped in five stack configs AND as six `--passWithNoTests` CLI arguments in four package templates, which overrode the configs — so a unit-test gate reported green having run zero tests (removed from both channels, #2603) |
 | declared-but-uncallable | `secrets.require` was documented as a startup assertion whose only caller was a bash line inside a SKILL.md |
-| enforced-off-the-path | a `.test.mjs` suite wired only into `.husky/pre-push.local` is real and does bite, but the hook is not invoked for server-side merge paths and provides no CI-path enforcement for CI-side pushes or `[skip ci]` commits — measured downstream at 23 of 37 suites, which a pass/fail guard would have called protected |
+| enforced-off-the-path | 23 of 37 `.test.mjs` suites downstream were wired only into `.husky/pre-push.local` (measured); a pre-push hook cannot run on the merge path — auto-merge, a UI merge, a CI-side change, a `[skip ci]` commit — so a pass/fail guard would have called them protected. The count is measured; the non-firing is inferred from how git hooks work, not observed |
 | verified-then-invalidated | gates ran alphabetically, so `artifact-freshness` proved the evidence manifest current and `code-style` then reformatted the sources it hashes — a PASSED verdict about a tree that was not the tree committed (#2590) |
 
 The rule that falls out, and the one to apply when a new case is ambiguous:

--- a/docs/design/gates-and-policy.md
+++ b/docs/design/gates-and-policy.md
@@ -20,7 +20,7 @@ through:
 | advisory-and-confusable | a not-required `🧪 Run Tests` beside the required `🧪 Run Unit Tests` merged red on two PRs (#2485) |
 | passing-with-no-work | `passWithNoTests: true` shipped in five stack configs AND as six `--passWithNoTests` CLI arguments in four package templates, which overrode the configs — so a unit-test gate reported green having run zero tests (removed from both channels, #2603) |
 | declared-but-uncallable | `secrets.require` was documented as a startup assertion whose only caller was a bash line inside a SKILL.md |
-| enforced-off-the-path | a `.test.mjs` suite wired only into `.husky/pre-push.local` is real and does bite, but a pre-push hook never fires for auto-merge, a UI merge, a CI-side change, or a `[skip ci]` commit — measured downstream at 23 of 37 suites, which a pass/fail guard would have called protected |
+| enforced-off-the-path | a `.test.mjs` suite wired only into `.husky/pre-push.local` is real and does bite, but the hook is not invoked for server-side merge paths and provides no CI-path enforcement for CI-side pushes or `[skip ci]` commits — measured downstream at 23 of 37 suites, which a pass/fail guard would have called protected |
 | verified-then-invalidated | gates ran alphabetically, so `artifact-freshness` proved the evidence manifest current and `code-style` then reformatted the sources it hashes — a PASSED verdict about a tree that was not the tree committed (#2590) |
 
 The rule that falls out, and the one to apply when a new case is ambiguous:

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -51,15 +51,16 @@
       "eas:publish:staging": "eas update --channel staging --environment preview --non-interactive",
       "eas:publish:production": "eas update --channel production --environment production --non-interactive",
       "security:zap": "bash scripts/zap-baseline.sh",
-      "test": "NODE_ENV=test jest --passWithNoTests",
-      "test:unit": "NODE_ENV=test jest --testPathIgnorePatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
-      "test:integration": "NODE_ENV=test jest --testPathPatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\" --passWithNoTests",
+      "test": "NODE_ENV=test jest",
+      "test:unit": "NODE_ENV=test jest --testPathIgnorePatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\"",
+      "test:integration": "NODE_ENV=test jest --testPathPatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\"",
       "test:cov": "NODE_ENV=test jest --coverage",
       "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "NODE_ENV=test jest --watch",
       "lint": "oxlint && eslint . --quiet",
       "lint:fix": "oxlint --fix && eslint . --fix",
-      "start:atlas": "cp .env.development .env.local && STAGE=development EXPO_ATLAS=true expo start"
+      "start:atlas": "cp .env.development .env.local && STAGE=development EXPO_ATLAS=true expo start",
+      "test:node": "node scripts/lisa-test-node.mjs"
     },
     "dependencies": {
       "@apollo/client": "^3.10.8",

--- a/harper-fabric/package-lisa/package.lisa.json
+++ b/harper-fabric/package-lisa/package.lisa.json
@@ -19,7 +19,8 @@
       "stop": "harperdb stop",
       "status": "harperdb status",
       "reset": "harperdb stop || true; [ -n \"$HOME\" ] && rm -rf \"$HOME/.harperdb\" && bun run bootstrap && bun run seed && bun run verify",
-      "prepare": "husky install || true"
+      "prepare": "husky install || true",
+      "test:node": "node scripts/lisa-test-node.mjs"
     },
     "dependencies": {
       "harperdb": "^4.7.29"

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -41,12 +41,13 @@
       "security:zap": "bash scripts/zap-baseline.sh",
       "test": "vitest run",
       "test:unit": "vitest run --exclude='**/integration/**'",
-      "test:integration": "vitest run '.integration.' --passWithNoTests",
+      "test:integration": "vitest run '.integration.'",
       "test:cov": "vitest run --coverage",
       "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "vitest",
       "lint": "oxlint && eslint . --quiet",
-      "lint:fix": "oxlint --fix && eslint . --fix"
+      "lint:fix": "oxlint --fix && eslint . --fix",
+      "test:node": "node scripts/lisa-test-node.mjs"
     },
     "dependencies": {
       "@apollo/server": "^5.4.0",

--- a/phaser/package-lisa/package.lisa.json
+++ b/phaser/package-lisa/package.lisa.json
@@ -14,7 +14,8 @@
       "knip:fix": "knip --fix",
       "sg:scan": "ast-grep scan",
       "sg:test": "ast-grep test",
-      "prepare": "husky install || true"
+      "prepare": "husky install || true",
+      "test:node": "node scripts/lisa-test-node.mjs"
     },
     "devDependencies": {
       "@ast-grep/cli": "^0.40.4",

--- a/src/configs/vitest/cdk.ts
+++ b/src/configs/vitest/cdk.ts
@@ -63,9 +63,6 @@ export const getCdkVitestConfig = ({
   test: {
     globals: true,
     environment: "node",
-    // Repos with no test files must not fail the pre-push/CI gate; vitest exits 1
-    // on "No test files found" otherwise. See typescript.ts for rationale.
-    passWithNoTests: true,
     include: [
       "test/**/*.test.ts",
       "test/**/*.spec.ts",

--- a/src/configs/vitest/harper-fabric.ts
+++ b/src/configs/vitest/harper-fabric.ts
@@ -46,9 +46,6 @@ export const getHarperFabricVitestConfig = ({
   test: {
     globals: true,
     environment: "node",
-    // Repos with no test files must not fail the pre-push/CI gate; vitest exits 1
-    // on "No test files found" otherwise. See typescript.ts for rationale.
-    passWithNoTests: true,
     include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
     exclude: [...defaultTestExclusions],
     testTimeout: 10000,

--- a/src/configs/vitest/nestjs.ts
+++ b/src/configs/vitest/nestjs.ts
@@ -87,9 +87,6 @@ export const getNestjsVitestConfig = ({
     globals: true,
     environment: "node",
     root: "src",
-    // Repos with no spec files must not fail the pre-push/CI gate; vitest exits 1
-    // on "No test files found" otherwise. See typescript.ts for rationale.
-    passWithNoTests: true,
     include: ["**/*.spec.ts"],
     exclude: [...defaultTestExclusions, ...worktreeExclusions()],
     testTimeout: 10000,

--- a/src/configs/vitest/phaser.ts
+++ b/src/configs/vitest/phaser.ts
@@ -49,9 +49,6 @@ export const getPhaserVitestConfig = ({
   test: {
     globals: true,
     environment: "node",
-    // Repos with no test files must not fail the pre-push/CI gate; vitest exits 1
-    // on "No test files found" otherwise. See typescript.ts for rationale.
-    passWithNoTests: true,
     include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
     exclude: [...defaultTestExclusions, "tests/e2e/**"],
     testTimeout: 10000,

--- a/src/configs/vitest/typescript.ts
+++ b/src/configs/vitest/typescript.ts
@@ -60,11 +60,6 @@ export const getTypescriptVitestConfig = ({
   test: {
     globals: true,
     environment: "node",
-    // Source-less/test-less repos (e.g. infra-only TypeScript projects) have no
-    // test files; vitest exits 1 on "No test files found", which fails the
-    // pre-push/CI gates with nothing to fix. Treat zero tests as intentional —
-    // the test-world analog of allowing `files: []` in tsconfig for zero sources.
-    passWithNoTests: true,
     include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
     exclude: [...defaultTestExclusions, ...worktreeExclusions()],
     testTimeout: 10000,

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -195,6 +195,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "cc4270e365f53c60a5eefb58a8ac8e22be184c0821fcdcc8fe67bcfc1df5e3dd",
     "dbca450e5a17133841ab015e71808feb028996f8297fda362dbeca4f07af2352",
     "e7d928c3b2d878c7a9ec9589894dfc3feaba54b8913c87be0550c34a1431ed9f",
+    "f0343c4ef3fde6576362eeb52e1ae3855108eba9d5034ccec8478db0637935d8",
     "fbd68cf571985d7cfccf0f280cfe8112955849126e44d27d55ad619f9abb79ef",
   ]),
   "scripts/lisa-hooks/block-direct-issue-create.sh": Object.freeze([
@@ -281,6 +282,9 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",
     "4a05a0ed70a274827fd2f0fd0c98890c66bee2fde70785b8379943ebe6650473",
     "9dd145c0f9dac6ed252b13d32e130dbab964da6cd357981b58541780ecb2f981",
+  ]),
+  "scripts/lisa-test-node.mjs": Object.freeze([
+    "c2b0f436107de5de0f616090012b48752bbbb47dd0add20098662faac0f5f677",
   ]),
   "scripts/lisa-work-item.mjs": Object.freeze([
     "04f78df45465d01601c8b5711b74749b2a2c2b70b9c916d6790bd69e1c11865d",

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -284,6 +284,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "9dd145c0f9dac6ed252b13d32e130dbab964da6cd357981b58541780ecb2f981",
   ]),
   "scripts/lisa-test-node.mjs": Object.freeze([
+    "31b338144af00e20e3de02202982846d7333433a9bbda76a8c77d50e6fdbc47b",
     "c2b0f436107de5de0f616090012b48752bbbb47dd0add20098662faac0f5f677",
   ]),
   "scripts/lisa-work-item.mjs": Object.freeze([

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -39,7 +39,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs":
       "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",
     "all/copy-overwrite/scripts/lisa-test-node.mjs":
-      "c2b0f436107de5de0f616090012b48752bbbb47dd0add20098662faac0f5f677",
+      "31b338144af00e20e3de02202982846d7333433a9bbda76a8c77d50e6fdbc47b",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
       "d89d1d6c365dac268cada974179c4152833fd6894287856a9e95adc03fabeff8",
     "all/copy-overwrite/scripts/schemas/lisa-command-envelope.v1.schema.json":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -19,7 +19,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
       "2d11968f6852ab745cba939de03c6d6cb5f413975d2cfc8fc447bdd0b218e91a",
     "all/copy-overwrite/scripts/lisa-gates.mjs":
-      "fbd68cf571985d7cfccf0f280cfe8112955849126e44d27d55ad619f9abb79ef",
+      "f0343c4ef3fde6576362eeb52e1ae3855108eba9d5034ccec8478db0637935d8",
     "all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh":
       "8d1f04ef5c5da9db9190e22b37a435e118e39d6e7deafc5402b4593c8e9db2b2",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
@@ -38,6 +38,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "d078570b2a7964eb481cd05e118e2a6559968020392c6e570d90cec8f20c5487",
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs":
       "2ace82daacdebbbb00a7eceb09fbe82cabec04330a083ca10417b2ee4e0a63eb",
+    "all/copy-overwrite/scripts/lisa-test-node.mjs":
+      "c2b0f436107de5de0f616090012b48752bbbb47dd0add20098662faac0f5f677",
     "all/copy-overwrite/scripts/lisa-work-item.mjs":
       "d89d1d6c365dac268cada974179c4152833fd6894287856a9e95adc03fabeff8",
     "all/copy-overwrite/scripts/schemas/lisa-command-envelope.v1.schema.json":
@@ -105,7 +107,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "cdk/merge/.oxlintrc.json":
       "f7d248cf8a89561374d7e68e24aa780f4a6a523938475ad685f034ce0194d75c",
     "cdk/package-lisa/package.lisa.json":
-      "6eb9a4cea78747750d6efadb7a142a349bc8572ed5e5d109f8b71d862ed4e45d",
+      "36d3cc0e6c1cf5496f82e37b452ba3fa07b3d43427e0d48f574cc53e5d2dabf5",
     "eslint-plugin-code-organization/README.md":
       "7943820d0b301041f764d4b33adc3c8afbd5bf08f800989390233e78962a51de",
     "eslint-plugin-code-organization/__tests__/enforce-statement-order.test.js":
@@ -271,7 +273,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/merge/.oxlintrc.json":
       "95b3069256c0040be0ef1a5adae46d14687ad56fb18f473a653ba2de45d106bb",
     "expo/package-lisa/package.lisa.json":
-      "34c4a356db67fa55d715a7bb4dafac8249a3793cd330bc920cd1769b58fcdcd0",
+      "a420d08893e891e543c9a3a8d1c8da9df1c0eef802a9570d0c6f7402d2487501",
     "harper-fabric/copy-contents/.prettierignore":
       "478c782f4c5611187e21584dfd5522e37fc636c5eb03394fea3db45321c6712c",
     "harper-fabric/copy-contents/gitignore":
@@ -313,7 +315,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "harper-fabric/merge/.oxlintrc.json":
       "b41ea588eed47e0f1532aab5f6226b82586269b84edd1947bdde603e0a8513fa",
     "harper-fabric/package-lisa/package.lisa.json":
-      "9202ce3a521c3f01da0b663d02263c8f8d40977659c34dedd9beb7b483b8f317",
+      "491d9c89003f7004eb1e5f8493e956371d89d687168ec8763ec6631ab842e93c",
     "nestjs/copy-overwrite/eslint.config.ts":
       "300895743cd8e3041f164902e1c8e509d8ef07474848a70621ac354d73595477",
     "nestjs/copy-overwrite/eslint.nestjs.ts":
@@ -401,7 +403,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/merge/.oxlintrc.json":
       "1de29d135744df0258e8659ee0b684acf84e687bbefade51db0576813e6ff097",
     "nestjs/package-lisa/package.lisa.json":
-      "f54fbe079e12caa89f1b768a851e71cd1c30e37918ca309c50add4379102381d",
+      "a6e3f4d0806e4c0b1f5a6730aebfb0ee9cddf3c16a6202381c055ffe3b481364",
     "npm-package/create-only/.github/workflows/publish-to-npm.yml":
       "1d051007a328ba4f6c67a5e3123593921b823e0866c05343c4588a6156e9f593",
     "npm-package/package-lisa/package.lisa.json":
@@ -459,7 +461,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "phaser/merge/.oxlintrc.json":
       "02c0d70e6e07bc0e981f94a1e2ccd01a2c295c4c66e8b8ea9b2f363d44fa5c06",
     "phaser/package-lisa/package.lisa.json":
-      "9cc4e080742e094b1c6c6e76e53f03887f2b096fc0f15b9417c0238ed36cea2e",
+      "2e121731930572541bf14d716757d42190ba1dc97fa2a5ce3dcd74b5f506f8ae",
     "plugins/src/base/agents/architecture-specialist.md":
       "076feb3a09ef056628bc33242f93278ce6b00f55878984a18a9337d326b5e1d4",
     "plugins/src/base/agents/bug-fixer.md":
@@ -2389,7 +2391,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/merge/.oxlintrc.json":
       "9504c20db80470c242c4ffe8cccad6951ed8141dfb5bf6503053e0b2712ab276",
     "typescript/package-lisa/package.lisa.json":
-      "ca736c6808d58efdea16abfbe2256a8318bc6d14b035951c1293f7c283919932",
+      "5e95a901e0aa4e0c120cef2055b1ba8961fad7c01ce47529487f395d581f18dd",
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
@@ -2564,6 +2566,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-overwrite/scripts/lisa-reconcile-policy.mjs": true,
     "all/copy-overwrite/scripts/lisa-run-gates.mjs": true,
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs": true,
+    "all/copy-overwrite/scripts/lisa-test-node.mjs": true,
     "all/copy-overwrite/scripts/lisa-work-item.mjs": true,
     "all/copy-overwrite/scripts/schemas/lisa-command-envelope.v1.schema.json": true,
     "all/copy-overwrite/scripts/schemas/lisa-state-contract.v1.schema.json": true,
@@ -9070,6 +9073,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/lisa-run-gates-floor.test.ts": true,
     "tests/unit/scripts/lisa-run-gates-shared-prover.test.ts": true,
     "tests/unit/scripts/lisa-run-gates.test.ts": true,
+    "tests/unit/scripts/lisa-test-node.test.ts": true,
     "tests/unit/scripts/lisa-work-item.test.ts": true,
     "tests/unit/scripts/maestro-flake-classification.test.ts": true,
     "tests/unit/scripts/maestro-flake-helpers.ts": true,

--- a/tests/unit/config/vitest-typescript.test.ts
+++ b/tests/unit/config/vitest-typescript.test.ts
@@ -38,10 +38,18 @@ describe("vitest.typescript", () => {
       expect(config.test?.testTimeout).toBe(10000);
     });
 
-    it("passes with no tests so source-less repos do not fail the gate", () => {
+    it("does NOT pass with no tests — an empty collection must be red", () => {
+      // Inverted deliberately. This flag turned "collected nothing" into a
+      // green run, which is how seven shipped configs could restrict collection
+      // to .ts/.tsx while .mjs suites went unrun and unnoticed: the narrow
+      // include produced empty collections and this made that comfortable.
+      //
+      // A project that genuinely has no tests for a gate now declares that gate
+      // `off` in .lisa.config.json — which is visible in a diff and drops the
+      // required context, instead of vacuously satisfying it.
       const config = getTypescriptVitestConfig();
 
-      expect(config.test?.passWithNoTests).toBe(true);
+      expect(config.test?.passWithNoTests).toBeUndefined();
     });
 
     it("uses v8 coverage provider", () => {

--- a/tests/unit/scripts/lisa-test-node.test.ts
+++ b/tests/unit/scripts/lisa-test-node.test.ts
@@ -2,8 +2,7 @@
  * Tests for the `.mjs` suite runner.
  *
  * The assertions that carry weight are the two silences this script exists to
- * break, and neither is visible from an exit code — so neither is asserted by
- * one. `node --test` exits 0 when its glob matches nothing, and that glob
+ * break. `node --test` exits 0 when its glob matches nothing, and that glob
  * descends into `node_modules`, so the naive one-line script would both run
  * other people's suites and report a clean pass having run none of yours.
  * @module tests/unit/scripts/lisa-test-node
@@ -149,12 +148,12 @@ describe("run", () => {
 });
 
 describe("main", () => {
-  it("reports the empty case out loud rather than exiting quietly", () => {
-    // `node --test` exits 0 on a glob matching nothing, so the exit code
-    // cannot carry this distinction. The transcript has to.
+  it("fails the empty case out loud rather than exiting quietly", () => {
+    // `node --test` exits 0 on a glob matching nothing, so this wrapper must
+    // make the empty collection explicit and red.
     const out = transcript();
     const status = main({ write: out.write, cwd: project([]) });
-    expect(status).toBe(0);
+    expect(status).toBe(1);
     expect(out.read()).toContain("collected 0");
     expect(out.read()).toContain("nothing to run");
   });

--- a/tests/unit/scripts/lisa-test-node.test.ts
+++ b/tests/unit/scripts/lisa-test-node.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for the `.mjs` suite runner.
+ *
+ * The assertions that carry weight are the two silences this script exists to
+ * break, and neither is visible from an exit code — so neither is asserted by
+ * one. `node --test` exits 0 when its glob matches nothing, and that glob
+ * descends into `node_modules`, so the naive one-line script would both run
+ * other people's suites and report a clean pass having run none of yours.
+ * @module tests/unit/scripts/lisa-test-node
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  collect,
+  isOwnTest,
+  main,
+  run,
+  TEST_GLOB,
+} from "../../../all/copy-overwrite/scripts/lisa-test-node.mjs";
+
+const SUITE = "a.test.mjs";
+const SUITE_B = "b.test.mjs";
+const NESTED = "scripts/b.test.mjs";
+
+let temps: string[] = [];
+
+afterEach(() => {
+  for (const dir of temps) rmSync(dir, { force: true, recursive: true });
+  temps = [];
+});
+
+/**
+ * Build a project tree containing the given relative files.
+ * @param files - Project-relative paths to create
+ * @returns The project root
+ */
+function project(files: readonly string[]): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-test-node-"));
+  temps.push(root);
+  for (const file of files) {
+    const full = path.join(root, file);
+    mkdirSync(path.dirname(full), { recursive: true });
+    writeFileSync(
+      full,
+      'import { test } from "node:test";\ntest("x", () => {});\n'
+    );
+  }
+  return root;
+}
+
+/**
+ * Collect everything a run writes, so the transcript can be asserted.
+ * @returns A writer plus the text it captured
+ */
+function transcript() {
+  const lines: string[] = [];
+  return {
+    read: () => lines.join(""),
+    write: (text: string) => {
+      lines[lines.length] = text;
+    },
+  };
+}
+
+describe("isOwnTest", () => {
+  it("keeps a project's own suites", () => {
+    expect(isOwnTest("scripts/check-thing.test.mjs")).toBe(true);
+    expect(isOwnTest(path.join("deep", "nested", "path", SUITE))).toBe(true);
+  });
+
+  it("rejects vendored and generated trees", () => {
+    // Measured: `**/*.test.ts` matches 1175 files in this repo, 470 of them
+    // inside node_modules. Running those reports other people's failures as
+    // yours.
+    for (const excluded of [
+      `node_modules/zod/${SUITE}`,
+      `dist/${SUITE}`,
+      `build/${SUITE}`,
+      `worktrees/wt/${SUITE}`,
+      `.worktrees/wt/${SUITE}`,
+      `deep/node_modules/pkg/${SUITE}`,
+    ]) {
+      expect(isOwnTest(excluded), excluded).toBe(false);
+    }
+  });
+
+  it("matches path SEGMENTS, not substrings", () => {
+    // A directory legitimately named `distribution` starts with `dist`. A
+    // substring check would silently drop that project's whole test tree.
+    expect(isOwnTest(`distribution/${SUITE}`)).toBe(true);
+    expect(isOwnTest(`builder/${SUITE}`)).toBe(true);
+    expect(isOwnTest(`my-worktrees-notes/${SUITE}`)).toBe(true);
+  });
+});
+
+describe("collect", () => {
+  it("finds suites anywhere in the tree", () => {
+    const root = project([SUITE, NESTED, "deep/nested/c.test.mjs"]);
+    expect(collect(root)).toEqual([
+      SUITE,
+      path.join("deep", "nested", "c.test.mjs"),
+      path.join("scripts", SUITE_B),
+    ]);
+  });
+
+  it("excludes vendored trees it would otherwise match", () => {
+    const root = project(["mine.test.mjs", "node_modules/theirs/x.test.mjs"]);
+    expect(collect(root)).toEqual(["mine.test.mjs"]);
+  });
+
+  it("ignores files that merely resemble a suite", () => {
+    const root = project([SUITE, "nope.mjs", "b.spec.mjs", "c.test.ts"]);
+    expect(collect(root)).toEqual([SUITE]);
+  });
+
+  it("returns empty rather than throwing when there are none", () => {
+    expect(collect(project([]))).toEqual([]);
+  });
+});
+
+describe("run", () => {
+  it("passes the collected files explicitly, never the glob", () => {
+    // What runs must be exactly what was reported as collected. Re-globbing
+    // inside the runner would let the log describe one set while another ran.
+    const seen: string[][] = [];
+    const exec = (_bin: string, args: string[]) => {
+      seen[seen.length] = args;
+      return { status: 0 };
+    };
+    run([SUITE, SUITE_B], exec as never);
+    expect(seen[0]).toEqual(["--test", SUITE, SUITE_B]);
+    expect(seen[0]?.join(" ")).not.toContain(TEST_GLOB);
+  });
+
+  it("propagates a failing status", () => {
+    expect(run([SUITE], (() => ({ status: 1 })) as never)).toBe(1);
+  });
+
+  it("treats a signal-killed run as failure, not success", () => {
+    // spawnSync reports a null status when the child is killed. Returning 0
+    // there would call an interrupted run a pass.
+    expect(run([SUITE], (() => ({ status: null })) as never)).toBe(1);
+  });
+});
+
+describe("main", () => {
+  it("reports the empty case out loud rather than exiting quietly", () => {
+    // `node --test` exits 0 on a glob matching nothing, so the exit code
+    // cannot carry this distinction. The transcript has to.
+    const out = transcript();
+    const status = main({ write: out.write, cwd: project([]) });
+    expect(status).toBe(0);
+    expect(out.read()).toContain("collected 0");
+    expect(out.read()).toContain("nothing to run");
+  });
+
+  it("names every suite it collected", () => {
+    // So a reader can tell "ran everything and passed" from "ran nothing" —
+    // the distinction that was missing and that made the defect invisible.
+    const out = transcript();
+    main({
+      write: out.write,
+      cwd: project([SUITE, NESTED]),
+      exec: (() => ({ status: 0 })) as never,
+    });
+    expect(out.read()).toContain("collected 2");
+    expect(out.read()).toContain(SUITE);
+    expect(out.read()).toContain(path.join("scripts", SUITE_B));
+  });
+
+  it("fails when a collected suite fails", () => {
+    const out = transcript();
+    expect(
+      main({
+        write: out.write,
+        cwd: project([SUITE]),
+        exec: (() => ({ status: 1 })) as never,
+      })
+    ).toBe(1);
+  });
+});

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -21,7 +21,8 @@
       "nightly:health": "node scripts/check-nightly-e2e-health.mjs",
       "check:skipped-required-checks": "node scripts/check-skipped-required-checks.mjs",
       "check:skipped-required-checks:remote": "node scripts/check-skipped-required-checks.mjs --remote",
-      "check:vacuous-required-checks": "node scripts/check-skipped-required-checks.mjs"
+      "check:vacuous-required-checks": "node scripts/check-skipped-required-checks.mjs",
+      "test:node": "node scripts/lisa-test-node.mjs"
     },
     "devDependencies": {
       "eslint-plugin-oxlint": "^1.62.0",
@@ -67,7 +68,7 @@
     "scripts": {
       "build": "tsc",
       "postinstall": "[ -n \"$CI\" ] || LISA_BOOTSTRAP=1 node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true",
-      "test:integration": "vitest run tests/integration --passWithNoTests"
+      "test:integration": "vitest run tests/integration"
     },
     "engines": {
       "npm": "please-use-bun",


### PR DESCRIPTION
Closes #2603.

Lisa ships nine `.mjs` guard scripts to every project and four more to expo consumers, and **every test config it ships collects only `.ts`/`.tsx`**. So a consumer who does the responsible thing and writes a test beside one of those guards gets a suite that never runs — and a green build saying so.

## Proven on one file, not argued

A genuinely failing `.test.mjs`, dropped into this repo:

```
vitest  ->  "No test files found, exiting with code 0"     exit 0
runner  ->  "not ok 1 - this failure must be seen"         exit 1
              # fail 1
```

## The scope was wider than the report

**Seven** shipped configs, not two, and **vitest is affected as well as jest**:

```
vitest/typescript.ts:68   ["tests/**/*.test.ts", "src/**/*.test.ts"]
vitest/harper-fabric.ts   ["tests/**/*.test.ts", "src/**/*.test.ts"]
vitest/phaser.ts          ["tests/**/*.test.ts", "src/**/*.test.ts"]
vitest/cdk.ts:69          ["test/**/*.test.ts", ...]
vitest/nestjs.ts:93       ["**/*.spec.ts"]
jest/expo.ts:156          ["<rootDir>/**/*.test.ts", "*.test.tsx"]
jest/typescript.ts:50     ["<rootDir>/tests/**/*.test.ts", ...]
```

Vitest's own default include **already matches `.mjs`**. Lisa narrowed a default that worked.

## The silence was installed, not overlooked

`vitest/cdk.ts` carried `passWithNoTests: true` immediately above the narrowed `include`, with a comment saying it was there because the narrow include produces "No test files found". The two defects were introduced together, and the second existed to make the first comfortable.

**`passWithNoTests` shipped through two channels, and the second overrode the first:** five vitest configs, plus **six `--passWithNoTests` CLI arguments across four package templates**. A CLI flag beats a config setting — so config-only surgery would have left tunnl, propswap and gemini-frontend-v2 at exactly today's behaviour while reporting complete. Both channels are now closed.

Credit where due: a peer session caught the second channel. I had scoped only the first, and would have shipped a fix three of four consumers never received.

## Why a wrapper, not a one-line script

Both reasons measured:

- **The glob descends into `node_modules`** — 470 of 1175 matches in this repo. A bare glob runs other people's suites.
- **`node --test` exits 0 when its glob matches nothing.** That is the same empty-is-green defect, sitting inside the tool meant to end it. A one-liner would have reproduced the bug inside its own fix.

So collection is explicit and **the count is always printed**. Zero is legitimate and never silent — a reader can tell "ran nothing" from "ran everything and passed", which is exactly the distinction that was missing.

## Why the CI job

Shipping the runner without wiring it into `quality.yml` would have produced a runner that projects wire into pre-push — and **a pre-push hook has no reach on the merge path** (auto-merge, UI merge, CI-side edits, `[skip ci]` commits). That would have been the same defect wearing the fix's clothes.

One **deliberate divergence** from the façade's fallback contract, documented in the job: elsewhere the fallback reproduces today's behaviour byte for byte. For this gate today's behaviour is *nothing*, and preserving nothing would make the fix opt-in. The fallback runs the shipped script.

## A seventh row in the defect table

**`enforced-off-the-path`** — a control that runs, is real, and does bite, but never on the path the failure takes. Measured downstream at **23 of 37** suites enforced only by a pre-push hook, which a pass/fail guard would have called protected. Distinct from all six existing forms, and the reason the follow-up guard must *classify* rather than answer yes/no.

## What lands

| | |
|---|---|
| `all/copy-overwrite/scripts/lisa-test-node.mjs` | the runner, shipped to every project |
| `test:node` | forced into 6 package templates |
| `test-node-suites` | new registry gate → context `🔍 Quality Checks / 🧪 Run .mjs Suites` |
| `quality.yml` | new job, façade-resolved, fallback runs the script |
| `passWithNoTests` | removed from 5 configs **and** 6 CLI sites |
| defect table | seventh row; `passing-with-no-work` evidence updated |

## Verification

- 13 new tests for the runner; full suite **706 files / 12540 tests**
- Push gates: 8 proved, 0 failed; `typecheck` clean
- The `vitest-typescript` assertion is **inverted** rather than deleted — it now asserts `passWithNoTests` is *undefined*, so reinstating the flag turns the suite red

## Expected consequence, stated up front

Removing `passWithNoTests` **reddens any project with an empty collection anywhere**. That is the intended signal. The remedy is one line per gate — declare it `off` in `.lisa.config.json`, which is visible in a diff and drops the required context instead of vacuously satisfying it.

Work-Item: CodySwannGT/lisa#2603

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic discovery and execution of project-owned Node test suites.
  - Added a dedicated quality gate for Node-based test suites, with reporting when suites are collected or unavailable.
  - Added Node test commands across supported project templates.

- **Bug Fixes**
  - Projects can no longer pass unit-test checks solely because no tests were found; missing tests now follow standard failure behavior.

- **Documentation**
  - Updated testing and quality-policy guidance to reflect the revised behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->