### PR TITLE
feat(hooks): refuse agent writes to copy-overwrite templates

### DIFF
--- a/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh
+++ b/all/copy-overwrite/scripts/lisa-enforcement-fallback.sh
@@ -70,7 +70,8 @@ repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 # `plugins/` directory to fall back on.
 status=0
 for guard in block-no-verify parity-safety-net block-shell-json-parsing \
-  block-instruction-file-edits block-direct-issue-create; do
+  block-instruction-file-edits block-direct-issue-create \
+  block-managed-file-edits; do
   script=""
   for candidate in \
     "$repo_root/scripts/lisa-hooks/$guard.sh" \

--- a/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# This file is managed by Lisa and IS replaced on each `lisa` run.
+# Do not edit directly — durable changes belong upstream in Lisa.
+
+# PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
+#
+# Lisa ships templates in three modes, and only one of them destroys host edits:
+#
+#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
+#                    gone at the next `bun install`, silently.
+#   copy-contents  — Lisa APPENDS its lines; host content survives.
+#   create-only    — skipped when the file exists; the host owns it outright.
+#
+# So this guard covers copy-overwrite and nothing else. Blocking the other two
+# would stop agents editing files they are supposed to own, which is worse than
+# the problem being solved.
+#
+# Measured, not hypothetical. Nothing enforced this, so downstream copies were
+# edited and then silently diverged: `classify-maestro-failures.mjs` reached
+# 36,061 bytes in one fleet repo against 29,586 shipped, and five gate files in
+# another stopped receiving upstream fixes — one over roughly 138 bytes of
+# cosmetic change. The edits were made in good faith; nothing told anyone the
+# file was not theirs.
+#
+# ## Why the path, not a banner comment
+#
+# 103 of Lisa's 145 copy-overwrite files carry a "managed by Lisa" header, and
+# the other 42 CANNOT: 30 are `.json` (no comment syntax), 8 are `.gitkeep` /
+# `.keep` placeholders, and the rest are bare-value files like `.nvmrc`. A guard
+# keyed on the banner would miss every one of them, so this resolves the path
+# against the installed package instead and covers all 145 regardless of format.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target resolves to a
+#      copy-overwrite template in the installed Lisa package;
+#   2. Bash output redirection (`>`, `>>`, `>|`), `tee`, or `sed -i` aimed at
+#      one. Reads never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_MANAGED_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's;
+#   - the Lisa source repository itself, where these files are the originals and
+#     editing them is the entire point.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override, checked first so it is always the cheapest way out.
+if [ -n "${LISA_ALLOW_MANAGED_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+project_root="${CLAUDE_PROJECT_DIR:-$PWD}"
+package_root="$project_root/node_modules/@codyswann/lisa"
+
+# No installed Lisa means nothing to classify against. Silent, because a project
+# that has not installed Lisa is not doing anything wrong.
+[ -d "$package_root" ] || exit 0
+
+# In Lisa's own repository these files ARE the originals. Blocking here would
+# make the templates uneditable by the only agents that should edit them.
+if [ -f "$project_root/package.json" ] &&
+  grep -q '"name": *"@codyswann/lisa"' "$project_root/package.json" 2>/dev/null; then
+  exit 0
+fi
+
+# Whether a host-relative path is shipped as a copy-overwrite template.
+#
+# A few stat calls rather than an enumeration: the same relative path is probed
+# under each stack's copy-overwrite tree, so cost does not grow with the 145
+# templates.
+managed_source() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  # Normalise to a project-relative path so an absolute target still matches.
+  local rel="${candidate#"$project_root"/}"
+  rel="${rel#./}"
+  [ -n "$rel" ] || return 1
+  local stack
+  for stack in "$package_root"/*/copy-overwrite; do
+    [ -d "$stack" ] || continue
+    if [ -e "$stack/$rel" ]; then
+      printf '%s' "${stack#"$package_root"/}/$rel"
+      return 0
+    fi
+  done
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  local source="$2"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
+(\`$source\` in the installed package) and is replaced wholesale on every
+\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
+until the next install and then vanish, with nothing reporting that it had.
+
+That is not hypothetical: downstream copies edited this way diverged silently
+until they stopped receiving upstream fixes entirely.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. The change should apply everywhere. Edit the template upstream in Lisa and
+   release it — \`/lisa:cross-pollinate\`, or an issue on CodySwannGT/lisa.
+   That is the only edit that survives an install.
+
+2. Only this project needs to differ. Look for the local escape hatch beside the
+   file — Lisa ships \`.local\` variants for the configs that support one
+   (\`eslint.config.local.ts\`, \`tsconfig.local.json\`, \`audit.ignore.local.json\`,
+   and others). Those are yours and are never overwritten.
+
+3. The behaviour is configurable rather than hardcoded. Check \`.lisa.config.json\`
+   — the \`gates\` block in particular decides which checks run and what command
+   proves each one, so a project can substitute its own task without touching a
+   shipped file.
+
+4. You believe this file should not be Lisa-managed at all. That is a real
+   argument and it belongs upstream, not in a local edit that will be erased.
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_MANAGED_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if source_path="$(managed_source "$candidate")"; then
+        refuse "$candidate" "$source_path"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Write signatures only. A bare mention is a read and stays allowed — the
+    # path has to be the target of a redirection, a tee, or an in-place sed.
+    # `>>?\|?` covers `>`, `>>`, and the noclobber override `>|`.
+    while IFS= read -r token; do
+      [ -n "$token" ] || continue
+      if source_path="$(managed_source "$token")"; then
+        refuse "$token" "$source_path"
+      fi
+    done <<EOF
+$(printf '%s' "$command_str" |
+  grep -Eo ">>?\|?[[:space:]]*['\"]?[^ |;&'\"]+|tee([[:space:]]+-[a-zA-Z]+)*[[:space:]]+['\"]?[^ |;&'\"]+|sed[[:space:]]+[^|;&]*-i[^|;&]*[[:space:]]['\"]?[^ |;&'\"]+" 2>/dev/null |
+  sed -E "s/^(>>?\|?|tee([[:space:]]+-[a-zA-Z]+)*|sed[[:space:]]+[^|;&]*-i[^|;&]*)[[:space:]]*//" |
+  tr -d "\"'" || true)
+EOF
+    ;;
+esac
+
+exit 0

