### PR TITLE
fix(hooks): let the git hooks find Lisa's scripts in the installed package

### DIFF
--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2259,15 +2259,15 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "tsconfig/typescript.json":
       "8cf66a6535640e0a723e24bdf7a2d8e58a634c451f0754875c7880811381a914",
     "typescript/copy-contents/.husky/commit-msg":
-      "85336c4d2c5bf5e16dd1b12b8c80668363d64b22e3c2e123955cf00e357fc22d",
+      "7c925044ba7c38e6ffc9f981f743f7d7a8ba7b2b587fc71b23f1b08c115556e6",
     "typescript/copy-contents/.husky/post-checkout":
       "f3abc4528e12d3ad2bc48b236d19f105e2817595c744156a558c62ae5551ccfb",
     "typescript/copy-contents/.husky/pre-commit":
-      "c29bb23a8466dd7f1e04ecbd2df5faaa5eb286f261cff948b9451430c0ca716b",
+      "f1313c83014912df8e769d452a61378eff6bc60a75d3c421974dcd100699b2a5",
     "typescript/copy-contents/.husky/pre-push":
-      "13da67af0060558dd0a81320efe2719ff23ca3e8488000479e063f5ae9025f2c",
+      "9aedd73755e035dd18d49f24effa9bc709df707c8c275692887bf0bee3e78e96",
     "typescript/copy-contents/.husky/prepare-commit-msg":
-      "58671fb61f6fcc1fc384a2d7295f16949faa58150a8213e0a39d3c70fad728b5",
+      "4a719c20da65653f266e7c8a346b5546ad05f1dfa34665fc7fec47e89d2f58d1",
     "typescript/copy-overwrite/.claude/hooks/worktree-create.sh":
       "8dbddc0297ca574d150b3e669550320bd2df6e592c083317626f53a91f36d349",
     "typescript/copy-overwrite/.github/GITHUB_ACTIONS.md":
@@ -8970,6 +8970,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/enforcement-gates-e2e.test.ts": true,
     "tests/unit/hooks/gate-coverage-handover.test.ts": true,
     "tests/unit/hooks/host-enforcement-fallback.test.ts": true,
+    "tests/unit/hooks/husky-resolver-lookup.test.ts": true,
     "tests/unit/hooks/inject-rules.test.ts": true,
     "tests/unit/hooks/install-pkgs-worktree-node-modules.test.ts": true,
     "tests/unit/hooks/lint-on-edit.test.ts": true,

--- a/tests/unit/hooks/husky-resolver-lookup.test.ts
+++ b/tests/unit/hooks/husky-resolver-lookup.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests that the shipped git hooks find Lisa's scripts in the installed
+ * package, not only in a copy inside the project.
+ *
+ * They resolved `scripts/<name>.mjs` and then `all/copy-overwrite/scripts/<name>.mjs`
+ * — the second of which exists only inside Lisa itself. In a consumer with no
+ * copy, neither path exists, the `[ -f ]` guard fails, and **the whole registry
+ * handover is skipped**: the gates block governs nothing locally and the
+ * built-in steps run instead.
+ *
+ * That is fail-safe (more checking, not less) and still wrong, because a
+ * project that declared its gates has no way to tell they are being ignored.
+ * Measured across the portfolio: three of four repositories have no copy at
+ * all, and the fourth's copy was two releases stale.
+ *
+ * The same defect was fixed in `quality.yml`'s façade; these are the local
+ * half of it.
+ * @module tests/unit/hooks/husky-resolver-lookup
+ */
+
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const HOOKS = path.join(REPO_ROOT, "typescript", "copy-contents", ".husky");
+
+/** The two Lisa scripts the shipped hooks invoke. */
+const RUN_GATES = "lisa-run-gates.mjs";
+const WORK_ITEM = "lisa-work-item.mjs";
+
+/** Every shipped hook that resolves a Lisa script, and which one. */
+const LOOKUPS = [
+  { hook: "pre-commit", varName: "GATE_RUNNER", script: RUN_GATES },
+  { hook: "pre-push", varName: "GATE_RUNNER", script: RUN_GATES },
+  {
+    hook: "pre-push",
+    varName: "WORK_ITEM_SCRIPT",
+    script: WORK_ITEM,
+  },
+  {
+    hook: "prepare-commit-msg",
+    varName: "WORK_ITEM_SCRIPT",
+    script: WORK_ITEM,
+  },
+  {
+    hook: "commit-msg",
+    varName: "WORK_ITEM_SCRIPT",
+    script: WORK_ITEM,
+  },
+] as const;
+
+/**
+ * Read one shipped hook.
+ * @param hook - File name under the husky template directory.
+ * @returns Its contents.
+ */
+const read = (hook: string): string =>
+  readFileSync(path.join(HOOKS, hook), "utf8");
+
+describe("the shipped hooks resolve Lisa scripts from the package", () => {
+  it.each(LOOKUPS)(
+    "$hook offers the installed package for $script",
+    ({ hook, script }) => {
+      expect(read(hook)).toContain(
+        `node_modules/@codyswann/lisa/all/copy-overwrite/scripts/${script}`
+      );
+    }
+  );
+
+  it.each(LOOKUPS)(
+    "$hook prefers the package over a copy in the project for $script",
+    ({ hook, script }) => {
+      // A copy can be edited once and then never receives a fix again, so the
+      // installed package — one versioned copy — is tried first.
+      const body = read(hook);
+      const pkg = body.indexOf(
+        `node_modules/@codyswann/lisa/all/copy-overwrite/scripts/${script}`
+      );
+      const copy = body.indexOf(`"scripts/${script}"`);
+      expect(pkg).toBeGreaterThan(-1);
+      expect(copy).toBeGreaterThan(-1);
+      expect(pkg).toBeLessThan(copy);
+    }
+  );
+
+  it.each(LOOKUPS)(
+    "$hook still lets Lisa run its own hooks for $script",
+    ({ hook, script }) => {
+      // Last candidate, and the only one that resolves inside this repository,
+      // where the package is not installed into itself.
+      const body = read(hook);
+      const own = body.indexOf(`"all/copy-overwrite/scripts/${script}"`);
+      const copy = body.indexOf(`"scripts/${script}"`);
+      expect(own).toBeGreaterThan(copy);
+    }
+  );
+});

