### PR TITLE
feat(e2e): refuse an EAS profile that cannot produce a testable app

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -548,6 +548,29 @@ jobs:
             bun install --frozen-lockfile
           fi
 
+      - name: 🧭 Check the build profile can produce a testable app
+        # Runs BEFORE the EAS setup and the build, because both mistakes it
+        # catches are free to detect now and cost a full native build to
+        # discover later — and when they surface later they surface as flows
+        # failing on unfamiliar screens, which reads as a product bug.
+        #
+        # Resolved from the installed package rather than a copy in the
+        # project: the same file would otherwise be edited once downstream and
+        # silently stop receiving fixes. Absent (a project on an older Lisa),
+        # the check is skipped rather than failing the build over its own
+        # rollout.
+        run: |
+          set -euo pipefail
+          GUARD="node_modules/@codyswann/lisa/scripts/lisa-assert-eas-profile.mjs"
+          if [ ! -f "$GUARD" ]; then
+            GUARD="scripts/lisa-assert-eas-profile.mjs"
+          fi
+          if [ ! -f "$GUARD" ]; then
+            echo "::warning title=EAS profile unchecked::No lisa-assert-eas-profile.mjs found, so the build profile was not checked. Update @codyswann/lisa to get it."
+            exit 0
+          fi
+          node "$GUARD" --profile="${{ inputs.eas_profile }}"
+
       - name: 🔧 Setup EAS
         uses: expo/expo-github-action@v8
         with:

--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -559,6 +559,12 @@ jobs:
         # silently stop receiving fixes. Absent (a project on an older Lisa),
         # the check is skipped rather than failing the build over its own
         # rollout.
+        env:
+          # Through `env:`, never interpolated into the run body. A caller
+          # supplies this, and `${{ }}` inside the script would make that value
+          # workflow SOURCE rather than an argument — the same reason the
+          # resolved gate command travels this way in quality.yml.
+          EAS_PROFILE: ${{ inputs.eas_profile }}
         run: |
           set -euo pipefail
           GUARD="node_modules/@codyswann/lisa/scripts/lisa-assert-eas-profile.mjs"
@@ -569,7 +575,7 @@ jobs:
             echo "::warning title=EAS profile unchecked::No lisa-assert-eas-profile.mjs found, so the build profile was not checked. Update @codyswann/lisa to get it."
             exit 0
           fi
-          node "$GUARD" --profile="${{ inputs.eas_profile }}"
+          node "$GUARD" --profile="$EAS_PROFILE"
 
       - name: 🔧 Setup EAS
         uses: expo/expo-github-action@v8

--- a/expo/create-only/eas.json
+++ b/expo/create-only/eas.json
@@ -1,0 +1,111 @@
+{
+  "cli": {
+    "version": ">= 7.2.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "base": {
+      "node": "22.21.1",
+      "resourceClass": "large",
+      "env": {
+        "NODE_OPTIONS": "--max-old-space-size=4096",
+        "PUPPETEER_SKIP_DOWNLOAD": "true"
+      }
+    },
+    "dev-base": {
+      "extends": "base",
+      "channel": "dev",
+      "env": {
+        "STAGE": "dev",
+        "EXPO_PUBLIC_ENV": "dev"
+      }
+    },
+    "dev": {
+      "extends": "dev-base",
+      "developmentClient": true,
+      "distribution": "internal",
+      "channel": "dev"
+    },
+    "dev-simulator": {
+      "extends": "dev-base",
+      "developmentClient": true,
+      "ios": {
+        "simulator": true
+      }
+    },
+    "dev-preview": {
+      "extends": "dev-base",
+      "developmentClient": false,
+      "distribution": "internal"
+    },
+    "dev-e2e": {
+      "extends": "dev-base",
+      "developmentClient": false,
+      "distribution": "internal",
+      "channel": "e2e",
+      "ios": {
+        "simulator": true
+      },
+      "android": {
+        "buildType": "apk"
+      },
+      "env": {
+        "EXPO_PUBLIC_E2E_BUILD": "true"
+      }
+    },
+    "staging": {
+      "extends": "base",
+      "channel": "staging",
+      "env": {
+        "STAGE": "staging",
+        "EXPO_PUBLIC_ENV": "staging"
+      }
+    },
+    "production-preview": {
+      "extends": "base",
+      "channel": "production",
+      "developmentClient": false,
+      "distribution": "internal",
+      "env": {
+        "STAGE": "production",
+        "EXPO_PUBLIC_ENV": "production"
+      }
+    },
+    "production": {
+      "extends": "base",
+      "channel": "production",
+      "env": {
+        "STAGE": "production",
+        "EXPO_PUBLIC_ENV": "production"
+      }
+    }
+  },
+  "submit": {
+    "base": {
+      "android": {},
+      "ios": {}
+    },
+    "dev": {
+      "extends": "base",
+      "ios": {},
+      "android": {
+        "track": "internal"
+      }
+    },
+    "staging": {
+      "extends": "base",
+      "ios": {},
+      "android": {
+        "track": "internal",
+        "releaseStatus": "draft"
+      }
+    },
+    "production": {
+      "extends": "base",
+      "ios": {},
+      "android": {
+        "track": "production"
+      }
+    }
+  }
+}