--- a/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
+#
+# Lisa ships templates in three modes, and only one of them destroys host edits:
+#
+#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
+#                    gone at the next `bun install`, silently.
+#   copy-contents  — Lisa APPENDS its lines; host content survives.
+#   create-only    — skipped when the file exists; the host owns it outright.
+#
+# So this guard covers copy-overwrite and nothing else. Blocking the other two
+# would stop agents editing files they are supposed to own, which is worse than
+# the problem being solved.
+#
+# Measured, not hypothetical. Nothing enforced this, so downstream copies were
+# edited and then silently diverged: `classify-maestro-failures.mjs` reached
+# 36,061 bytes in one fleet repo against 29,586 shipped, and five gate files in
+# another stopped receiving upstream fixes — one over roughly 138 bytes of
+# cosmetic change. The edits were made in good faith; nothing told anyone the
+# file was not theirs.
+#
+# ## Why the path, not a banner comment
+#
+# 103 of Lisa's 145 copy-overwrite files carry a "managed by Lisa" header, and
+# the other 42 CANNOT: 30 are `.json` (no comment syntax), 8 are `.gitkeep` /
+# `.keep` placeholders, and the rest are bare-value files like `.nvmrc`. A guard
+# keyed on the banner would miss every one of them, so this resolves the path
+# against the installed package instead and covers all 145 regardless of format.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target resolves to a
+#      copy-overwrite template in the installed Lisa package;
+#   2. Bash output redirection (`>`, `>>`, `>|`), `tee`, or `sed -i` aimed at
+#      one. Reads never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_MANAGED_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's;
+#   - the Lisa source repository itself, where these files are the originals and
+#     editing them is the entire point.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override, checked first so it is always the cheapest way out.
+if [ -n "${LISA_ALLOW_MANAGED_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+project_root="${CLAUDE_PROJECT_DIR:-$PWD}"
+package_root="$project_root/node_modules/@codyswann/lisa"
+
+# No installed Lisa means nothing to classify against. Silent, because a project
+# that has not installed Lisa is not doing anything wrong.
+[ -d "$package_root" ] || exit 0
+
+# In Lisa's own repository these files ARE the originals. Blocking here would
+# make the templates uneditable by the only agents that should edit them.
+if [ -f "$project_root/package.json" ] &&
+  grep -q '"name": *"@codyswann/lisa"' "$project_root/package.json" 2>/dev/null; then
+  exit 0
+fi
+
+# Whether a host-relative path is shipped as a copy-overwrite template.
+#
+# A few stat calls rather than an enumeration: the same relative path is probed
+# under each stack's copy-overwrite tree, so cost does not grow with the 145
+# templates.
+managed_source() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  # Normalise to a project-relative path so an absolute target still matches.
+  local rel="${candidate#"$project_root"/}"
+  rel="${rel#./}"
+  [ -n "$rel" ] || return 1
+  local stack
+  for stack in "$package_root"/*/copy-overwrite; do
+    [ -d "$stack" ] || continue
+    if [ -e "$stack/$rel" ]; then
+      printf '%s' "${stack#"$package_root"/}/$rel"
+      return 0
+    fi
+  done
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  local source="$2"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
+(\`$source\` in the installed package) and is replaced wholesale on every
+\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
+until the next install and then vanish, with nothing reporting that it had.
+
+That is not hypothetical: downstream copies edited this way diverged silently
+until they stopped receiving upstream fixes entirely.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. The change should apply everywhere. Edit the template upstream in Lisa and
+   release it — \`/lisa:cross-pollinate\`, or an issue on CodySwannGT/lisa.
+   That is the only edit that survives an install.
+
+2. Only this project needs to differ. Look for the local escape hatch beside the
+   file — Lisa ships \`.local\` variants for the configs that support one
+   (\`eslint.config.local.ts\`, \`tsconfig.local.json\`, \`audit.ignore.local.json\`,
+   and others). Those are yours and are never overwritten.
+
+3. The behaviour is configurable rather than hardcoded. Check \`.lisa.config.json\`
+   — the \`gates\` block in particular decides which checks run and what command
+   proves each one, so a project can substitute its own task without touching a
+   shipped file.
+
+4. You believe this file should not be Lisa-managed at all. That is a real
+   argument and it belongs upstream, not in a local edit that will be erased.
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_MANAGED_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if source_path="$(managed_source "$candidate")"; then
+        refuse "$candidate" "$source_path"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Write signatures only. A bare mention is a read and stays allowed — the
+    # path has to be the target of a redirection, a tee, or an in-place sed.
+    # `>>?\|?` covers `>`, `>>`, and the noclobber override `>|`.
+    while IFS= read -r token; do
+      [ -n "$token" ] || continue
+      if source_path="$(managed_source "$token")"; then
+        refuse "$token" "$source_path"
+      fi
+    done <<EOF
+$(printf '%s' "$command_str" |
+  grep -Eo ">>?\|?[[:space:]]*['\"]?[^ |;&'\"]+|tee([[:space:]]+-[a-zA-Z]+)*[[:space:]]+['\"]?[^ |;&'\"]+|sed[[:space:]]+[^|;&]*-i[^|;&]*[[:space:]]['\"]?[^ |;&'\"]+" 2>/dev/null |
+  sed -E "s/^(>>?\|?|tee([[:space:]]+-[a-zA-Z]+)*|sed[[:space:]]+[^|;&]*-i[^|;&]*)[[:space:]]*//" |
+  tr -d "\"'" || true)
+EOF
+    ;;
+esac
+
+exit 0

