### PR TITLE
feat(gates): run the gate-config validator in CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2235,6 +2235,89 @@ jobs:
   # cache. It never prints a ✅ it cannot support. Refusal is exit 1 except
   # under the seed's `"enforcement": "warn"`, which keeps a fresh install loud
   # rather than red.
+  # Gate-config validity. `lisa-gates.mjs validate` catches an unknown gate id,
+  # a moment a gate cannot legally run at, and a malformed level — each with a
+  # did-you-mean. It has always existed and, until this job, nothing ever ran
+  # it: its only callers were prose lines inside lisa-doctor SKILL.md files, so
+  # a typo'd gate id resolved to nothing and read as a working declaration.
+  # That is `declared-but-uncallable` applied to config validation itself.
+  #
+  # DELIBERATELY NOT A GATE, and deliberately not skippable via `skip_jobs`.
+  # A project that could declare this `off` — or name it in `skip_jobs` — could
+  # switch off validation OF ITS OWN gate declarations, which is the circularity
+  # that manufactures vacuous greens in the first place. Everything else in this
+  # workflow answers to the config; this is the one job that judges it.
+  gate_config_validity:
+    permissions:
+      contents: read
+    name: 🧭 Gate Config Validity
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: 🔧 Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          package-manager-cache: false
+          node-version: ${{ inputs.node_version }}
+
+      - name: 🍞 Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: 📦 Install dependencies
+        run: |
+          if [ "${{ inputs.package_manager }}" = "npm" ]; then
+            npm ci
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn install --frozen-lockfile
+          elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            bun install --frozen-lockfile
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧭 Validate the gates block
+        run: |
+          set -euo pipefail
+          # Resolution order prefers the PACKAGE copy over the in-repo one.
+          # The same file ships inside @codyswann/lisa, so a consumer already
+          # has it under node_modules whether or not it was copied in; reading
+          # it from there is one versioned copy instead of a per-repo fork that
+          # silently stops receiving fixes. The in-repo path stays first-class
+          # only until the copies are retired, and the third entry is Lisa
+          # validating itself, where node_modules holds no copy of Lisa.
+          for candidate in \
+            "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" \
+            "scripts/lisa-gates.mjs" \
+            "all/copy-overwrite/scripts/lisa-gates.mjs"; do
+            if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
+          done
+
+          if [ -z "${RESOLVER:-}" ]; then
+            # A project with no gates block has nothing to validate and is not
+            # yet on this template. One WITH a gates block and no resolver is a
+            # different thing entirely: its declarations govern the required
+            # contexts and nothing can check them, so that fails rather than
+            # passing quietly.
+            if [ -f .lisa.config.json ] && node -e 'process.exit(Object.keys((require("./.lisa.config.json").gates)||{}).length ? 0 : 1)'; then
+              echo "::error::.lisa.config.json declares a gates block but no lisa-gates.mjs could be found to validate it. Run \`lisa apply\` so the resolver is installed."
+              exit 1
+            fi
+            echo "No gates resolver and no gates block — project not yet on the gate registry; nothing to validate."
+            exit 0
+          fi
+
+          echo "Validating .lisa.config.json gates via $RESOLVER"
+          node "$RESOLVER" validate
+        working-directory: ${{ inputs.working_directory || '.' }}
+
   skipped_required_checks:
     permissions:
       contents: read

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8677,6 +8677,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/bootstrap-keychain.test.ts": true,
     "tests/integration/cli-smoke.test.ts": true,
     "tests/integration/failure-issue-workflows.test.ts": true,
+    "tests/integration/gate-config-validity-job.test.ts": true,
     "tests/integration/jest-expo-haste-pruning.test.ts": true,
     "tests/integration/lisa.test.ts": true,
     "tests/integration/maestro-caller-template.test.ts": true,