--- a/scripts/lisa-assert-eas-profile.mjs
+++ b/scripts/lisa-assert-eas-profile.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+/**
+ * Refuse an EAS build profile that cannot produce a testable E2E binary.
+ *
+ * Two profile mistakes waste a full native build and then fail the suite in a
+ * way that reads as a product bug rather than a configuration one:
+ *
+ * 1. `developmentClient: true` builds a **dev client**, which is a shell that
+ *    loads JavaScript from a Metro server at runtime. CI has no Metro server,
+ *    so the app opens its "development servers" launcher instead of the
+ *    product. Every flow then fails on a screen that appears nowhere in the
+ *    app, and the failure looks like a broken selector.
+ * 2. A profile with no `channel` takes the default one, so the binary can
+ *    receive an over-the-air update published for unrelated work while the
+ *    suite is running. The build under test stops being the build that was
+ *    made, and the run is no longer reproducible.
+ *
+ * Both are cheap to detect and expensive to discover late, so this runs before
+ * the build rather than after it.
+ *
+ * ## Why this does not use `JSON.parse`, and does not read one profile
+ *
+ * `eas.json` is not required to be strict JSON — trailing commas are common
+ * and EAS accepts them. A real consumer file (`geminisportsai/frontend-v2`)
+ * has one on line 16, so a strict parse would crash this guard on the very
+ * repository the standard was extracted from.
+ *
+ * And a profile's effective settings are inherited: `dev-e2e` extends
+ * `dev-base` extends `base`, and `developmentClient` may be set on any of
+ * them. Reading only the named profile would pass a profile that inherits
+ * `developmentClient: true` from a parent.
+ * @module scripts/lisa-assert-eas-profile
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+
+/** Channel values that mean "no dedicated channel was chosen". */
+const DEFAULT_CHANNELS = new Set(["default"]);
+
+/** How deep an `extends` chain may go before it is treated as a cycle. */
+const MAX_DEPTH = 20;
+
+/**
+ * Parse `eas.json` the way EAS does rather than the way `JSON.parse` does.
+ *
+ * Strips `//` and block comments, then trailing commas. Deliberately tolerant:
+ * the guard's job is to judge the profile, and refusing to read a file EAS
+ * itself accepts would fail builds over punctuation.
+ * @param {string} text Raw file contents.
+ * @returns {Record<string, any>} The parsed document.
+ */
+export function parseEasJson(text) {
+  const withoutComments = text
+    .replace(/(^|[^:])\/\/.*$/gm, "$1")
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+  const withoutTrailingCommas = withoutComments.replace(/,(\s*[}\]])/g, "$1");
+  return JSON.parse(withoutTrailingCommas);
+}
+
+/**
+ * Flatten a build profile through its `extends` chain.
+ *
+ * Ancestors are applied first so the named profile wins, which is EAS's own
+ * precedence. `env` is merged key-by-key for the same reason.
+ * @param {Record<string, any>} profiles The `build` block.
+ * @param {string} name Profile to resolve.
+ * @returns {Record<string, any>} The effective profile.
+ */
+export function resolveProfile(profiles, name) {
+  const chain = [];
+  const seen = new Set();
+  let current = name;
+
+  while (current) {
+    if (seen.has(current)) {
+      throw new Error(
+        `The build profile "${name}" extends itself through "${current}", so its settings cannot be worked out. Break the loop in eas.json.`
+      );
+    }
+    if (chain.length >= MAX_DEPTH) {
+      throw new Error(
+        `The build profile "${name}" extends more than ${MAX_DEPTH} profiles deep, which almost certainly means a loop in eas.json.`
+      );
+    }
+    const profile = profiles?.[current];
+    if (!profile) {
+      const known = Object.keys(profiles ?? {});
+      throw new Error(
+        `eas.json has no build profile called "${current}"` +
+          (current === name ? "" : ` (reached by extending from "${name}")`) +
+          `. It defines: ${known.length ? known.join(", ") : "none"}.`
+      );
+    }
+    seen.add(current);
+    chain.unshift(profile);
+    current = profile.extends;
+  }
+
+  const effective = {};
+  for (const link of chain) {
+    Object.assign(effective, link, {
+      env: { ...(effective.env ?? {}), ...(link.env ?? {}) },
+    });
+  }
+  delete effective.extends;
+  return effective;
+}
+
+/**
+ * Judge a resolved profile, returning every problem rather than the first.
+ * @param {Record<string, any>} profile Effective profile.
+ * @param {string} name Its name, for the messages.
+ * @returns {string[]} Operator-readable problems; empty means usable.
+ */
+export function problemsWith(profile, name) {
+  const problems = [];
+
+  if (profile.developmentClient === true) {
+    problems.push(
+      `"${name}" builds a development client (developmentClient: true). A development client loads the app's JavaScript from a Metro server at runtime, and there is no Metro server in CI, so the app opens its "development servers" screen instead of the product and every flow fails on a screen that is not part of the app. Set developmentClient: false on the profile used for end-to-end runs.`
+    );
+  }
+
+  const channel = profile.channel;
+  if (!channel) {
+    problems.push(
+      `"${name}" sets no channel, so the build takes the default one and can receive an over-the-air update published for unrelated work while the suite is running — meaning the build being tested is no longer the build that was made. Give the profile its own channel, conventionally "e2e".`
+    );
+  } else if (DEFAULT_CHANNELS.has(channel)) {
+    problems.push(
+      `"${name}" uses the "${channel}" channel, which is shared with everything else that does not choose one, so an unrelated over-the-air update can replace the build mid-suite. Give the profile its own channel, conventionally "e2e".`
+    );
+  }
+
+  return problems;
+}
+
+/**
+ * CLI entry point.
+ * @param {string[]} argv Arguments after the script path.
+ * @returns {number} Process exit code.
+ */
+export function main(argv) {
+  const flag = name => {
+    const hit = argv.find(arg => arg.startsWith(`--${name}=`));
+    return hit ? hit.slice(name.length + 3) : null;
+  };
+  const file = flag("file") ?? "eas.json";
+  const name = flag("profile");
+
+  if (!name) {
+    console.error(
+      "usage: lisa-assert-eas-profile.mjs --profile=<name> [--file=eas.json]"
+    );
+    return 1;
+  }
+
+  if (!existsSync(file)) {
+    // Not every project builds with EAS. One that does not has no profile to
+    // judge, and inventing a failure here would block suites that never had
+    // this class of problem.
+    console.log(
+      `No ${file} in this project, so there is no EAS build profile to check.`
+    );
+    return 0;
+  }
+
+  let document;
+  try {
+    document = parseEasJson(readFileSync(file, "utf8"));
+  } catch (error) {
+    console.error(
+      `::error title=Unreadable eas.json::${file} could not be read: ${error.message}`
+    );
+    return 1;
+  }
+
+  let profile;
+  try {
+    profile = resolveProfile(document.build, name);
+  } catch (error) {
+    console.error(`::error title=EAS profile not usable::${error.message}`);
+    return 1;
+  }
+
+  const problems = problemsWith(profile, name);
+  for (const problem of problems) {
+    console.error(`::error title=EAS profile not usable for E2E::${problem}`);
+  }
+  if (problems.length) {
+    console.error(
+      `\nThe "${name}" profile would build an app the suite cannot drive, so the build was stopped before it started rather than after ninety minutes.`
+    );
+    return 1;
+  }
+
+  console.log(
+    `EAS profile "${name}" is usable for end-to-end runs: developmentClient=${profile.developmentClient === true}, channel=${profile.channel}.`
+  );
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/lisa-assert-eas-profile.mjs
+++ b/scripts/lisa-assert-eas-profile.mjs
@@ -34,6 +34,8 @@
 
 import { existsSync, readFileSync } from "node:fs";
 
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
+
 /** Channel values that mean "no dedicated channel was chosen". */
 const DEFAULT_CHANNELS = new Set(["default"]);
 
@@ -200,6 +202,9 @@ export function main(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Realpath both sides rather than comparing URL strings: agents in this repo
+// run from git worktrees and /tmp on macOS, both symlinked, where a raw
+// comparison silently answers "no" and the CLI body never runs.
+if (invokedAsScript(import.meta.url)) {
   process.exit(main(process.argv.slice(2)));
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -242,6 +242,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "b807c9c94a3b00b93d2463a9b098dac41db227ac1f5b0b1cb746e5e6f68de15d",
     "expo/create-only/e2e.thresholds.json":
       "23ac9bab7fe84cfa542785156425e020af9baabdbeb1a53293ae7e2395e4dd92",
+    "expo/create-only/eas.json":
+      "3d710e6c1ac1d40e60aab765c8766f276a5ee1012057b0eda405eac54d301321",
     "expo/create-only/jest.config.local.ts":
       "0647741c9df4cecc1b7c285e28bfbec217994f0b7984eecf81ca47095e936754",
     "expo/create-only/jest.config.react-native-mock.js":
@@ -2184,6 +2186,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "791f01b55dd7a6b5d9a5f4cb9c44167caa146c2fc3c31a2ae4c2d8a350adc2f1",
     "scripts/lib/reusable-workflow-contract.mjs":
       "134ee2a327290f066f1eb318b5ed53c711557c3e10ed462c00ff5c97cfb20863",
+    "scripts/lisa-assert-eas-profile.mjs":
+      "427592ff10bf90eb22599d5b55aa24529961f4fd619defbc380b868583de71b8",
     "scripts/lisa-commit-and-pr-local.sh":
       "605409c3ce6ec38ad3275604291a1ceae98f7807a605654263bc14f811c03903",
     "scripts/lisa-enforcement-fallback.sh":
@@ -2733,6 +2737,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "expo/create-only/bdd/coverage-map.json": true,
     "expo/create-only/bdd/features/.keep": true,
     "expo/create-only/e2e.thresholds.json": true,
+    "expo/create-only/eas.json": true,
     "expo/create-only/jest.config.local.ts": true,
     "expo/create-only/jest.config.react-native-mock.js": true,
     "expo/create-only/jest.setup.local.ts": true,
@@ -8214,6 +8219,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/lib/per-agent-hook-filter.mjs": true,
     "scripts/lib/reusable-workflow-contract.d.mts": true,
     "scripts/lib/reusable-workflow-contract.mjs": true,
+    "scripts/lisa-assert-eas-profile.mjs": true,
     "scripts/lisa-commit-and-pr-local.sh": true,
     "scripts/lisa-enforcement-fallback.sh": true,
     "scripts/lisa-github-environments.sh": true,
@@ -8681,6 +8687,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/jest-expo-haste-pruning.test.ts": true,
     "tests/integration/lisa.test.ts": true,
     "tests/integration/maestro-caller-template.test.ts": true,
+    "tests/integration/maestro-eas-profile-guard.test.ts": true,
     "tests/integration/maestro-leg-order-wait.test.ts": true,
     "tests/integration/maestro-leg-order.test.ts": true,
     "tests/integration/maestro-native-concurrency.test.ts": true,
@@ -9056,6 +9063,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/github-governance.test.ts": true,
     "tests/unit/scripts/install-claude-plugins-self.test.ts": true,
     "tests/unit/scripts/invoked-as-script.test.ts": true,
+    "tests/unit/scripts/lisa-assert-eas-profile.test.ts": true,
     "tests/unit/scripts/lisa-gates-evidence.test.ts": true,
     "tests/unit/scripts/lisa-gates-fixtures.ts": true,
     "tests/unit/scripts/lisa-gates-moment-validation.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2187,7 +2187,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lib/reusable-workflow-contract.mjs":
       "134ee2a327290f066f1eb318b5ed53c711557c3e10ed462c00ff5c97cfb20863",
     "scripts/lisa-assert-eas-profile.mjs":
-      "427592ff10bf90eb22599d5b55aa24529961f4fd619defbc380b868583de71b8",
+      "0e4143ed0569b7d5361d8d0f1b6ca0268d6189804dca11cf970121712d7b9577",
     "scripts/lisa-commit-and-pr-local.sh":
       "605409c3ce6ec38ad3275604291a1ceae98f7807a605654263bc14f811c03903",
     "scripts/lisa-enforcement-fallback.sh":

--- a/tests/integration/maestro-eas-profile-guard.test.ts
+++ b/tests/integration/maestro-eas-profile-guard.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests that the EAS profile guard is wired where it can still save the build.
+ *
+ * The guard's value is entirely in its position: the two profile mistakes it
+ * catches are free to detect before the build and cost a ninety-minute native
+ * build to discover after it — and when they surface after, they surface as
+ * flows failing on screens that are not part of the app, which reads as a
+ * product bug rather than a configuration one.
+ *
+ * A test that only checked the step existed would pass with the step at the
+ * end of the job, so ORDER is what is asserted here.
+ * @module tests/integration/maestro-eas-profile-guard
+ */
+
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { loadWorkflow } from "../helpers/workflow-test-utils.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKFLOW = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+const workflow = loadWorkflow(WORKFLOW);
+const steps = workflow.jobs.build?.steps ?? [];
+
+/** The guard step, named once so the assertions cannot drift from it. */
+const GUARD = "Check the build profile";
+const indexOf = (fragment: string) =>
+  steps.findIndex(step => step.name?.includes(fragment));
+
+describe("the EAS profile guard runs before anything expensive", () => {
+  it("is present in the build job", () => {
+    expect(indexOf(GUARD)).toBeGreaterThan(-1);
+  });
+
+  it("runs before the EAS build", () => {
+    expect(indexOf(GUARD)).toBeLessThan(indexOf("Build with EAS"));
+  });
+
+  it("runs before EAS setup, so a bad profile costs no EAS session", () => {
+    expect(indexOf(GUARD)).toBeLessThan(indexOf("Setup EAS"));
+  });
+
+  it("runs after install, because it resolves out of node_modules", () => {
+    expect(indexOf(GUARD)).toBeGreaterThan(indexOf("Install dependencies"));
+  });
+});
+
+describe("the guard resolves from the package, not a copied file", () => {
+  const body = steps[indexOf(GUARD)]?.run ?? "";
+
+  it("prefers the installed package", () => {
+    const pkg = body.indexOf("node_modules/@codyswann/lisa");
+    const local = body.indexOf('"scripts/lisa-assert-eas-profile.mjs"');
+    expect(pkg).toBeGreaterThan(-1);
+    expect(pkg).toBeLessThan(local === -1 ? Infinity : local);
+  });
+
+  it("passes the caller's profile rather than assuming a name", () => {
+    expect(body).toContain("inputs.eas_profile");
+  });
+
+  it("does not fail a project whose Lisa predates the guard", () => {
+    // The guard blocking builds over its own rollout would be a worse failure
+    // than the one it prevents.
+    expect(body).toContain("::warning title=EAS profile unchecked");
+    expect(body).toContain("exit 0");
+  });
+
+  it("does not discard the guard's output", () => {
+    expect(body).not.toContain("2>/dev/null");
+    expect(body).toContain("set -euo pipefail");
+  });
+
+  it("cannot report success while the guard fails", () => {
+    const step = steps[indexOf(GUARD)] as Record<string, unknown>;
+    expect(step["continue-on-error"]).toBeUndefined();
+  });
+});
+
+describe("the iOS driver timeout stays generous", () => {
+  it("keeps a startup bound of at least 180s", () => {
+    // The suite abandons itself if the XCUITest driver never binds its port,
+    // so this bound must exceed a slow cold start on a fresh simulator.
+    const input = workflow.on?.workflow_call?.inputs
+      ?.ios_driver_startup_timeout_ms as { default?: number } | undefined;
+    expect(Number(input?.default)).toBeGreaterThanOrEqual(180000);
+  });
+});

--- a/tests/integration/maestro-eas-profile-guard.test.ts
+++ b/tests/integration/maestro-eas-profile-guard.test.ts
@@ -65,8 +65,15 @@ describe("the guard resolves from the package, not a copied file", () => {
     expect(pkg).toBeLessThan(local === -1 ? Infinity : local);
   });
 
-  it("passes the caller's profile rather than assuming a name", () => {
-    expect(body).toContain("inputs.eas_profile");
+  it("passes the caller's profile through env, never into the script text", () => {
+    // A caller supplies this value, so `${{ }}` inside the run body would make
+    // it workflow SOURCE rather than an argument — shell metacharacters in a
+    // profile name would execute. Same reason the resolved gate command
+    // travels by env in quality.yml.
+    const step = steps[indexOf(GUARD)];
+    expect(step?.env?.EAS_PROFILE).toBe("${{ inputs.eas_profile }}");
+    expect(body).toContain('--profile="$EAS_PROFILE"');
+    expect(body).not.toContain("${{ inputs.eas_profile }}");
   });
 
   it("does not fail a project whose Lisa predates the guard", () => {

--- a/tests/unit/scripts/lisa-assert-eas-profile.test.ts
+++ b/tests/unit/scripts/lisa-assert-eas-profile.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests the EAS build-profile guard.
+ *
+ * Two mistakes waste a full native build and then fail the suite in a way that
+ * reads as a product bug: a development-client profile (which needs a Metro
+ * server CI does not have) and a profile with no channel (which lets an
+ * unrelated over-the-air update replace the build mid-suite).
+ *
+ * The two cases worth stating outright, because a naive guard fails both:
+ * `eas.json` need not be strict JSON, and a profile's settings are inherited
+ * through `extends`.
+ * @module tests/unit/scripts/lisa-assert-eas-profile
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  parseEasJson,
+  problemsWith,
+  resolveProfile,
+} from "../../../scripts/lisa-assert-eas-profile.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "scripts",
+  "lisa-assert-eas-profile.mjs"
+);
+
+/** A profile shaped like the standard Lisa ships. */
+const E2E = {
+  extends: "dev-base",
+  developmentClient: false,
+  channel: "e2e",
+};
+
+describe("parseEasJson accepts what EAS accepts", () => {
+  it("reads a file with a trailing comma, which JSON.parse rejects", () => {
+    // Not hypothetical: geminisportsai/frontend-v2's eas.json has one on line
+    // 16, so a strict parse would crash this guard on the very repository the
+    // standard was extracted from.
+    const text = '{"build":{"base":{"channel":"e2e",}}}';
+    expect(() => JSON.parse(text)).toThrow();
+    expect(parseEasJson(text)).toEqual({
+      build: { base: { channel: "e2e" } },
+    });
+  });
+
+  it("reads a file with comments", () => {
+    const text = `{
+      // the profile the suite builds
+      "build": { "dev-e2e": { "channel": "e2e" } }
+    }`;
+    expect(parseEasJson(text).build["dev-e2e"].channel).toBe("e2e");
+  });
+
+  it("does not mistake a URL's slashes for a comment", () => {
+    const text = '{"build":{"base":{"env":{"API":"https://example.com/x"}}}}';
+    expect(parseEasJson(text).build.base.env.API).toBe("https://example.com/x");
+  });
+});
+
+describe("resolveProfile flattens the extends chain", () => {
+  const profiles = {
+    base: { channel: "default", env: { A: "1" } },
+    "dev-base": { extends: "base", developmentClient: true, env: { B: "2" } },
+    "dev-e2e": E2E,
+  };
+
+  it("lets the named profile win over its ancestors", () => {
+    const resolved = resolveProfile(profiles, "dev-e2e");
+    expect(resolved.developmentClient).toBe(false);
+    expect(resolved.channel).toBe("e2e");
+  });
+
+  it("inherits what the named profile does not set", () => {
+    // The case a guard reading only the named profile gets wrong.
+    const resolved = resolveProfile(profiles, "dev-base");
+    expect(resolved.channel).toBe("default");
+  });
+
+  it("merges env across the chain", () => {
+    expect(resolveProfile(profiles, "dev-e2e").env).toEqual({
+      A: "1",
+      B: "2",
+    });
+  });
+
+  it("names the profiles that exist when one does not", () => {
+    expect(() => resolveProfile(profiles, "nope")).toThrow(/dev-e2e/);
+  });
+
+  it("refuses a cycle rather than looping forever", () => {
+    expect(() =>
+      resolveProfile({ a: { extends: "b" }, b: { extends: "a" } }, "a")
+    ).toThrow(/extends itself/);
+  });
+});
+
+describe("problemsWith judges the resolved profile", () => {
+  it("passes a profile that is not a dev client and has its own channel", () => {
+    expect(
+      problemsWith({ developmentClient: false, channel: "e2e" }, "dev-e2e")
+    ).toEqual([]);
+  });
+
+  it("fails a development client, and says why it breaks the suite", () => {
+    const [problem] = problemsWith(
+      { developmentClient: true, channel: "e2e" },
+      "dev"
+    );
+    expect(problem).toMatch(/Metro server/);
+  });
+
+  it("fails a profile with no channel", () => {
+    expect(problemsWith({ developmentClient: false }, "dev-e2e")).toHaveLength(
+      1
+    );
+  });
+
+  it("fails the shared default channel", () => {
+    const [problem] = problemsWith(
+      { developmentClient: false, channel: "default" },
+      "dev-e2e"
+    );
+    expect(problem).toMatch(/over-the-air/);
+  });
+
+  it("reports every problem at once, not just the first", () => {
+    expect(problemsWith({ developmentClient: true }, "dev")).toHaveLength(2);
+  });
+
+  it("catches a dev client inherited from a parent", () => {
+    // The whole reason resolution happens before judgement.
+    const profiles = {
+      "dev-base": { developmentClient: true, channel: "e2e" },
+      "dev-e2e": { extends: "dev-base" },
+    };
+    expect(
+      problemsWith(resolveProfile(profiles, "dev-e2e"), "dev-e2e")
+    ).toHaveLength(1);
+  });
+});
+
+describe("the CLI", () => {
+  const run = (contents: string | null, profile: string) => {
+    const dir = mkdtempSync(path.join(tmpdir(), "lisa-eas-"));
+    const file = path.join(dir, "eas.json");
+    if (contents !== null) writeFileSync(file, contents, "utf8");
+    const result = spawnSync(
+      process.execPath,
+      [SCRIPT, `--file=${file}`, `--profile=${profile}`],
+      { encoding: "utf8" }
+    );
+    rmSync(dir, { recursive: true, force: true });
+    return { status: result.status, out: `${result.stdout}${result.stderr}` };
+  };
+
+  it("passes a usable profile", () => {
+    const { status } = run(
+      '{"build":{"dev-e2e":{"developmentClient":false,"channel":"e2e"}}}',
+      "dev-e2e"
+    );
+    expect(status).toBe(0);
+  });
+
+  it("fails a dev-client profile", () => {
+    const { status, out } = run(
+      '{"build":{"dev-e2e":{"developmentClient":true,"channel":"e2e"}}}',
+      "dev-e2e"
+    );
+    expect(status).toBe(1);
+    expect(out).toContain("::error");
+  });
+
+  it("passes a project with no eas.json rather than inventing a failure", () => {
+    // Not every project builds with EAS, and blocking those would fail suites
+    // that never had this class of problem.
+    const { status } = run(null, "dev-e2e");
+    expect(status).toBe(0);
+  });
+
+  it("requires a profile name", () => {
+    const result = spawnSync(process.execPath, [SCRIPT], { encoding: "utf8" });
+    expect(result.status).toBe(1);
+    expect(`${result.stderr}`).toContain("usage:");
+  });
+});


### PR DESCRIPTION
## The problem

The mobile end-to-end workflow builds a real app with EAS and then drives it
like a person would. Which app it builds is decided by a "build profile" in the
project's `eas.json`, and two profile mistakes break the run in a way that is
very hard to read:

1. **A development-client profile.** A development client is a shell that loads
   the app's code from a local server at runtime. There is no such server in
   CI, so the app opens its "development servers" screen instead of the
   product. Every test then fails on a screen that does not exist in the app,
   which looks like the app is broken rather than the configuration.
2. **A profile with no release channel.** The build takes the shared default
   channel, so an over-the-air update published for unrelated work can replace
   the app *while the suite is running*. The build being tested stops being the
   build that was made, and the run cannot be reproduced.

Both cost a full native build — up to ninety minutes — before anything shows a
symptom, and the symptom points at the wrong thing.

## What this adds

**A check that runs before the build**, in the same job, immediately after
dependencies are installed and *before* EAS is even set up. A bad profile now
costs about a minute instead of an hour and a half, and says exactly what is
wrong and how to fix it.

**A standard `eas.json` for new Expo projects.** Lisa previously shipped none at
all, so every project invented its own and there was nothing for the check to
be a standard against. The `dev-e2e` profile in it is the one the workflow
expects by default.

## Two things the obvious version of this check gets wrong

**`eas.json` does not have to be strict JSON.** Trailing commas are common and
EAS accepts them. A real project's file — `geminisportsai/frontend-v2` — has one
on line 16, so a check using a strict JSON reader would crash on the very
project this standard came from. Verified against that actual file.

**Profiles inherit from each other.** `dev-e2e` builds on `dev-base`, which
builds on `base`, and the development-client setting can be on any of them. A
check that reads only the named profile would approve one that inherits the
broken setting from a parent. The check resolves the whole chain first.

## Deliberately not done

**The driver-startup timeout was already better than the plan called for.** The
plan said to ship 180000ms; the workflow already accepts this as an input and
defaults to **240000ms**. Lowering it would have been a regression, so it was
left alone and the test now pins it at 180000 or higher rather than at an exact
value.

## Done when

- [x] A bad profile fails before the build, not after
- [x] A development-client profile is refused, including when inherited
- [x] A profile with no channel, or the shared default channel, is refused
- [x] The check reads files EAS accepts but strict JSON does not
- [x] Lisa ships a standard `eas.json` with a `dev-e2e` profile
- [x] A project on an older Lisa is warned, not blocked


Work-Item: CodySwannGT/lisa#2609


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized build and submission profiles for development, staging, production, preview, simulator, and end-to-end workflows.
  * Added validation to ensure selected build profiles are configured correctly before native builds begin.

* **Bug Fixes**
  * Builds now provide clear errors for missing or invalid profiles while remaining compatible with older tooling.

* **Tests**
  * Added coverage for profile inheritance, validation errors, configuration parsing, and workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->