--- a/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
+#
+# Lisa ships templates in three modes, and only one of them destroys host edits:
+#
+#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
+#                    gone at the next `bun install`, silently.
+#   copy-contents  — Lisa APPENDS its lines; host content survives.
+#   create-only    — skipped when the file exists; the host owns it outright.
+#
+# So this guard covers copy-overwrite and nothing else. Blocking the other two
+# would stop agents editing files they are supposed to own, which is worse than
+# the problem being solved.
+#
+# Measured, not hypothetical. Nothing enforced this, so downstream copies were
+# edited and then silently diverged: `classify-maestro-failures.mjs` reached
+# 36,061 bytes in one fleet repo against 29,586 shipped, and five gate files in
+# another stopped receiving upstream fixes — one over roughly 138 bytes of
+# cosmetic change. The edits were made in good faith; nothing told anyone the
+# file was not theirs.
+#
+# ## Why the path, not a banner comment
+#
+# 103 of Lisa's 145 copy-overwrite files carry a "managed by Lisa" header, and
+# the other 42 CANNOT: 30 are `.json` (no comment syntax), 8 are `.gitkeep` /
+# `.keep` placeholders, and the rest are bare-value files like `.nvmrc`. A guard
+# keyed on the banner would miss every one of them, so this resolves the path
+# against the installed package instead and covers all 145 regardless of format.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target resolves to a
+#      copy-overwrite template in the installed Lisa package;
+#   2. Bash output redirection (`>`, `>>`, `>|`), `tee`, or `sed -i` aimed at
+#      one. Reads never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_MANAGED_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's;
+#   - the Lisa source repository itself, where these files are the originals and
+#     editing them is the entire point.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override, checked first so it is always the cheapest way out.
+if [ -n "${LISA_ALLOW_MANAGED_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+project_root="${CLAUDE_PROJECT_DIR:-$PWD}"
+package_root="$project_root/node_modules/@codyswann/lisa"
+
+# No installed Lisa means nothing to classify against. Silent, because a project
+# that has not installed Lisa is not doing anything wrong.
+[ -d "$package_root" ] || exit 0
+
+# In Lisa's own repository these files ARE the originals. Blocking here would
+# make the templates uneditable by the only agents that should edit them.
+if [ -f "$project_root/package.json" ] &&
+  grep -q '"name": *"@codyswann/lisa"' "$project_root/package.json" 2>/dev/null; then
+  exit 0
+fi
+
+# Whether a host-relative path is shipped as a copy-overwrite template.
+#
+# A few stat calls rather than an enumeration: the same relative path is probed
+# under each stack's copy-overwrite tree, so cost does not grow with the 145
+# templates.
+managed_source() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  # Normalise to a project-relative path so an absolute target still matches.
+  local rel="${candidate#"$project_root"/}"
+  rel="${rel#./}"
+  [ -n "$rel" ] || return 1
+  local stack
+  for stack in "$package_root"/*/copy-overwrite; do
+    [ -d "$stack" ] || continue
+    if [ -e "$stack/$rel" ]; then
+      printf '%s' "${stack#"$package_root"/}/$rel"
+      return 0
+    fi
+  done
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  local source="$2"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
+(\`$source\` in the installed package) and is replaced wholesale on every
+\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
+until the next install and then vanish, with nothing reporting that it had.
+
+That is not hypothetical: downstream copies edited this way diverged silently
+until they stopped receiving upstream fixes entirely.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. The change should apply everywhere. Edit the template upstream in Lisa and
+   release it — \`/lisa:cross-pollinate\`, or an issue on CodySwannGT/lisa.
+   That is the only edit that survives an install.
+
+2. Only this project needs to differ. Look for the local escape hatch beside the
+   file — Lisa ships \`.local\` variants for the configs that support one
+   (\`eslint.config.local.ts\`, \`tsconfig.local.json\`, \`audit.ignore.local.json\`,
+   and others). Those are yours and are never overwritten.
+
+3. The behaviour is configurable rather than hardcoded. Check \`.lisa.config.json\`
+   — the \`gates\` block in particular decides which checks run and what command
+   proves each one, so a project can substitute its own task without touching a
+   shipped file.
+
+4. You believe this file should not be Lisa-managed at all. That is a real
+   argument and it belongs upstream, not in a local edit that will be erased.
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_MANAGED_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if source_path="$(managed_source "$candidate")"; then
+        refuse "$candidate" "$source_path"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Write signatures only. A bare mention is a read and stays allowed — the
+    # path has to be the target of a redirection, a tee, or an in-place sed.
+    # `>>?\|?` covers `>`, `>>`, and the noclobber override `>|`.
+    while IFS= read -r token; do
+      [ -n "$token" ] || continue
+      if source_path="$(managed_source "$token")"; then
+        refuse "$token" "$source_path"
+      fi
+    done <<EOF
+$(printf '%s' "$command_str" |
+  grep -Eo ">>?\|?[[:space:]]*['\"]?[^ |;&'\"]+|tee([[:space:]]+-[a-zA-Z]+)*[[:space:]]+['\"]?[^ |;&'\"]+|sed[[:space:]]+[^|;&]*-i[^|;&]*[[:space:]]['\"]?[^ |;&'\"]+" 2>/dev/null |
+  sed -E "s/^(>>?\|?|tee([[:space:]]+-[a-zA-Z]+)*|sed[[:space:]]+[^|;&]*-i[^|;&]*)[[:space:]]*//" |
+  tr -d "\"'" || true)
+EOF
+    ;;
+esac
+
+exit 0

