### PR TITLE
feat(gates): façade the dependency audit

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3300,7 +3300,51 @@ jobs:
           fi
         working-directory: ${{ inputs.working_directory || '.' }}
 
+      # Gate façade — contract and fallback rationale documented in full on the
+      # 🧹 Lint job above.
+      - name: 🎛️ Resolve the dependency-vulnerability gate
+        id: gate
+        env:
+          GATE_ID: dependency-vulnerability
+          FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
+        run: |
+          set -euo pipefail
+          RESOLVER=""
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+            if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
+          done
+          if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          node "$RESOLVER" list --moment="$GATE_MOMENT" --json --include-off | node -e '
+          let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
+          const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
+          if (hit && hit.level === "off") return process.stdout.write("configured=off\n");
+          const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
+          if (!task) return process.stdout.write("configured=false\n");
+          const runner = (require("./.lisa.config.json").gates || {}).runner || process.env.FALLBACK_RUNNER;
+          const plain = value => /^[A-Za-z0-9:._@\/= -]+$/.test(value);
+          if (!plain(task) || !plain(runner)) { console.error(`::error::gates.${id} resolves to "${runner} ${task}", which is not a plain command.`); process.exit(1); }
+          process.stdout.write(`configured=true\nrunner=${runner}\ntask=${task}\n`); });
+          ' >> "$GITHUB_OUTPUT"
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🔒 Run the dependency-vulnerability gate
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          GATE_RUNNER: ${{ steps.gate.outputs.runner }}
+          GATE_TASK: ${{ steps.gate.outputs.task }}
+        # Deliberate word split. Both values were validated above to be plain
+        # words, so the runner ("npm run", "bun run", "just") and a task
+        # carrying flags both reach argv without a shell metacharacter.
+        run: $GATE_RUNNER $GATE_TASK
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       - name: 📋 Load audit exclusions
+        # FALLBACK ONLY — the exclusion list and the audit invocation below are
+        # npm/yarn/bun `audit` specifics. A project declaring its own
+        # `dependency-vulnerability` task has said what proves the property, and
+        # may well use a scanner with no notion of a GHSA exclusion file.
+        if: steps.gate.outputs.configured == 'false'
         id: audit_exclusions
         shell: bash
         run: |
@@ -3327,6 +3371,8 @@ jobs:
         working-directory: ${{ inputs.working_directory || '.' }}
 
       - name: 🔒 Run security audit
+        # FALLBACK — unchanged behavior for a project with no `gates` block.
+        if: steps.gate.outputs.configured == 'false'
         run: |
           GHSA_IDS="${{ steps.audit_exclusions.outputs.ghsa_ids }}"
           CVE_IDS="${{ steps.audit_exclusions.outputs.cve_ids }}"

--- a/tests/integration/quality-gate-facade-fixture.ts
+++ b/tests/integration/quality-gate-facade-fixture.ts
@@ -60,7 +60,7 @@ export const NOT_CONFIGURED = "steps.gate.outputs.configured == 'false'";
 export const DECLARED_OFF = "steps.gate.outputs.configured == 'off'";
 
 /**
- * The twelve jobs converted to the gate façade.
+ * The thirteen jobs converted to the gate façade.
  *
  * Kept exhaustive by `quality-gate-moment-input.test.ts`, which fails if the
  * workflow contains a resolve step this list omits. `test_node_suites` shipped
@@ -163,6 +163,17 @@ export const CONVERTED: ConvertedJob[] = [
     fallbackSteps: ["🌱 No environment reseed adapter declared"],
   },
   {
+    job: "npm_security_scan",
+    jobName: "🔒 Security Scan",
+    gate: "dependency-vulnerability",
+    gateStep: "🔒 Run the dependency-vulnerability gate",
+    // Both fallback steps, not just the audit itself: the exclusion loader is
+    // npm/yarn/bun `audit` specifics (GHSA and CVE id files), and a project
+    // that declared its own task may use a scanner with no notion of them.
+    // Leaving it running would compute exclusions nothing consumes.
+    fallbackSteps: ["📋 Load audit exclusions", "🔒 Run security audit"],
+  },
+  {
     job: "dead_code",
     jobName: "🗑️ Dead Code Detection",
     gate: "dead-code",
@@ -188,7 +199,7 @@ export const CONVERTED: ConvertedJob[] = [
  * Steps that carried `continue-on-error` BEFORE this conversion.
  *
  * A failing job that reports green is the exact defect the façade exists to
- * prevent, so the set is pinned rather than checked only on the twelve jobs:
+ * prevent, so the set is pinned rather than checked only on the thirteen jobs:
  * growing it anywhere in this workflow has to fail here.
  */
 export const PREEXISTING_CONTINUE_ON_ERROR = ["📊 SonarCloud Scan"];