--- a/typescript/copy-contents/.husky/commit-msg
+++ b/typescript/copy-contents/.husky/commit-msg
@@ -20,7 +20,10 @@ fi
 # Get the commit message file path
 COMMIT_MSG_FILE=$1
 
-WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+WORK_ITEM_SCRIPT="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+fi
 if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
   WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
 fi

--- a/typescript/copy-contents/.husky/pre-commit
+++ b/typescript/copy-contents/.husky/pre-commit
@@ -76,7 +76,10 @@ fi
 # Fail-safe by construction: no coverage file, an empty one, a runner that
 # could not run, or no exact match, all mean the built-in step runs.
 # ---------------------------------------------------------------------------
-GATE_RUNNER="scripts/lisa-run-gates.mjs"
+GATE_RUNNER="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-run-gates.mjs"
+if [ ! -f "$GATE_RUNNER" ]; then
+  GATE_RUNNER="scripts/lisa-run-gates.mjs"
+fi
 if [ ! -f "$GATE_RUNNER" ]; then
   GATE_RUNNER="all/copy-overwrite/scripts/lisa-run-gates.mjs"
 fi

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -1,6 +1,9 @@
 # BEGIN: AI GUARDRAILS
 
-WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+WORK_ITEM_SCRIPT="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+fi
 if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
   WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
 fi
@@ -58,7 +61,10 @@ echo "📦 Using package manager: $PACKAGE_MANAGER"
 # The project-specific extension slots at the bottom of this file run either
 # way — they are project behaviour, not registry gates.
 # ---------------------------------------------------------------------------
-GATE_RUNNER="scripts/lisa-run-gates.mjs"
+GATE_RUNNER="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-run-gates.mjs"
+if [ ! -f "$GATE_RUNNER" ]; then
+  GATE_RUNNER="scripts/lisa-run-gates.mjs"
+fi
 if [ ! -f "$GATE_RUNNER" ]; then
   GATE_RUNNER="all/copy-overwrite/scripts/lisa-run-gates.mjs"
 fi

--- a/typescript/copy-contents/.husky/prepare-commit-msg
+++ b/typescript/copy-contents/.husky/prepare-commit-msg
@@ -1,6 +1,9 @@
 # BEGIN: AI GUARDRAILS
 
-WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+WORK_ITEM_SCRIPT="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-work-item.mjs"
+if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
+  WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
+fi
 if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
   WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
 fi


### PR DESCRIPTION
## The problem

Lisa's git hooks hand their work over to a shared script. They look for it in
two places:

```
scripts/lisa-run-gates.mjs                      a copy inside the project
all/copy-overwrite/scripts/lisa-run-gates.mjs   exists only inside Lisa itself
```

The second path only resolves inside the Lisa repository. So in a project with
no copy, **neither path exists**, the file check fails, and the whole handover
is skipped: the project's declared quality gates govern nothing at commit or
push time.

## How common that is

Measured across the four portfolio projects:

```
TunnlAI/frontend             no copy
PropSwapLLC/frontend         copy present, two releases stale
geminisportsai/frontend-v2   no copy
geminisportsai/backend-v2    no copy
```

Three of four. Their gate declarations have no local effect at all, and the
fourth was running logic two releases old.

## Why it went unnoticed

It fails safely. With no handover, the hooks run their own built-in checks
instead — so *more* is checked, not less, and nothing breaks. What is lost is
the project's ability to configure anything: it declares gates, sees no error,
and is quietly ignored.

That is the same shape as the CI defect fixed alongside this, where a
declaration of `off` governed nothing. A setting that is silently disregarded
is worse than one that is rejected, because nothing prompts anyone to look.

## The fix

Look in the installed package first:

```
node_modules/@codyswann/lisa/all/copy-overwrite/scripts/<script>   the package
scripts/<script>                                                  a copy, if any
all/copy-overwrite/scripts/<script>                               Lisa itself
```

Package first because a copy inside a project can be edited once and then never
receives a fix again — which is what happened to the fourth project above. The
copy stays as a second option so nothing breaks while copies are still around,
and the Lisa-internal path stays last so this repository can still run its own
hooks.

Five lookups across four hook files.

## Done when

- [x] Every shipped hook offers the installed package
- [x] The package is preferred over a copy inside the project
- [x] A copy still works, so nothing breaks before the copies are retired
- [x] Lisa can still run its own hooks
- [x] Pinned by tests, so the order cannot drift back


Work-Item: CodySwannGT/lisa#2613