--- a/plugins/lisa/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa/hooks/block-managed-file-edits.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
+#
+# Lisa ships templates in three modes, and only one of them destroys host edits:
+#
+#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
+#                    gone at the next `bun install`, silently.
+#   copy-contents  — Lisa APPENDS its lines; host content survives.
+#   create-only    — skipped when the file exists; the host owns it outright.
+#
+# So this guard covers copy-overwrite and nothing else. Blocking the other two
+# would stop agents editing files they are supposed to own, which is worse than
+# the problem being solved.
+#
+# Measured, not hypothetical. Nothing enforced this, so downstream copies were
+# edited and then silently diverged: `classify-maestro-failures.mjs` reached
+# 36,061 bytes in one fleet repo against 29,586 shipped, and five gate files in
+# another stopped receiving upstream fixes — one over roughly 138 bytes of
+# cosmetic change. The edits were made in good faith; nothing told anyone the
+# file was not theirs.
+#
+# ## Why the path, not a banner comment
+#
+# 103 of Lisa's 145 copy-overwrite files carry a "managed by Lisa" header, and
+# the other 42 CANNOT: 30 are `.json` (no comment syntax), 8 are `.gitkeep` /
+# `.keep` placeholders, and the rest are bare-value files like `.nvmrc`. A guard
+# keyed on the banner would miss every one of them, so this resolves the path
+# against the installed package instead and covers all 145 regardless of format.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target resolves to a
+#      copy-overwrite template in the installed Lisa package;
+#   2. Bash output redirection (`>`, `>>`, `>|`), `tee`, or `sed -i` aimed at
+#      one. Reads never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_MANAGED_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's;
+#   - the Lisa source repository itself, where these files are the originals and
+#     editing them is the entire point.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override, checked first so it is always the cheapest way out.
+if [ -n "${LISA_ALLOW_MANAGED_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+project_root="${CLAUDE_PROJECT_DIR:-$PWD}"
+package_root="$project_root/node_modules/@codyswann/lisa"
+
+# No installed Lisa means nothing to classify against. Silent, because a project
+# that has not installed Lisa is not doing anything wrong.
+[ -d "$package_root" ] || exit 0
+
+# In Lisa's own repository these files ARE the originals. Blocking here would
+# make the templates uneditable by the only agents that should edit them.
+if [ -f "$project_root/package.json" ] &&
+  grep -q '"name": *"@codyswann/lisa"' "$project_root/package.json" 2>/dev/null; then
+  exit 0
+fi
+
+# Whether a host-relative path is shipped as a copy-overwrite template.
+#
+# A few stat calls rather than an enumeration: the same relative path is probed
+# under each stack's copy-overwrite tree, so cost does not grow with the 145
+# templates.
+managed_source() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  # Normalise to a project-relative path so an absolute target still matches.
+  local rel="${candidate#"$project_root"/}"
+  rel="${rel#./}"
+  [ -n "$rel" ] || return 1
+  local stack
+  for stack in "$package_root"/*/copy-overwrite; do
+    [ -d "$stack" ] || continue
+    if [ -e "$stack/$rel" ]; then
+      printf '%s' "${stack#"$package_root"/}/$rel"
+      return 0
+    fi
+  done
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  local source="$2"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
+(\`$source\` in the installed package) and is replaced wholesale on every
+\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
+until the next install and then vanish, with nothing reporting that it had.
+
+That is not hypothetical: downstream copies edited this way diverged silently
+until they stopped receiving upstream fixes entirely.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. The change should apply everywhere. Edit the template upstream in Lisa and
+   release it — \`/lisa:cross-pollinate\`, or an issue on CodySwannGT/lisa.
+   That is the only edit that survives an install.
+
+2. Only this project needs to differ. Look for the local escape hatch beside the
+   file — Lisa ships \`.local\` variants for the configs that support one
+   (\`eslint.config.local.ts\`, \`tsconfig.local.json\`, \`audit.ignore.local.json\`,
+   and others). Those are yours and are never overwritten.
+
+3. The behaviour is configurable rather than hardcoded. Check \`.lisa.config.json\`
+   — the \`gates\` block in particular decides which checks run and what command
+   proves each one, so a project can substitute its own task without touching a
+   shipped file.
+
+4. You believe this file should not be Lisa-managed at all. That is a real
+   argument and it belongs upstream, not in a local edit that will be erased.
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_MANAGED_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if source_path="$(managed_source "$candidate")"; then
+        refuse "$candidate" "$source_path"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Write signatures only. A bare mention is a read and stays allowed — the
+    # path has to be the target of a redirection, a tee, or an in-place sed.
+    # `>>?\|?` covers `>`, `>>`, and the noclobber override `>|`.
+    while IFS= read -r token; do
+      [ -n "$token" ] || continue
+      if source_path="$(managed_source "$token")"; then
+        refuse "$token" "$source_path"
+      fi
+    done <<EOF
+$(printf '%s' "$command_str" |
+  grep -Eo ">>?\|?[[:space:]]*['\"]?[^ |;&'\"]+|tee([[:space:]]+-[a-zA-Z]+)*[[:space:]]+['\"]?[^ |;&'\"]+|sed[[:space:]]+[^|;&]*-i[^|;&]*[[:space:]]['\"]?[^ |;&'\"]+" 2>/dev/null |
+  sed -E "s/^(>>?\|?|tee([[:space:]]+-[a-zA-Z]+)*|sed[[:space:]]+[^|;&]*-i[^|;&]*)[[:space:]]*//" |
+  tr -d "\"'" || true)
+EOF
+    ;;
+esac
+
+exit 0