--- a/tests/integration/gate-config-validity-job.test.ts
+++ b/tests/integration/gate-config-validity-job.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests the job that validates a project's own gates block.
+ *
+ * `lisa-gates.mjs validate` catches unknown gate ids, illegal moments and
+ * malformed levels — and until this job existed, nothing ran it. Its only
+ * callers were prose lines inside lisa-doctor SKILL.md files, so a typo'd gate
+ * id resolved to nothing and read as a working declaration. That is
+ * `declared-but-uncallable` applied to config validation itself.
+ *
+ * The load-bearing property is that this job is NOT gate-configurable and NOT
+ * skippable: a project able to switch off validation of its own declarations
+ * could manufacture exactly the vacuous green the registry exists to prevent.
+ * @module tests/integration/gate-config-validity-job
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { source, workflow } from "./quality-gate-facade-fixture.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const GATES = path.join(
+  REPO_ROOT,
+  "all",
+  "copy-overwrite",
+  "scripts",
+  "lisa-gates.mjs"
+);
+
+/** The job id under test. */
+const JOB = "gate_config_validity";
+
+/** Its branch-protection context name. */
+const JOB_NAME = "🧭 Gate Config Validity";
+
+describe("the gate-config validity job exists and is unconditional", () => {
+  it("declares the job", () => {
+    expect(workflow.jobs[JOB]).toBeDefined();
+  });
+
+  it("carries the exact context name a ruleset matches", () => {
+    expect((workflow.jobs[JOB] as { name?: string }).name).toBe(JOB_NAME);
+  });
+
+  it("cannot be turned off with skip_jobs", () => {
+    // Every other job honours skip_jobs. This one must not: a project able to
+    // skip validation of its own gates block could declare anything at all.
+    expect(workflow.jobs[JOB].if ?? "").not.toContain("skip_jobs");
+  });
+
+  it("has no condition at all, so it runs on every pull request", () => {
+    expect(workflow.jobs[JOB].if).toBeUndefined();
+  });
+
+  it("is not itself a configurable gate", () => {
+    // A `gates` entry for this job would let .lisa.config.json declare it off,
+    // which is the same circularity by another route.
+    const steps = workflow.jobs[JOB].steps ?? [];
+    expect(steps.find(step => step.id === "gate")).toBeUndefined();
+  });
+
+  it("reports failure rather than continuing", () => {
+    const steps = workflow.jobs[JOB].steps ?? [];
+    expect(
+      (workflow.jobs[JOB] as Record<string, unknown>)["continue-on-error"]
+    ).toBeUndefined();
+    for (const step of steps) {
+      expect(
+        (step as Record<string, unknown>)["continue-on-error"]
+      ).toBeUndefined();
+    }
+  });
+});
+
+describe("it resolves the shipped resolver, preferring the package copy", () => {
+  const body =
+    (workflow.jobs[JOB].steps ?? []).find(step =>
+      step.name?.includes("Validate the gates block")
+    )?.run ?? "";
+
+  it("prefers node_modules over the in-repo copy", () => {
+    // The same file ships inside @codyswann/lisa, so reading it from the
+    // package is one versioned copy rather than a per-repo fork that silently
+    // stops receiving fixes.
+    const pkg = body.indexOf("node_modules/@codyswann/lisa");
+    const repo = body.indexOf('"scripts/lisa-gates.mjs"');
+    expect(pkg).toBeGreaterThan(-1);
+    expect(repo).toBeGreaterThan(-1);
+    expect(pkg).toBeLessThan(repo);
+  });
+
+  it("still resolves Lisa validating itself", () => {
+    expect(body).toContain("all/copy-overwrite/scripts/lisa-gates.mjs");
+  });
+
+  it("actually runs validate", () => {
+    expect(body).toContain("validate");
+  });
+
+  it("fails when a gates block exists but no resolver does", () => {
+    // The dangerous asymmetry: no block and no resolver is a project not yet
+    // on the template, but a block with no resolver means declarations govern
+    // the required contexts and nothing can check them.
+    expect(body).toContain("declares a gates block but no lisa-gates.mjs");
+    expect(body).toContain("exit 1");
+  });
+
+  it("does not discard the resolver's stderr", () => {
+    expect(body).not.toContain("2>/dev/null");
+    expect(body).toContain("set -euo pipefail");
+  });
+});
+
+describe("validate bites — the behaviour the job depends on", () => {
+  /**
+   * Run `validate` against a throwaway config.
+   * @param config The `.lisa.config.json` contents.
+   * @returns Exit status and merged output.
+   */
+  const seed = (config: unknown): string => {
+    const dir = mkdtempSync(path.join(tmpdir(), "lisa-cfg-"));
+    const file = path.join(dir, ".lisa.config.json");
+    writeFileSync(file, JSON.stringify(config), "utf8");
+    return dir;
+  };
+
+  const validate = (config: unknown) => {
+    const dir = seed(config);
+    const result = spawnSync(process.execPath, [GATES, "validate"], {
+      cwd: dir,
+      encoding: "utf8",
+    });
+    rmSync(dir, { recursive: true, force: true });
+    return { status: result.status, out: `${result.stdout}${result.stderr}` };
+  };
+
+  it("fails an unknown gate id and suggests the real one", () => {
+    const { status, out } = validate({
+      gates: { "test-node-suits": { "pull-request": "optional" } },
+    });
+    expect(status).not.toBe(0);
+    expect(out).toContain("test-node-suites");
+  });
+
+  it("fails a gate declared at a moment it cannot run at", () => {
+    const { status } = validate({
+      gates: { "code-style": { "session-start": "required" } },
+    });
+    expect(status).not.toBe(0);
+  });
+
+  it("fails a level that is not a level", () => {
+    const { status } = validate({
+      gates: { "code-style": { "pull-request": "mandatory" } },
+    });
+    expect(status).not.toBe(0);
+  });
+
+  it("passes a correct declaration", () => {
+    const { status } = validate({
+      gates: { "code-style": { run: "lint", "pull-request": "required" } },
+    });
+    expect(status).toBe(0);
+  });
+
+  it("passes a project with no gates block at all", () => {
+    const { status } = validate({});
+    expect(status).toBe(0);
+  });
+});
+
+describe("the workflow documents why this job is unskippable", () => {
+  it("says so in the source, where the next person to add skip_jobs will look", () => {
+    expect(source).toContain("DELIBERATELY NOT A GATE");
+  });
+});