--- a/tests/integration/quality-gate-facade.test.ts
+++ b/tests/integration/quality-gate-facade.test.ts
@@ -124,7 +124,7 @@ describe("quality.yml gate façade", () => {
     );
 
     it("resolves every gate with one byte-identical block, differing only in GATE_ID", () => {
-      // Twelve copies exist because the single-copy alternative — a resolver job
+      // Thirteen copies exist because the single-copy alternative — a resolver job
       // read through `needs:` — leaves dependents SKIPPED when it fails, and a
       // skipped required check counts as satisfied. Copies that cannot be
       // deduplicated must instead be prevented from drifting, so this compares


### PR DESCRIPTION
## The problem

Lisa's security-audit job hardcodes the dependency audit:

```
npm audit --production --audit-level=high
```

with `yarn` and `bun` variants beside it, plus a GHSA/CVE exclusion loader that
only those tools understand.

A project cannot substitute anything. If it prefers `osv-scanner`, a different
severity policy, a vendored allowlist, or a scanner its security team already
runs, it gets Lisa's opinion or it turns the whole job off. Every other quality
check in the workflow can be swapped for a project's own command; this one could
not.

## What this changes

`🔒 Security Scan` now resolves the `dependency-vulnerability` gate from
`.lisa.config.json` first, exactly as Lint, Type Check, Build, Tests and Dead
Code already do. A project declaring its own task runs it. A project that
declares nothing keeps today's behaviour byte-for-byte.

**Both** hardcoded steps move to the fallback path, not just the audit itself.
The exclusion loader reads GHSA and CVE id files that are `npm`/`yarn`/`bun`
audit specifics; a project using a different scanner has no use for them, and
computing exclusions nothing consumes is worse than not computing them.

## What was deliberately left alone, and why

Six other checks matched a gate by name. Four should not be converted, and the
reasons differ:

- **Mutation Testing** and **Verification Coverage** — both would work, but
  neither installs dependencies unconditionally today. The façade resolves
  through a script that lives in the installed package, so without an install
  the resolution silently returns "nothing configured" and the project's
  declaration governs nothing — the exact defect fixed in #2612. Converting them
  means making their installs unconditional, which adds real time to every
  project that does not use them. That is a cost worth deciding on separately.
- **Playwright E2E** — the work happens in a sharded matrix job while the
  reported check is a separate aggregate job sharing its name. A matrix job
  rewrites its own check name, so this needs a different shape than the others.
- **Work-Item Traceability** and **Threshold Ratchet** — deliberately *not*
  configurable. Both are governance: one enforces that thresholds may only
  tighten, and letting a project substitute its own command there would let it
  swap in something that always passes. That is the waiver list this programme
  removed, reintroduced through the back door.

## Done when

- [x] The audit job resolves the gate before falling back
- [x] A project with no `gates` block behaves exactly as before
- [x] The audit-specific exclusion loader is on the fallback path too
- [x] The resolve block stays byte-identical to the other twelve

Work-Item: CodySwannGT/lisa#2622