--- a/plugins/src/base/hooks/block-managed-file-edits.sh
+++ b/plugins/src/base/hooks/block-managed-file-edits.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
+#
+# Lisa ships templates in three modes, and only one of them destroys host edits:
+#
+#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
+#                    gone at the next `bun install`, silently.
+#   copy-contents  — Lisa APPENDS its lines; host content survives.
+#   create-only    — skipped when the file exists; the host owns it outright.
+#
+# So this guard covers copy-overwrite and nothing else. Blocking the other two
+# would stop agents editing files they are supposed to own, which is worse than
+# the problem being solved.
+#
+# Measured, not hypothetical. Nothing enforced this, so downstream copies were
+# edited and then silently diverged: `classify-maestro-failures.mjs` reached
+# 36,061 bytes in one fleet repo against 29,586 shipped, and five gate files in
+# another stopped receiving upstream fixes — one over roughly 138 bytes of
+# cosmetic change. The edits were made in good faith; nothing told anyone the
+# file was not theirs.
+#
+# ## Why the path, not a banner comment
+#
+# 103 of Lisa's 145 copy-overwrite files carry a "managed by Lisa" header, and
+# the other 42 CANNOT: 30 are `.json` (no comment syntax), 8 are `.gitkeep` /
+# `.keep` placeholders, and the rest are bare-value files like `.nvmrc`. A guard
+# keyed on the banner would miss every one of them, so this resolves the path
+# against the installed package instead and covers all 145 regardless of format.
+#
+# Blocked signatures:
+#   1. Write / Edit / MultiEdit / NotebookEdit whose target resolves to a
+#      copy-overwrite template in the installed Lisa package;
+#   2. Bash output redirection (`>`, `>>`, `>|`), `tee`, or `sed -i` aimed at
+#      one. Reads never fire.
+#
+# Exemptions (allowed):
+#   - `LISA_ALLOW_MANAGED_FILE_WRITE` set — the operator's explicit override,
+#     named in the refusal;
+#   - paths under `node_modules/` or `dist/` — vendored copies, not the host's;
+#   - the Lisa source repository itself, where these files are the originals and
+#     editing them is the entire point.
+set -euo pipefail
+
+input="$(cat)"
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+# The operator's override, checked first so it is always the cheapest way out.
+if [ -n "${LISA_ALLOW_MANAGED_FILE_WRITE:-}" ]; then
+  exit 0
+fi
+
+tool_name="$(printf '%s' "$input" | jq -r '.tool_name // empty')"
+[ -n "$tool_name" ] || exit 0
+
+project_root="${CLAUDE_PROJECT_DIR:-$PWD}"
+package_root="$project_root/node_modules/@codyswann/lisa"
+
+# No installed Lisa means nothing to classify against. Silent, because a project
+# that has not installed Lisa is not doing anything wrong.
+[ -d "$package_root" ] || exit 0
+
+# In Lisa's own repository these files ARE the originals. Blocking here would
+# make the templates uneditable by the only agents that should edit them.
+if [ -f "$project_root/package.json" ] &&
+  grep -q '"name": *"@codyswann/lisa"' "$project_root/package.json" 2>/dev/null; then
+  exit 0
+fi
+
+# Whether a host-relative path is shipped as a copy-overwrite template.
+#
+# A few stat calls rather than an enumeration: the same relative path is probed
+# under each stack's copy-overwrite tree, so cost does not grow with the 145
+# templates.
+managed_source() {
+  local candidate="$1"
+  case "$candidate" in
+    */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
+  esac
+  # Normalise to a project-relative path so an absolute target still matches.
+  local rel="${candidate#"$project_root"/}"
+  rel="${rel#./}"
+  [ -n "$rel" ] || return 1
+  local stack
+  for stack in "$package_root"/*/copy-overwrite; do
+    [ -d "$stack" ] || continue
+    if [ -e "$stack/$rel" ]; then
+      printf '%s' "${stack#"$package_root"/}/$rel"
+      return 0
+    fi
+  done
+  return 1
+}
+
+refuse() {
+  local target="$1"
+  local source="$2"
+  cat >&2 <<EOF
+BLOCKED: refusing to write \`$target\`.
+
+WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
+(\`$source\` in the installed package) and is replaced wholesale on every
+\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
+until the next install and then vanish, with nothing reporting that it had.
+
+That is not hypothetical: downstream copies edited this way diverged silently
+until they stopped receiving upstream fixes entirely.
+
+WHERE IT GOES INSTEAD — take the first one that fits:
+
+1. The change should apply everywhere. Edit the template upstream in Lisa and
+   release it — \`/lisa:cross-pollinate\`, or an issue on CodySwannGT/lisa.
+   That is the only edit that survives an install.
+
+2. Only this project needs to differ. Look for the local escape hatch beside the
+   file — Lisa ships \`.local\` variants for the configs that support one
+   (\`eslint.config.local.ts\`, \`tsconfig.local.json\`, \`audit.ignore.local.json\`,
+   and others). Those are yours and are never overwritten.
+
+3. The behaviour is configurable rather than hardcoded. Check \`.lisa.config.json\`
+   — the \`gates\` block in particular decides which checks run and what command
+   proves each one, so a project can substitute its own task without touching a
+   shipped file.
+
+4. You believe this file should not be Lisa-managed at all. That is a real
+   argument and it belongs upstream, not in a local edit that will be erased.
+
+If a human explicitly asked for this edit, they can re-run with
+\`LISA_ALLOW_MANAGED_FILE_WRITE=1\` set, which bypasses this guard.
+EOF
+  exit 2
+}
+
+case "$tool_name" in
+  Write | Edit | MultiEdit | NotebookEdit | Update)
+    paths="$(printf '%s' "$input" | jq -r '
+      [ .tool_input.file_path?,
+        .tool_input.path?,
+        .tool_input.notebook_path?,
+        (.tool_input.edits? // [] | .[].file_path?)
+      ] | map(select(. != null and . != "")) | .[]' 2>/dev/null || true)"
+    while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      if source_path="$(managed_source "$candidate")"; then
+        refuse "$candidate" "$source_path"
+      fi
+    done <<EOF
+$paths
+EOF
+    ;;
+  Bash)
+    command_str="$(printf '%s' "$input" | jq -r '.tool_input.command // empty')"
+    [ -n "$command_str" ] || exit 0
+    # Write signatures only. A bare mention is a read and stays allowed — the
+    # path has to be the target of a redirection, a tee, or an in-place sed.
+    # `>>?\|?` covers `>`, `>>`, and the noclobber override `>|`.
+    while IFS= read -r token; do
+      [ -n "$token" ] || continue
+      if source_path="$(managed_source "$token")"; then
+        refuse "$token" "$source_path"
+      fi
+    done <<EOF
+$(printf '%s' "$command_str" |
+  grep -Eo ">>?\|?[[:space:]]*['\"]?[^ |;&'\"]+|tee([[:space:]]+-[a-zA-Z]+)*[[:space:]]+['\"]?[^ |;&'\"]+|sed[[:space:]]+[^|;&]*-i[^|;&]*[[:space:]]['\"]?[^ |;&'\"]+" 2>/dev/null |
+  sed -E "s/^(>>?\|?|tee([[:space:]]+-[a-zA-Z]+)*|sed[[:space:]]+[^|;&]*-i[^|;&]*)[[:space:]]*//" |
+  tr -d "\"'" || true)
+EOF
+    ;;
+esac
+
+exit 0