### PR DESCRIPTION
## The problem

Lisa can already check that a project's `gates` block in `.lisa.config.json`
makes sense. It catches a misspelt gate name, a check declared to run at a point
it cannot run at, and an enforcement level that is not a level — each with a
"did you mean" suggestion.

**Nothing ever ran it.**

Its only callers were instruction lines inside `lisa-doctor` documentation
files, which means it fired only when a person happened to run `/lisa:doctor`
and read that far. No CI job, no git hook, no install step.

## What that costs

A typo in a gate name resolves to nothing, and nothing is indistinguishable
from "this project has no checks configured here". Measured:

```
config declares "test-node-suits"   (the real name is "test-node-suites")

validate   ->  "is not a gate Lisa knows. Did you mean test-node-suites?"   exit 1
list       ->  optional  test-node-suits  (intercepted by Lisa)             exit 0
```

Only the first surface objects, and it is the one that never runs. The second
is what the quality workflow actually calls. So a project could declare
enforcement, see a plausible-looking line confirming it, and have nothing
enforced.

This is the same defect the gate registry exists to prevent — a check that
reports satisfied without having proved anything — applied to the validation
of the checks themselves.

## What this adds

A `🧭 Gate Config Validity` job in `quality.yml` that runs `validate` on every
pull request.

**It is deliberately not a configurable check, and deliberately cannot be
skipped.** Every other job in the workflow answers to `.lisa.config.json`; this
is the one that judges it. A project able to switch off validation of its own
declarations could declare anything at all, which is the circularity that
produces the empty green in the first place.

It prefers the copy of the resolver inside the installed `@codyswann/lisa`
package over the copy in the project, because the same file ships in the
package — one versioned copy instead of a per-repo copy that can be edited once
and silently stop receiving fixes.

## Safe for the fleet as it stands

- A project with no `gates` block and no resolver: nothing to validate, passes.
- A project with a `gates` block and no resolver: **fails**, because its
  declarations govern which checks are required and nothing can check them.
- Lisa's own configuration was verified valid before this landed, so it does
  not redden this repository.

## Done when

- [x] `validate` runs on every pull request
- [x] The job cannot be disabled by config or by `skip_jobs`
- [x] A bad gate name, an illegal moment, and a bad level each fail the job
- [x] A correct config, and a project with no gates block, both pass
- [ ] Separately, and needing a human: add the context to the branch-protection
      ruleset so it blocks rather than merely reports


Work-Item: CodySwannGT/lisa#2607
