### PR TITLE
feat(gates): resolve quality gates at a caller-chosen moment

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -54,6 +54,28 @@ on:
         required: false
         default: 'npm'
         type: string
+      moment:
+        # Which set of gates applies. Every job below resolves its gate from
+        # `.lisa.config.json` AT THIS MOMENT, so one input decides whether this
+        # run enforces the pull-request set or a scheduled one.
+        #
+        # This exists to retire `skip_jobs` inversion. A nightly caller that
+        # wants only the E2E gates currently has no way to say so, and instead
+        # names the two dozen jobs it does NOT want — a list that silently goes
+        # stale every time a job is added, and which turns required contexts
+        # into vacuous greens (see `skip_jobs` below). Declaring the gate at
+        # `continuous:<environment>` instead says the same thing positively,
+        # from the same declaration that drives the required-context list.
+        #
+        # An unknown moment is REFUSED by scripts/lisa-gates.mjs rather than
+        # resolving to nothing: a moment is looked up as a key on each gate, so
+        # a typo would otherwise match nothing, report `configured=false` for
+        # every job, and run each fallback while claiming the registry declared
+        # nothing here.
+        description: 'Which gate set applies: a fixed moment (pull-request, push, commit) or a family with an environment (continuous:dev, pre-deploy:production). Defaults to pull-request; an unrecognised value fails the run.'
+        required: false
+        default: 'pull-request'
+        type: string
       skip_jobs:
         # ⚠️ PREFER `gates` IN .lisa.config.json. `skip_jobs` is retained
         # because repositories pass it today, but it is unsafe by