--- a/scripts/build-plugins.sh
+++ b/scripts/build-plugins.sh
@@ -121,7 +121,8 @@ if [ -d "$SRC_DIR/base/hooks" ]; then
   mkdir -p "$HOST_GUARD_DIR"
 fi
 for guard in block-no-verify parity-safety-net block-shell-json-parsing \
-  block-instruction-file-edits block-direct-issue-create; do
+  block-instruction-file-edits block-direct-issue-create \
+  block-managed-file-edits; do
   if [ -f "$SRC_DIR/base/hooks/$guard.sh" ]; then
     materialize "$SRC_DIR/base/hooks/$guard.sh" "$HOST_GUARD_DIR/$guard.sh"
     chmod +x "$HOST_GUARD_DIR/$guard.sh"

--- a/scripts/lisa-enforcement-fallback.sh
+++ b/scripts/lisa-enforcement-fallback.sh
@@ -67,7 +67,8 @@ repo_root="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}"
 # `plugins/` directory to fall back on.
 status=0
 for guard in block-no-verify parity-safety-net block-shell-json-parsing \
-  block-instruction-file-edits block-direct-issue-create; do
+  block-instruction-file-edits block-direct-issue-create \
+  block-managed-file-edits; do
   script=""
   for candidate in \
     "$repo_root/scripts/lisa-hooks/$guard.sh" \

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -177,6 +177,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "68e1b78d5d4471fadbe2eb575ae46221838217290123a9910d76dba0f1c34131",
     "8dc942ac4edc2017d6b8277296c8f80542e7c024eef1bb65de609979d0ca9a0e",
     "9cab71562d01421d57c6719318a4d03a6249a45c1aea434db3ff26e3065eeb66",
+    "aafd027c4b6092da15d0389f9e8dcedbd9105e9083057e2da39f78fd5f72e0df",
     "d7d88e44763694bed5eae998cd3663922c957e49f9f9621d9201f0417a4128ad",
     "e17c45f7cadf0fb55dd07270776caf211af99b7d4771a4fde75aafe5919e8dbe",
   ]),
@@ -216,6 +217,9 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "8996e0bcbf1db085a5d99734e797c91f5025997bd967bc374efff8348dac14c2",
     "be1e77fb0ddb246eddae71ebac25e972c3c9e8079514e0dc78d0b73df919464c",
     "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
+  ]),
+  "scripts/lisa-hooks/block-managed-file-edits.sh": Object.freeze([
+    "18aebaef5ea9bf6af220dc9beef80a5cfb37282c6a53047783b4cc96d8daa4e3",
   ]),
   "scripts/lisa-hooks/block-no-verify.sh": Object.freeze([
     "031ef7a53fc49cb18665105b834b7b50ad6a43317e0821949809e877e0562ce4",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -15,7 +15,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs":
       "f0f3c43bbb6d1e389135b0205a051e64891e539d4272df2a87841ee82a8b7a55",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
-      "68e1b78d5d4471fadbe2eb575ae46221838217290123a9910d76dba0f1c34131",
+      "aafd027c4b6092da15d0389f9e8dcedbd9105e9083057e2da39f78fd5f72e0df",
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
       "2d11968f6852ab745cba939de03c6d6cb5f413975d2cfc8fc447bdd0b218e91a",
     "all/copy-overwrite/scripts/lisa-gates.mjs":
@@ -24,6 +24,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "8d1f04ef5c5da9db9190e22b37a435e118e39d6e7deafc5402b4593c8e9db2b2",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
+    "all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh":
+      "18aebaef5ea9bf6af220dc9beef80a5cfb37282c6a53047783b4cc96d8daa4e3",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
       "83a8b8108654086afb6a6f23a8f09f9f041eb2cd4094c5531fa7ab1f75e873dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
@@ -676,6 +678,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "aa249cae53caeb3e0fb6d6af114e2756084f45a2896332fb063a9f20e4902125",
     "plugins/src/base/hooks/block-instruction-file-edits.sh":
       "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
+    "plugins/src/base/hooks/block-managed-file-edits.sh":
+      "abdbcd889925879aa43fe0420971cf1a79a7b9a534c06e681fe3f0fbb5475894",
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "81c51041f8cb47bf79692c485c4f42ac7ed0a5a830821dc514cb468bc7a06b83",
     "plugins/src/base/hooks/block-no-verify.sh":
@@ -2095,7 +2099,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "rails/merge/.claude/settings.json":
       "9c49f8c7c453f8749c90def3e22d412c3345c533d24b30dc7745ffa052ad6fa1",
     "scripts/build-plugins.sh":
-      "a2d935155a71e61c927c4a83e4a4151248fc13961214d7a57f5021e7bc3a8779",
+      "00a3207bb5a485bfee80fb71be6e9577979fd156b15a85517e88a2f9261bc9f4",
     "scripts/check-conflict-markers.mjs":
       "78c286ed6d7cce3a030fd7561fbe6285e2051d34540640f016b86ef89e3fb08b",
     "scripts/check-derived-artifacts.mjs":
@@ -2181,7 +2185,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-commit-and-pr-local.sh":
       "605409c3ce6ec38ad3275604291a1ceae98f7807a605654263bc14f811c03903",
     "scripts/lisa-enforcement-fallback.sh":
-      "3049c2f1051c7c02dd60b62355964651e1565ebe6bdcb5e37634cd686cf1deb1",
+      "e241a2c7c6aaeb17241adfc9ca4e4f900259e90dae7444fc01992936ea8bcfb4",
     "scripts/lisa-github-environments.sh":
       "0a76e92f108519abaf3e29991299ec3b0db20ea533e69e6d2a53d802dba9c370",
     "scripts/lisa-github-repo-settings.sh":
@@ -2515,6 +2519,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-overwrite/scripts/lisa-gates.mjs": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh": true,
+    "all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh": true,
@@ -3701,6 +3706,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/commands/lisa/wiki/install.md": true,
     "plugins/lisa-copilot/hooks/block-direct-issue-create.sh": true,
     "plugins/lisa-copilot/hooks/block-instruction-file-edits.sh": true,
+    "plugins/lisa-copilot/hooks/block-managed-file-edits.sh": true,
     "plugins/lisa-copilot/hooks/block-no-verify.sh": true,
     "plugins/lisa-copilot/hooks/block-shell-json-parsing.sh": true,
     "plugins/lisa-copilot/hooks/cleanup-stale-worktrees.sh": true,
@@ -4157,6 +4163,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/commands/lisa/wiki/install.md": true,
     "plugins/lisa-cursor/hooks/block-direct-issue-create.sh": true,
     "plugins/lisa-cursor/hooks/block-instruction-file-edits.sh": true,
+    "plugins/lisa-cursor/hooks/block-managed-file-edits.sh": true,
     "plugins/lisa-cursor/hooks/block-no-verify.sh": true,
     "plugins/lisa-cursor/hooks/block-shell-json-parsing.sh": true,
     "plugins/lisa-cursor/hooks/cleanup-stale-worktrees.sh": true,
@@ -6706,6 +6713,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/hooks/block-direct-issue-create.sh": true,
     "plugins/lisa/hooks/block-instruction-file-edits.agy.sh": true,
     "plugins/lisa/hooks/block-instruction-file-edits.sh": true,
+    "plugins/lisa/hooks/block-managed-file-edits.sh": true,
     "plugins/lisa/hooks/block-no-verify.agy.sh": true,
     "plugins/lisa/hooks/block-no-verify.sh": true,
     "plugins/lisa/hooks/block-shell-json-parsing.agy.sh": true,
@@ -7345,6 +7353,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/hooks/block-direct-issue-create.sh": true,
     "plugins/src/base/hooks/block-instruction-file-edits.agy.sh": true,
     "plugins/src/base/hooks/block-instruction-file-edits.sh": true,
+    "plugins/src/base/hooks/block-managed-file-edits.sh": true,
     "plugins/src/base/hooks/block-no-verify.agy.sh": true,
     "plugins/src/base/hooks/block-no-verify.sh": true,
     "plugins/src/base/hooks/block-shell-json-parsing.agy.sh": true,
@@ -8913,6 +8922,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/enforcement-fallback.test.ts": true,
     "tests/unit/hooks/enforcement-gates-e2e.test.ts": true,
     "tests/unit/hooks/gate-coverage-handover.test.ts": true,
+    "tests/unit/hooks/hook-scripts-parse.test.ts": true,
     "tests/unit/hooks/host-enforcement-fallback.test.ts": true,
     "tests/unit/hooks/husky-resolver-lookup.test.ts": true,
     "tests/unit/hooks/inject-rules.test.ts": true,

--- a/tests/unit/hooks/hook-scripts-parse.test.ts
+++ b/tests/unit/hooks/hook-scripts-parse.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Every shipped shell guard and the enforcement fallback must parse.
+ *
+ * Written after breaking `scripts/lisa-enforcement-fallback.sh` with a doubled
+ * backslash while adding a guard to its list. That script *is* the PreToolUse
+ * hook, so the syntax error made every Bash, Edit and Write call fail —
+ * including the ones that would have fixed it. Recovery needed a human running
+ * `git checkout`.
+ *
+ * The same edit went into two more files. One was
+ * `all/copy-overwrite/scripts/lisa-enforcement-fallback.sh` — the copy SHIPPED
+ * to every consumer — which would have broken enforcement fleet-wide while
+ * being invisible here, because the template is not the file this repository
+ * executes.
+ *
+ * `bash -n` costs milliseconds and catches the whole class. Nothing else in the
+ * suite parses these, because they are data to every TypeScript test that
+ * mentions them.
+ * @module tests/unit/hooks/hook-scripts-parse
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+/** Absolute interpreter path; resolving `bash` through PATH is not permitted. */
+const BASH = "/bin/bash";
+
+/** Directories whose every `.sh` file must parse. */
+const GUARD_DIRS = [
+  "plugins/src/base/hooks",
+  "src/codex/scripts",
+  "all/copy-overwrite/scripts",
+  "scripts",
+];
+
+/**
+ * Every shell script under the audited directories.
+ * @returns Repo-relative paths
+ */
+function shellScripts(): string[] {
+  return GUARD_DIRS.flatMap(dir => {
+    const absolute = path.join(REPO_ROOT, dir);
+    if (!existsSync(absolute)) return [];
+    return readdirSync(absolute)
+      .filter(name => name.endsWith(".sh"))
+      .map(name => path.posix.join(dir, name));
+  });
+}
+
+const SCRIPTS = shellScripts();
+
+describe("every shipped shell script parses", () => {
+  it("finds scripts to check at all", () => {
+    // The absent-case rule: a discovery bug would make the per-file assertions
+    // pass by iterating nothing, which is exactly how a syntax error ships.
+    expect(SCRIPTS.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it.each(SCRIPTS)("%s is syntactically valid", script => {
+    expect(() =>
+      execFileSync(BASH, ["-n", path.join(REPO_ROOT, script)], {
+        stdio: "pipe",
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("the enforcement fallback and its shipped twin stay in step", () => {
+  // The repository copy is what this repo executes; the copy-overwrite copy is
+  // what every consumer executes. An edit applied to one and not the other is
+  // invisible until it reaches the fleet.
+  const REPO_COPY = "scripts/lisa-enforcement-fallback.sh";
+  const SHIPPED_COPY =
+    "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh";
+
+  it("both exist", () => {
+    expect(existsSync(path.join(REPO_ROOT, REPO_COPY))).toBe(true);
+    expect(existsSync(path.join(REPO_ROOT, SHIPPED_COPY))).toBe(true);
+  });
+
+  it.each([REPO_COPY, SHIPPED_COPY])("%s runs every guard", copy => {
+    // Named rather than counted: a guard dropped from one list and not the
+    // other is the drift this pins, and the failure has to say which guard.
+    const text = readFileSync(path.join(REPO_ROOT, copy), "utf8");
+    for (const guard of [
+      "block-no-verify",
+      "parity-safety-net",
+      "block-shell-json-parsing",
+      "block-instruction-file-edits",
+      "block-direct-issue-create",
+      "block-managed-file-edits",
+    ]) {
+      expect(text).toContain(guard);
+    }
+  });
+});


### PR DESCRIPTION
## The problem

Lisa ships files into projects in three ways, and only one of them destroys
what a developer or agent writes:

| mode | what happens on the next install |
| --- | --- |
| **copy-overwrite** | replaced wholesale — **your edit is gone, silently** |
| copy-contents | Lisa adds its lines; your content stays |
| create-only | skipped if the file exists; you own it |

Nothing stopped an agent editing the first kind. So it happened, in good faith,
and the edits quietly diverged: one fleet project's copy of a shared script grew
to 36,061 bytes against the 29,586 Lisa ships, and five files in another stopped
receiving upstream fixes entirely — one of them over about 138 bytes of
cosmetic change.

Nothing told anyone the file was not theirs to edit.

## What this adds

A guard that refuses writes to copy-overwrite files and explains where the edit
should go instead — upstream to Lisa, a `.local` override beside the file, or
the `gates` block in `.lisa.config.json` when the behaviour is configurable
rather than hardcoded.

It covers **only** copy-overwrite. Blocking the other two kinds would stop
people editing files they are supposed to own, which is worse than the problem.

A human who really wants the edit can set `LISA_ALLOW_MANAGED_FILE_WRITE`, and
the refusal says so.

## Why it does not look for the "managed by Lisa" banner

Because 42 of the 145 copy-overwrite files **cannot carry one**: 30 are `.json`,
which has no comment syntax, 8 are empty placeholder files, and the rest hold a
single bare value. A banner-based guard would miss every one of them.

Instead it checks whether the file being written exists as a template inside the
installed Lisa package — which works for all 145 regardless of format.

## A second guard, added because this change broke the repository

Registering the new guard meant adding its name to three shell scripts. A
generated edit wrote a doubled backslash where a line continuation was needed,
which broke the script that **is** the enforcement hook. Every command then
failed, including the ones that would have fixed it, and recovery needed a
human.

The same broken edit also landed in the copy that ships to every project, where
it would have disabled enforcement fleet-wide while looking fine here.

So this also adds a check that every shipped shell script actually parses, and
that both copies of the enforcement script list the same guards. It costs
milliseconds and nothing was checking it before.

## Done when

- [x] Writes to copy-overwrite files are refused, with an explanation
- [x] copy-contents, create-only, and unmanaged files are untouched
- [x] Reads are never blocked
- [x] Lisa's own repository is exempt, so its templates stay editable
- [x] A human override exists and is named in the refusal
- [x] Every shipped shell script is checked for syntax
- [x] Both enforcement-script copies are pinned to the same guard list

Work-Item: CodySwannGT/lisa#2620