@@ -464,10 +486,11 @@ jobs:
         env:
           GATE_ID: code-style
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -562,10 +585,11 @@ jobs:
         env:
           GATE_ID: code-style-slow
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -641,10 +665,11 @@ jobs:
         env:
           GATE_ID: type-correctness
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -1092,10 +1117,11 @@ jobs:
         env:
           GATE_ID: test-correctness
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -1370,10 +1396,11 @@ jobs:
         env:
           GATE_ID: test-integration
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -1979,10 +2006,11 @@ jobs:
         env:
           GATE_ID: format-conformance
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -2058,10 +2086,11 @@ jobs:
         env:
           GATE_ID: build-integrity
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -2535,10 +2564,11 @@ jobs:
         env:
           GATE_ID: test-node-suites
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -2632,10 +2662,11 @@ jobs:
         env:
           GATE_ID: dead-code
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
@@ -2722,10 +2753,11 @@ jobs:
         env:
           GATE_ID: structural-rules
           FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
         run: |
           set -euo pipefail
           if [ ! -f scripts/lisa-gates.mjs ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          node scripts/lisa-gates.mjs list --moment=pull-request --json | node -e '
+          node scripts/lisa-gates.mjs list --moment="$GATE_MOMENT" --json | node -e '
           let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
           const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
           const task = hit && hit.mode === "run" && hit.task ? hit.task : "";

--- a/all/copy-overwrite/scripts/lisa-gates.mjs
+++ b/all/copy-overwrite/scripts/lisa-gates.mjs
@@ -948,6 +948,26 @@ export function auditConfigKeys(config) {
  * @returns {Array<{id: string, level: string, mode: string, awaits: string|null, task: string|null, command: string|null, label: string, work: string|null, evidence: {proof: string[], no_work: string[], on_hollow: string, wait_minutes: number|null, on_timeout: string}|null}>} Resolved provers, sorted by gate id.
  */
 export function resolveMoment({ gates, moment, runner = "npm run" }) {
+  // A moment is looked up as a KEY on each gate, so one Lisa does not know
+  // matches nothing and yields `[]` — indistinguishable from a real moment at
+  // which this project declares no gates. Every consumer reads that as "run
+  // the unguarded fallback": the quality workflow reports `configured=false`
+  // for every job, and lisa-run-gates prints a green "0 of 0 gate(s)". A typo
+  // would therefore disable the whole registry while reporting success, which
+  // is the defect this subsystem exists to stop. `[]` stays a truthful answer
+  // for a real moment; it is refused only for one that cannot exist.
+  if (!isMoment(moment)) {
+    const near = nearest(moment, [...MOMENTS, ...MOMENT_FAMILIES]);
+    throw new Error(
+      `"${moment}" is not a moment Lisa knows` +
+        (near ? `. Did you mean "${near}"?` : ".") +
+        ` Known moments: ${MOMENTS.join(", ")}` +
+        `; or a family with an environment: ${MOMENT_FAMILIES.map(
+          family => `${family}:<environment>`
+        ).join(", ")}.`
+    );
+  }
+
   const resolved = [];
   for (const [id, gate] of Object.entries(gates ?? {})) {
     const raw = gate?.[moment];
@@ -1155,10 +1175,18 @@ function main() {
       return;
     }
     for (const gate of resolved) {
+      // "Lisa runs this internally" and "nothing will run this" printed
+      // identically until this was split: an unresolvable gate has a null
+      // command, and so does an intercepted one, so a typo'd gate id rendered
+      // as `(intercepted by Lisa)` — a line that reads like success to the
+      // person running `list` to check their config. Interception is a
+      // property of the gate id, so ask the mode, not the command.
       const how =
         gate.mode === "await"
           ? `await ${gate.awaits}`
-          : (gate.command ?? "(intercepted by Lisa)");
+          : gate.mode === "intercept"
+            ? "(intercepted by Lisa)"
+            : (gate.command ?? "(NO PROVER — nothing runs this gate)");
       console.log(`${gate.level.padEnd(9)} ${gate.id.padEnd(28)} ${how}`);
     }
     return;

--- a/docs/design/gates-and-policy.md
+++ b/docs/design/gates-and-policy.md
@@ -10,7 +10,7 @@ Tracking issue: CodySwannGT/lisa#2579.
 
 Every decision below is downstream of one failure mode: **a check reporting
 satisfied without having proved anything.** It has appeared in this repository in
-at least seven distinct forms, each found only after it had already let something
+at least eight distinct forms, each found only after it had already let something
 through:
 
 | form | evidence |
@@ -22,6 +22,7 @@ through:
 | declared-but-uncallable | `secrets.require` was documented as a startup assertion whose only caller was a bash line inside a SKILL.md |
 | enforced-off-the-path | 23 of 37 `.test.mjs` suites downstream were wired only into `.husky/pre-push.local` (measured); a pre-push hook cannot run where no local push happens — auto-merge, a merge performed in the UI, a change committed CI-side — so a pass/fail guard would have called them protected. The count is measured; the non-firing is inferred from how git hooks work, not observed. (`[skip ci]` is the converse and does NOT belong here: the hook fires, CI does not — a gap in the other direction) |
 | verified-then-invalidated | gates ran alphabetically, so `artifact-freshness` proved the evidence manifest current and `code-style` then reformatted the sources it hashes — a PASSED verdict about a tree that was not the tree committed (#2590) |
+| selected-nothing | a moment is read as a KEY on each gate, so an unrecognised one matched nothing and resolved to `[]`, which every consumer read as "this project declares no gates here". Measured before the fix: `lisa-gates.mjs list --moment=continous:dev` printed `[]` and exited 0, and `lisa-run-gates.mjs --moment=continous:dev` printed `✅ 0 proved, 0 failed ... of 0 gate(s) declared` and exited 0 — the line the husky hooks read as "every required gate was proved". One typo deselected the entire registry and reported success. Unreachable from outside while every call site passed the literal `pull-request`; adding the `moment` input to `quality.yml` is what would have made it caller-reachable, so `resolveMoment` now refuses a moment that cannot exist. `[]` remains a truthful answer for a real moment at which nothing is declared — the guard distinguishes the two, which is the whole point |
 
 The rule that falls out, and the one to apply when a new case is ambiguous:
 

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -187,6 +187,8 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   ]),
   "scripts/lisa-gates.mjs": Object.freeze([
     "13ac69bf2bbae76bc702506bcef5c8fb2b26befaf1358627f4726c1a8ac5905a",
+    "2afa67f8f8b762bc462246d3d0839f34e3ee84ed4daad8d6e187ae21026040bc",
+    "444ed4b879ef7af5dc409ae48743ad06354e47b727ddb5be0877cab52ddd0b64",
     "4907989922ad86f5c162413e1b4c8560b6e7bb9417ab4d109f8dbfc676d4921e",
     "7249cbe9f8fddfa6087331fa7fccd9df9813f5ba764623b747273a0ebbcbb576",
     "79b646d543b541c096d79526fa09dbda3408667ba1a99ee833f94668b181433b",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -19,7 +19,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
       "2d11968f6852ab745cba939de03c6d6cb5f413975d2cfc8fc447bdd0b218e91a",
     "all/copy-overwrite/scripts/lisa-gates.mjs":
-      "f0343c4ef3fde6576362eeb52e1ae3855108eba9d5034ccec8478db0637935d8",
+      "2afa67f8f8b762bc462246d3d0839f34e3ee84ed4daad8d6e187ae21026040bc",
     "all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh":
       "8d1f04ef5c5da9db9190e22b37a435e118e39d6e7deafc5402b4593c8e9db2b2",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
@@ -8696,6 +8696,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/oxlint-worktree-resolution.test.ts": true,
     "tests/integration/quality-gate-facade-fixture.ts": true,
     "tests/integration/quality-gate-facade.test.ts": true,
+    "tests/integration/quality-gate-moment-input.test.ts": true,
     "tests/integration/quality-workflow.test.ts": true,
     "tests/integration/release-changelog-entry.test.ts": true,
     "tests/integration/release-changelog-push-recovery.test.ts": true,
@@ -9056,6 +9057,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/invoked-as-script.test.ts": true,
     "tests/unit/scripts/lisa-gates-evidence.test.ts": true,
     "tests/unit/scripts/lisa-gates-fixtures.ts": true,
+    "tests/unit/scripts/lisa-gates-moment-validation.test.ts": true,
     "tests/unit/scripts/lisa-gates-order.test.ts": true,
     "tests/unit/scripts/lisa-gates-resolution.test.ts": true,
     "tests/unit/scripts/lisa-gates-self-config.test.ts": true,

--- a/tests/helpers/workflow-test-utils.ts
+++ b/tests/helpers/workflow-test-utils.ts
@@ -21,9 +21,27 @@ export interface WorkflowJob {
   outputs?: Record<string, string>;
 }
 
-/** Root shape of a parsed GitHub Actions workflow. */
+/** Shape of one `workflow_call` input declaration. */
+export interface WorkflowInput {
+  description?: string;
+  required?: boolean;
+  default?: unknown;
+  type?: string;
+}
+
+/**
+ * Root shape of a parsed GitHub Actions workflow.
+ *
+ * `on` survives as a string key because js-yaml parses with the YAML 1.2 core
+ * schema, where it is not the boolean it would be under YAML 1.1.
+ */
 export interface ParsedWorkflow {
   jobs: Record<string, WorkflowJob>;
+  on?: {
+    workflow_call?: {
+      inputs?: Record<string, WorkflowInput>;
+    };
+  };
 }
 
 /**

--- a/tests/integration/quality-gate-facade-fixture.ts
+++ b/tests/integration/quality-gate-facade-fixture.ts
@@ -48,7 +48,12 @@ export const CONFIGURED = "steps.gate.outputs.configured == 'true'";
 export const NOT_CONFIGURED = "steps.gate.outputs.configured != 'true'";
 
 /**
- * The nine jobs converted to the gate façade.
+ * The ten jobs converted to the gate façade.
+ *
+ * Kept exhaustive by `quality-gate-moment-input.test.ts`, which fails if the
+ * workflow contains a resolve step this list omits. `test_node_suites` shipped
+ * uncovered for exactly that reason: it was added with an identical resolve
+ * block, and nothing here noticed.
  *
  * `jobName` is a LITERAL, not a lookup. A job name is a branch-protection
  * context matched by exact string in a GitHub ruleset, and a wrong one has
@@ -117,6 +122,18 @@ export const CONVERTED: ConvertedJob[] = [
     ],
   },
   {
+    job: "test_node_suites",
+    jobName: "🧪 Run .mjs Suites",
+    gate: "test-node-suites",
+    gateStep: "🧪 Run the mjs-suites gate",
+    // This job's FALLBACK deliberately diverges from the others: elsewhere the
+    // fallback reproduces what the project did before the façade, and here
+    // that was nothing at all, so preserving it would have made the fix
+    // opt-in. The divergence is in what the fallback DOES; its structure is
+    // the same, which is why it belongs under the same drift assertions.
+    fallbackSteps: ["🧪 Run .mjs suites (lisa-test-node)"],
+  },
+  {
     job: "dead_code",
     jobName: "🗑️ Dead Code Detection",
     gate: "dead-code",
@@ -142,7 +159,7 @@ export const CONVERTED: ConvertedJob[] = [
  * Steps that carried `continue-on-error` BEFORE this conversion.
  *
  * A failing job that reports green is the exact defect the façade exists to
- * prevent, so the set is pinned rather than checked only on the nine jobs:
+ * prevent, so the set is pinned rather than checked only on the ten jobs:
  * growing it anywhere in this workflow has to fail here.
  */
 export const PREEXISTING_CONTINUE_ON_ERROR = ["📊 SonarCloud Scan"];

--- a/tests/integration/quality-gate-facade.test.ts
+++ b/tests/integration/quality-gate-facade.test.ts
@@ -58,7 +58,9 @@ describe("quality.yml gate façade", () => {
         expect(resolve).toBeDefined();
         expect(resolve?.env?.GATE_ID).toBe(gate);
         expect(resolve?.run).toContain("scripts/lisa-gates.mjs");
-        expect(resolve?.run).toContain("--moment=pull-request");
+        // The moment itself is asserted in quality-gate-moment-input.test.ts;
+        // here it only has to reach the resolver.
+        expect(resolve?.run).toContain("--moment=");
       }
     );
 
@@ -103,7 +105,7 @@ describe("quality.yml gate façade", () => {
     );
 
     it("resolves every gate with one byte-identical block, differing only in GATE_ID", () => {
-      // Nine copies exist because the single-copy alternative — a resolver job
+      // Ten copies exist because the single-copy alternative — a resolver job
       // read through `needs:` — leaves dependents SKIPPED when it fails, and a
       // skipped required check counts as satisfied. Copies that cannot be
       // deduplicated must instead be prevented from drifting, so this compares

--- a/tests/integration/quality-gate-moment-input.test.ts
+++ b/tests/integration/quality-gate-moment-input.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests that `quality.yml` resolves its gates at a caller-chosen moment.
+ *
+ * Every façade job hardcoded `--moment=pull-request`, which is why a scheduled
+ * caller that wants a different set of gates has no way to ask for one and
+ * inverts `skip_jobs` instead — naming the two dozen jobs it does NOT want.
+ * That inversion is the thing being retired, and it exists solely because of
+ * this hardcoding.
+ *
+ * The default is `pull-request`, so every existing caller resolves exactly what
+ * it resolved before.
+ * @module tests/integration/quality-gate-moment-input
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CONVERTED,
+  resolveStep,
+  source,
+  workflow,
+} from "./quality-gate-facade-fixture.js";
+
+/** The input a caller sets to choose which gates apply. */
+const MOMENT_INPUT = "moment";
+
+/** How the moment reaches the resolver's shell. */
+const MOMENT_ENV = "GATE_MOMENT";
+
+describe("quality.yml exposes the moment as an input", () => {
+  const inputs = workflow.on?.workflow_call?.inputs;
+
+  it("declares a moment input", () => {
+    expect(inputs?.[MOMENT_INPUT]).toBeDefined();
+  });
+
+  it("defaults to pull-request, so every existing caller is unchanged", () => {
+    expect(inputs?.[MOMENT_INPUT]?.default).toBe("pull-request");
+    expect(inputs?.[MOMENT_INPUT]?.type).toBe("string");
+  });
+
+  it("does not require callers to pass it", () => {
+    expect(inputs?.[MOMENT_INPUT]?.required).not.toBe(true);
+  });
+});
+
+describe("every façade job resolves at the caller's moment", () => {
+  it.each(CONVERTED)("$job passes the moment through env", ({ job }) => {
+    expect(resolveStep(job)?.env?.[MOMENT_ENV]).toBe("${{ inputs.moment }}");
+  });
+
+  it.each(CONVERTED)(
+    "$job reads the moment as a shell variable, never interpolated into the command",
+    ({ job }) => {
+      // `.lisa.config.json` values are already kept out of the YAML for this
+      // reason; a caller-supplied input is the same class of value. Written as
+      // `${{ inputs.moment }}` inside the run body it would BE workflow source.
+      const body = resolveStep(job)?.run ?? "";
+      expect(body).toContain(`--moment="$${MOMENT_ENV}"`);
+      expect(body).not.toContain("${{ inputs.moment }}");
+    }
+  );
+
+  it.each(CONVERTED)("$job hardcodes no moment", ({ job }) => {
+    expect(resolveStep(job)?.run ?? "").not.toContain("--moment=pull-request");
+  });
+
+  it("leaves no hardcoded moment anywhere in the workflow", () => {
+    // Counted across the file rather than per job: a resolve block added later
+    // and missed by CONVERTED would otherwise reintroduce the hardcoding
+    // without failing anything.
+    expect(source).not.toContain("--moment=pull-request");
+  });
+
+  it("covers every resolve block in the workflow, not just the listed ones", () => {
+    const byName = (left: string, right: string) => left.localeCompare(right);
+    const withGateStep = Object.keys(workflow.jobs)
+      .filter(job => resolveStep(job) !== undefined)
+      .toSorted(byName);
+    expect(withGateStep).toEqual(CONVERTED.map(c => c.job).toSorted(byName));
+  });
+});

--- a/tests/unit/scripts/lisa-gates-moment-validation.test.ts
+++ b/tests/unit/scripts/lisa-gates-moment-validation.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests that an unrecognised moment fails loudly instead of resolving to
+ * nothing.
+ *
+ * `resolveMoment` reads `gate[moment]`, so a moment Lisa does not know simply
+ * matches no key on any gate and returns `[]`. Every consumer reads that empty
+ * list as "this project declares no gates here" and falls through to its
+ * unguarded path: `lisa-gates.mjs list` reports `configured=false` for all ten
+ * façade jobs, and `lisa-run-gates.mjs` prints a green
+ * `0 proved, 0 failed ... of 0 gate(s) declared` and exits 0.
+ *
+ * That is the defect this subsystem exists to stop — a check reporting
+ * satisfied without having proved anything — reachable through a single typo.
+ * It became reachable from outside the repository when `quality.yml` gained a
+ * `moment` input, because until then every call site passed the literal
+ * `pull-request`.
+ * @module tests/unit/scripts/lisa-gates-moment-validation
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { resolveMoment } from "../../../all/copy-overwrite/scripts/lisa-gates.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPTS = path.join(REPO_ROOT, "all", "copy-overwrite", "scripts");
+const GATES = path.join(SCRIPTS, "lisa-gates.mjs");
+const RUN_GATES = path.join(SCRIPTS, "lisa-run-gates.mjs");
+
+/** A gates block declaring one gate at one real moment. */
+const gates = {
+  "code-style": { run: "lint", "pull-request": "required" },
+};
+
+/**
+ * Run one of the shipped scripts and capture its result.
+ * @param script Absolute path to the script.
+ * @param args CLI arguments.
+ * @returns The completed process.
+ */
+const run = (script: string, args: string[]) =>
+  spawnSync(process.execPath, [script, ...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+
+describe("resolveMoment rejects a moment Lisa does not know", () => {
+  it.each([
+    ["a misspelt family", "continous:dev"],
+    ["a family with no environment", "continuous"],
+    ["a bare typo", "pull-requst"],
+    ["nonsense", "totally-bogus"],
+  ])("throws on %s", (_label, moment) => {
+    expect(() => resolveMoment({ gates, moment })).toThrow(/not a moment/i);
+  });
+
+  it("names the offending moment, so the operator can see the typo", () => {
+    expect(() => resolveMoment({ gates, moment: "continous:dev" })).toThrow(
+      /continous:dev/
+    );
+  });
+
+  it.each([
+    ["a fixed moment", "pull-request"],
+    ["a fixed moment with no gates declared at it", "session-start"],
+    ["a family with an environment", "continuous:dev"],
+    ["a deploy family", "pre-deploy:production"],
+  ])("still resolves %s", (_label, moment) => {
+    expect(() => resolveMoment({ gates, moment })).not.toThrow();
+  });
+
+  it("returns an empty list for a VALID moment with nothing declared", () => {
+    // The distinction this guard turns on: `[]` is a truthful answer for a
+    // real moment, and a lie for one that does not exist.
+    expect(resolveMoment({ gates, moment: "session-start" })).toEqual([]);
+  });
+});
+
+describe("the shipped CLIs refuse an unknown moment", () => {
+  it("lisa-gates.mjs list exits nonzero rather than printing []", () => {
+    const result = run(GATES, ["list", "--moment=continous:dev", "--json"]);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).not.toContain("[]");
+    expect(`${result.stderr}`).toMatch(/continous:dev/);
+  });
+
+  it("lisa-run-gates.mjs never reports green for an unknown moment", () => {
+    // The dangerous shape: this runner's ✅ line is what the husky hooks read
+    // as "every required gate was proved", and it printed exactly that for a
+    // moment that cannot exist.
+    const result = run(RUN_GATES, ["--moment=continous:dev"]);
+    expect(result.status).not.toBe(0);
+    expect(`${result.stdout}`).not.toContain("✅");
+    expect(`${result.stdout}${result.stderr}`).toMatch(/continous:dev/);
+  });
+
+  it("lisa-gates.mjs list still succeeds for a real moment", () => {
+    const result = run(GATES, ["list", "--moment=pull-request", "--json"]);
+    expect(result.status).toBe(0);
+  });
+});
+
+describe("list distinguishes an unrunnable gate from an intercepted one", () => {
+  /**
+   * Run `list` against a throwaway config in its own directory.
+   * @param config The `.lisa.config.json` contents.
+   * @returns The plain-text listing.
+   */
+  const seed = (config: unknown): string => {
+    const dir = mkdtempSync(path.join(tmpdir(), "lisa-gates-"));
+    const file = path.join(dir, ".lisa.config.json");
+    writeFileSync(file, JSON.stringify(config), "utf8");
+    return dir;
+  };
+
+  const listWith = (config: unknown): string => {
+    const dir = seed(config);
+    const result = spawnSync(
+      process.execPath,
+      [GATES, "list", "--moment=pull-request"],
+      { cwd: dir, encoding: "utf8" }
+    );
+    rmSync(dir, { recursive: true, force: true });
+    return `${result.stdout}`;
+  };
+
+  it("does not call an unresolvable gate intercepted", () => {
+    // A gate id Lisa does not know has no task, so its command is null — the
+    // same null an intercepted gate has. Rendering both as "intercepted by
+    // Lisa" told a config author their typo was being handled.
+    const listing = listWith({
+      gates: { "x-nothing-runs-me": { "pull-request": "optional" } },
+    });
+    expect(listing).toContain("x-nothing-runs-me");
+    expect(listing).not.toContain("intercepted by Lisa");
+    expect(listing).toContain("NO PROVER");
+  });
+
+  it("still calls a genuinely intercepted gate intercepted", () => {
+    const listing = listWith({
+      gates: { "verification-bypass": { "pull-request": "required" } },
+    });
+    expect(listing).toContain("intercepted by Lisa");
+  });
+});


### PR DESCRIPTION
## What this does

`quality.yml` asks `.lisa.config.json` what is required **at a moment** — but
the moment was hardcoded in ten places, so it could only ever ask about a pull
request. This adds a `moment` input and uses it in all ten.

A nightly caller that wants a different set of checks currently has no way to
say so, and inverts `skip_jobs` instead: geminisports names the **24 jobs it
does not want**. That list goes stale whenever a job is added, and every entry
on it reports green having run nothing, because GitHub counts a skipped
required check as satisfied.

## Existing callers are unchanged — measured, not argued

The input defaults to `pull-request`. With the default in place the resolver's
output is byte-identical to the hardcoded form:

```
--moment="$GATE_MOMENT"  (GATE_MOMENT=pull-request)   ==   --moment=pull-request
```

The value reaches the shell through `env:`, like every other resolved value in
these blocks, never interpolated into the run body — a caller-supplied input
written as `${{ }}` inside the script *would be* workflow source. Under
`set -u` an unset variable fails the step rather than resolving an empty moment.

## Ten, not nine

The plan said nine. `test-node-suites`, shipped in #2604, has a byte-identical
resolve block that the fixture list never named, so the drift test guarding
these copies did not cover the newest one — the PR that added a gate shipped it
outside the test that exists to catch exactly that.

It is covered now, and a new assertion fails if the workflow contains a resolve
step the fixture omits. A fixture maintained by hand will eventually not be.

## It also closes a live hole that this input would have widened

A moment is looked up as a **key** on each gate, so one Lisa does not know
matched nothing and resolved to `[]` — indistinguishable from a real moment at
which a project declares nothing. Measured before the fix:

```
lisa-gates.mjs list --moment=continous:dev
  ->  []                                                  exit 0

lisa-run-gates.mjs --moment=continous:dev
  ->  ✅ 0 proved, 0 failed (optional) ... of 0 gate(s)     exit 0
```

The second is the dangerous one: that line is what the husky hooks read as
"every required gate was proved". **One typo disabled the entire registry and
reported success.**

This was unreachable from outside the repo while every call site passed the
literal `pull-request`. Adding the input is precisely what makes it
caller-reachable, so the guard ships here rather than as a follow-up — the input
alone would have widened a live hole. It sits in `resolveMoment`, the one
function both CLIs share, so neither surface can be fixed while the other is
not. A **valid** moment with nothing declared still returns `[]`, because that
answer is true; only a moment that cannot exist is refused, with a did-you-mean.

Recorded as an eighth form, `selected-nothing`, in the defect table. Distinct
from `required-and-skipped` (GitHub's accounting) and `passing-with-no-work` (a
runner with no tests): here the **selector** silently deselects everything, one
layer above either.

## And one display bug in the same family

An unresolvable gate has a null command, and so does an intercepted one, so a
typo'd gate id printed as `(intercepted by Lisa)` — a line that reads like
success to whoever ran `list` to check their config. Measured:

```
optional  test-node-suits   (intercepted by Lisa)      <- a typo, nothing runs it
```

Interception is a property of the gate id, so the listing now asks the mode
rather than the command. Raised by a peer session against my own measurement.

## Verification

- 12,603 tests pass; lint and typecheck clean
- Guard proven **RED first**: 38 failing assertions before the fix. 6 passed
  throughout by design — they assert that *valid* moments still resolve
- Both derived artifacts regenerated after staging and verified with
  `check:artifacts`
- Default-caller equivalence and fail-closed-on-unset both executed, not reasoned

## Flagged, deliberately not fixed here

`lisa-gates.mjs validate` catches an unknown **gate id** loudly, with a
did-you-mean — but its only callers are prose lines inside `lisa-doctor`
SKILL.md files. Nothing in CI, no workflow, no hook runs it. That is the
`declared-but-uncallable` row applied to config validation itself, and a third
instance of that form.

Wiring it into CI would turn config typos into red required checks across the
fleet simultaneously, and at least one consumer repo has no `gates` key at all.
That is a rollout decision, not a cleanup, so it is raised rather than folded
into this PR.

## Follow-up (not this PR)

Nightlies pass `continuous:dev`; `lisa doctor` migrates exclusion lists
mechanically but **must refuse inverted selection lists** — an inverted list
means "only these", and a doctor that "repaired" the nightly would disable those
gates on pull requests too. Then the input is deleted and a gate refuses any
caller still passing it.

Work-Item: CodySwannGT/lisa#2605
