### PR TITLE
fix(hooks): the managed-file guard must honour .lisaignore

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
@@ -109,6 +109,21 @@ lisaignored() {
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
+    # A leading `!` is not gitignore negation here. The real matcher passes
+    # patterns to minimatch, which negates by default, and it combines them with
+    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
+    # ignored. Measured:
+    #
+    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
+    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
+    #
+    # Reproducing that faithfully would mean disabling this guard on a typo.
+    # Reproducing the intuitive gitignore reading would mean blocking files the
+    # matcher considers ignored. Both are wrong, so the file is treated as
+    # claimed and the write is allowed — the same direction this function errs
+    # everywhere else. Filed upstream; when the matcher stops negating, delete
+    # this branch rather than teaching it a second wrong answer.
+    case "$pattern" in !*) return 0 ;; esac
     case "$pattern" in
       */)
         case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac

--- a/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
@@ -70,6 +70,49 @@ if [ -f "$project_root/package.json" ] &&
   exit 0
 fi
 
+# Whether the project has claimed a path in `.lisaignore`.
+#
+# THIS IS THE OWNERSHIP QUESTION, and it decides whether blocking is right at
+# all. `lisa apply` skips an ignored path — it logs `Kept (.lisaignore)` and
+# counts it as ignored rather than overwritten — so the file is the project's,
+# its edits survive, and refusing them would be refusing someone access to their
+# own file. `doctor-lisa-owned-artifacts` already consults this list; this guard
+# did not, which would have blocked deliberate forks.
+#
+# The real matcher is minimatch in `src/utils/ignore-patterns.ts` and cannot be
+# reproduced faithfully in shell. This covers the common shapes — exact path,
+# directory prefix, glob, and a bare pattern matching any segment — and where it
+# is unsure it ALLOWS. Wrongly allowing costs an edit that apply may overwrite,
+# which is the behaviour before this guard existed; wrongly blocking locks
+# someone out of a file they own.
+lisaignored() {
+  local rel="$1"
+  local list="$project_root/.lisaignore"
+  [ -f "$list" ] || return 1
+  local pattern
+  while IFS= read -r pattern || [ -n "$pattern" ]; do
+    pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [ -n "$pattern" ] || continue
+    case "$pattern" in \#*) continue ;; esac
+    case "$pattern" in
+      */)
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        ;;
+    esac
+    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+    case "$rel" in $pattern) return 0 ;; esac
+    case "$pattern" in
+      */*) ;;
+      *)
+        # shellcheck disable=SC2254 -- ditto, matched against the basename.
+        case "${rel##*/}" in $pattern) return 0 ;; esac
+        ;;
+    esac
+  done <"$list"
+  return 1
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -84,6 +127,8 @@ managed_source() {
   local rel="${candidate#"$project_root"/}"
   rel="${rel#./}"
   [ -n "$rel" ] || return 1
+  # Claimed by the project, so not ours to refuse.
+  lisaignored "$rel" && return 1
   local stack
   for stack in "$package_root"/*/copy-overwrite; do
     [ -d "$stack" ] || continue
@@ -125,7 +170,17 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    proves each one, so a project can substitute its own task without touching a
    shipped file.
 
-4. You believe this file should not be Lisa-managed at all. That is a real
+4. This project has deliberately FORKED this file and means to keep its own
+   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
+   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
+   the fork survives, this guard stops refusing it, and the divergence is
+   declared where the next person can see it rather than discovered later.
+
+   Take this route only if the fork is intended. A file edited locally WITHOUT
+   being ignored is not a fork, it is an edit with a deletion scheduled against
+   it, and it stops receiving upstream fixes while still looking current.
+
+5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
 
 If a human explicitly asked for this edit, they can re-run with

--- a/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
@@ -4,16 +4,30 @@
 
 # PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
 #
-# Lisa ships templates in three modes, and only one of them destroys host edits:
+# Lisa ships templates in three modes, and only one of them is unsafe to edit:
 #
-#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
-#                    gone at the next `bun install`, silently.
+#   copy-overwrite — see below; the harm depends on the file.
 #   copy-contents  — Lisa APPENDS its lines; host content survives.
 #   create-only    — skipped when the file exists; the host owns it outright.
 #
 # So this guard covers copy-overwrite and nothing else. Blocking the other two
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
+#
+# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
+# and an earlier version of this guard described only one of them:
+#
+#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
+#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
+#       The file silently forks and stops receiving upstream fixes while looking
+#       current. Nothing is deleted; that is what makes it hard to notice.
+#   everything else (`.json` configs and friends)
+#     — replaced wholesale on the next apply, which runs on every install.
+#       The edit vanishes.
+#
+# The refusal branches on ledger membership so it states the consequence that
+# actually applies, rather than describing both and leaving the reader to work
+# out which they are in.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -113,6 +127,13 @@ lisaignored() {
   return 1
 }
 
+# A candidate rewritten relative to the project, so an absolute target from a
+# tool payload and a relative one from a shell command classify identically.
+relative_path() {
+  local rel="${1#"$project_root"/}"
+  printf '%s' "${rel#./}"
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -123,9 +144,8 @@ managed_source() {
   case "$candidate" in
     */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
   esac
-  # Normalise to a project-relative path so an absolute target still matches.
-  local rel="${candidate#"$project_root"/}"
-  rel="${rel#./}"
+  local rel
+  rel="$(relative_path "$candidate")"
   [ -n "$rel" ] || return 1
   # Claimed by the project, so not ours to refuse.
   lisaignored "$rel" && return 1
@@ -140,19 +160,44 @@ managed_source() {
   return 1
 }
 
+# Whether a destination is a ledger-tracked Lisa-owned guard.
+#
+# The two populations behind this guard have OPPOSITE consequences, so the
+# refusal has to know which one it is looking at rather than describing both and
+# leaving the reader to guess. A guard in the content-hash ledger classifies as
+# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
+# replaced wholesale. Both are bad, for different reasons, and the right next
+# step differs too.
+ledger_tracked() {
+  local rel="$1"
+  local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
+  [ -f "$ledger" ] || return 1
+  grep -q "\"$rel\"" "$ledger" 2>/dev/null
+}
+
 refuse() {
   local target="$1"
   local source="$2"
+  local rel="$3"
+  local consequence
+  if ledger_tracked "$rel"; then
+    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
+will PRESERVE your edit rather than overwrite it — and that is the trap. The
+file silently forks: it keeps looking current while every upstream fix stops
+reaching it. One repository in this fleet is carrying 243 lines of divergence
+nobody knew about, in a guard that had quietly stopped receiving fixes."
+  else
+    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
+wholesale — and apply runs on every \`bun install\`. Your edit survives until the
+next install and then vanishes, with nothing reporting that it had."
+  fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
 
-WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
-(\`$source\` in the installed package) and is replaced wholesale on every
-\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
-until the next install and then vanish, with nothing reporting that it had.
+WHY: this file is Lisa-managed, shipped as a **copy-overwrite** template
+(\`$source\` in the installed package).
 
-That is not hypothetical: downstream copies edited this way diverged silently
-until they stopped receiving upstream fixes entirely.
+$consequence
 
 WHERE IT GOES INSTEAD — take the first one that fits:
 
@@ -171,14 +216,20 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
-   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
-   the fork survives, this guard stops refusing it, and the divergence is
-   declared where the next person can see it rather than discovered later.
+   version. What to do depends on which population it is, and \`.lisaignore\` is
+   the WRONG answer for a hash-tracked guard:
 
-   Take this route only if the fork is intended. A file edited locally WITHOUT
-   being ignored is not a fork, it is an edit with a deletion scheduled against
-   it, and it stops receiving upstream fixes while still looking current.
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
+     ledger already preserves your version, so ignoring it buys nothing — and it
+     silences the standoff \`lisa doctor\` reports on every run, replacing a true
+     warning with the line "Enforcement guards match the installed Lisa
+     version", which is then false. A visible, resolvable fork becomes a silent
+     permanent one. Keep the warning and resolve the fork: upstream what is
+     general, or accept the standoff knowingly. To make this one edit, use the
+     override below.
+   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
+     preserves it, and the entry declares the divergence where the next person
+     can see it.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
@@ -200,7 +251,7 @@ case "$tool_name" in
     while IFS= read -r candidate; do
       [ -n "$candidate" ] || continue
       if source_path="$(managed_source "$candidate")"; then
-        refuse "$candidate" "$source_path"
+        refuse "$candidate" "$source_path" "$(relative_path "$candidate")"
       fi
     done <<EOF
 $paths
@@ -215,7 +266,7 @@ EOF
     while IFS= read -r token; do
       [ -n "$token" ] || continue
       if source_path="$(managed_source "$token")"; then
-        refuse "$token" "$source_path"
+        refuse "$token" "$source_path" "$(relative_path "$token")"
       fi
     done <<EOF
 $(printf '%s' "$command_str" |

--- a/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
@@ -67,6 +67,49 @@ if [ -f "$project_root/package.json" ] &&
   exit 0
 fi
 
+# Whether the project has claimed a path in `.lisaignore`.
+#
+# THIS IS THE OWNERSHIP QUESTION, and it decides whether blocking is right at
+# all. `lisa apply` skips an ignored path — it logs `Kept (.lisaignore)` and
+# counts it as ignored rather than overwritten — so the file is the project's,
+# its edits survive, and refusing them would be refusing someone access to their
+# own file. `doctor-lisa-owned-artifacts` already consults this list; this guard
+# did not, which would have blocked deliberate forks.
+#
+# The real matcher is minimatch in `src/utils/ignore-patterns.ts` and cannot be
+# reproduced faithfully in shell. This covers the common shapes — exact path,
+# directory prefix, glob, and a bare pattern matching any segment — and where it
+# is unsure it ALLOWS. Wrongly allowing costs an edit that apply may overwrite,
+# which is the behaviour before this guard existed; wrongly blocking locks
+# someone out of a file they own.
+lisaignored() {
+  local rel="$1"
+  local list="$project_root/.lisaignore"
+  [ -f "$list" ] || return 1
+  local pattern
+  while IFS= read -r pattern || [ -n "$pattern" ]; do
+    pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [ -n "$pattern" ] || continue
+    case "$pattern" in \#*) continue ;; esac
+    case "$pattern" in
+      */)
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        ;;
+    esac
+    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+    case "$rel" in $pattern) return 0 ;; esac
+    case "$pattern" in
+      */*) ;;
+      *)
+        # shellcheck disable=SC2254 -- ditto, matched against the basename.
+        case "${rel##*/}" in $pattern) return 0 ;; esac
+        ;;
+    esac
+  done <"$list"
+  return 1
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -81,6 +124,8 @@ managed_source() {
   local rel="${candidate#"$project_root"/}"
   rel="${rel#./}"
   [ -n "$rel" ] || return 1
+  # Claimed by the project, so not ours to refuse.
+  lisaignored "$rel" && return 1
   local stack
   for stack in "$package_root"/*/copy-overwrite; do
     [ -d "$stack" ] || continue
@@ -122,7 +167,17 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    proves each one, so a project can substitute its own task without touching a
    shipped file.
 
-4. You believe this file should not be Lisa-managed at all. That is a real
+4. This project has deliberately FORKED this file and means to keep its own
+   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
+   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
+   the fork survives, this guard stops refusing it, and the divergence is
+   declared where the next person can see it rather than discovered later.
+
+   Take this route only if the fork is intended. A file edited locally WITHOUT
+   being ignored is not a fork, it is an edit with a deletion scheduled against
+   it, and it stops receiving upstream fixes while still looking current.
+
+5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
 
 If a human explicitly asked for this edit, they can re-run with

--- a/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
@@ -106,6 +106,21 @@ lisaignored() {
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
+    # A leading `!` is not gitignore negation here. The real matcher passes
+    # patterns to minimatch, which negates by default, and it combines them with
+    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
+    # ignored. Measured:
+    #
+    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
+    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
+    #
+    # Reproducing that faithfully would mean disabling this guard on a typo.
+    # Reproducing the intuitive gitignore reading would mean blocking files the
+    # matcher considers ignored. Both are wrong, so the file is treated as
+    # claimed and the write is allowed — the same direction this function errs
+    # everywhere else. Filed upstream; when the matcher stops negating, delete
+    # this branch rather than teaching it a second wrong answer.
+    case "$pattern" in !*) return 0 ;; esac
     case "$pattern" in
       */)
         case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac

--- a/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 # PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
 #
-# Lisa ships templates in three modes, and only one of them destroys host edits:
+# Lisa ships templates in three modes, and only one of them is unsafe to edit:
 #
-#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
-#                    gone at the next `bun install`, silently.
+#   copy-overwrite — see below; the harm depends on the file.
 #   copy-contents  — Lisa APPENDS its lines; host content survives.
 #   create-only    — skipped when the file exists; the host owns it outright.
 #
 # So this guard covers copy-overwrite and nothing else. Blocking the other two
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
+#
+# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
+# and an earlier version of this guard described only one of them:
+#
+#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
+#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
+#       The file silently forks and stops receiving upstream fixes while looking
+#       current. Nothing is deleted; that is what makes it hard to notice.
+#   everything else (`.json` configs and friends)
+#     — replaced wholesale on the next apply, which runs on every install.
+#       The edit vanishes.
+#
+# The refusal branches on ledger membership so it states the consequence that
+# actually applies, rather than describing both and leaving the reader to work
+# out which they are in.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -110,6 +124,13 @@ lisaignored() {
   return 1
 }
 
+# A candidate rewritten relative to the project, so an absolute target from a
+# tool payload and a relative one from a shell command classify identically.
+relative_path() {
+  local rel="${1#"$project_root"/}"
+  printf '%s' "${rel#./}"
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -120,9 +141,8 @@ managed_source() {
   case "$candidate" in
     */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
   esac
-  # Normalise to a project-relative path so an absolute target still matches.
-  local rel="${candidate#"$project_root"/}"
-  rel="${rel#./}"
+  local rel
+  rel="$(relative_path "$candidate")"
   [ -n "$rel" ] || return 1
   # Claimed by the project, so not ours to refuse.
   lisaignored "$rel" && return 1
@@ -137,19 +157,44 @@ managed_source() {
   return 1
 }
 
+# Whether a destination is a ledger-tracked Lisa-owned guard.
+#
+# The two populations behind this guard have OPPOSITE consequences, so the
+# refusal has to know which one it is looking at rather than describing both and
+# leaving the reader to guess. A guard in the content-hash ledger classifies as
+# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
+# replaced wholesale. Both are bad, for different reasons, and the right next
+# step differs too.
+ledger_tracked() {
+  local rel="$1"
+  local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
+  [ -f "$ledger" ] || return 1
+  grep -q "\"$rel\"" "$ledger" 2>/dev/null
+}
+
 refuse() {
   local target="$1"
   local source="$2"
+  local rel="$3"
+  local consequence
+  if ledger_tracked "$rel"; then
+    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
+will PRESERVE your edit rather than overwrite it — and that is the trap. The
+file silently forks: it keeps looking current while every upstream fix stops
+reaching it. One repository in this fleet is carrying 243 lines of divergence
+nobody knew about, in a guard that had quietly stopped receiving fixes."
+  else
+    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
+wholesale — and apply runs on every \`bun install\`. Your edit survives until the
+next install and then vanishes, with nothing reporting that it had."
+  fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
 
-WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
-(\`$source\` in the installed package) and is replaced wholesale on every
-\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
-until the next install and then vanish, with nothing reporting that it had.
+WHY: this file is Lisa-managed, shipped as a **copy-overwrite** template
+(\`$source\` in the installed package).
 
-That is not hypothetical: downstream copies edited this way diverged silently
-until they stopped receiving upstream fixes entirely.
+$consequence
 
 WHERE IT GOES INSTEAD — take the first one that fits:
 
@@ -168,14 +213,20 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
-   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
-   the fork survives, this guard stops refusing it, and the divergence is
-   declared where the next person can see it rather than discovered later.
+   version. What to do depends on which population it is, and \`.lisaignore\` is
+   the WRONG answer for a hash-tracked guard:
 
-   Take this route only if the fork is intended. A file edited locally WITHOUT
-   being ignored is not a fork, it is an edit with a deletion scheduled against
-   it, and it stops receiving upstream fixes while still looking current.
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
+     ledger already preserves your version, so ignoring it buys nothing — and it
+     silences the standoff \`lisa doctor\` reports on every run, replacing a true
+     warning with the line "Enforcement guards match the installed Lisa
+     version", which is then false. A visible, resolvable fork becomes a silent
+     permanent one. Keep the warning and resolve the fork: upstream what is
+     general, or accept the standoff knowingly. To make this one edit, use the
+     override below.
+   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
+     preserves it, and the entry declares the divergence where the next person
+     can see it.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
@@ -197,7 +248,7 @@ case "$tool_name" in
     while IFS= read -r candidate; do
       [ -n "$candidate" ] || continue
       if source_path="$(managed_source "$candidate")"; then
-        refuse "$candidate" "$source_path"
+        refuse "$candidate" "$source_path" "$(relative_path "$candidate")"
       fi
     done <<EOF
 $paths
@@ -212,7 +263,7 @@ EOF
     while IFS= read -r token; do
       [ -n "$token" ] || continue
       if source_path="$(managed_source "$token")"; then
-        refuse "$token" "$source_path"
+        refuse "$token" "$source_path" "$(relative_path "$token")"
       fi
     done <<EOF
 $(printf '%s' "$command_str" |

--- a/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
@@ -67,6 +67,49 @@ if [ -f "$project_root/package.json" ] &&
   exit 0
 fi
 
+# Whether the project has claimed a path in `.lisaignore`.
+#
+# THIS IS THE OWNERSHIP QUESTION, and it decides whether blocking is right at
+# all. `lisa apply` skips an ignored path — it logs `Kept (.lisaignore)` and
+# counts it as ignored rather than overwritten — so the file is the project's,
+# its edits survive, and refusing them would be refusing someone access to their
+# own file. `doctor-lisa-owned-artifacts` already consults this list; this guard
+# did not, which would have blocked deliberate forks.
+#
+# The real matcher is minimatch in `src/utils/ignore-patterns.ts` and cannot be
+# reproduced faithfully in shell. This covers the common shapes — exact path,
+# directory prefix, glob, and a bare pattern matching any segment — and where it
+# is unsure it ALLOWS. Wrongly allowing costs an edit that apply may overwrite,
+# which is the behaviour before this guard existed; wrongly blocking locks
+# someone out of a file they own.
+lisaignored() {
+  local rel="$1"
+  local list="$project_root/.lisaignore"
+  [ -f "$list" ] || return 1
+  local pattern
+  while IFS= read -r pattern || [ -n "$pattern" ]; do
+    pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [ -n "$pattern" ] || continue
+    case "$pattern" in \#*) continue ;; esac
+    case "$pattern" in
+      */)
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        ;;
+    esac
+    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+    case "$rel" in $pattern) return 0 ;; esac
+    case "$pattern" in
+      */*) ;;
+      *)
+        # shellcheck disable=SC2254 -- ditto, matched against the basename.
+        case "${rel##*/}" in $pattern) return 0 ;; esac
+        ;;
+    esac
+  done <"$list"
+  return 1
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -81,6 +124,8 @@ managed_source() {
   local rel="${candidate#"$project_root"/}"
   rel="${rel#./}"
   [ -n "$rel" ] || return 1
+  # Claimed by the project, so not ours to refuse.
+  lisaignored "$rel" && return 1
   local stack
   for stack in "$package_root"/*/copy-overwrite; do
     [ -d "$stack" ] || continue
@@ -122,7 +167,17 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    proves each one, so a project can substitute its own task without touching a
    shipped file.
 
-4. You believe this file should not be Lisa-managed at all. That is a real
+4. This project has deliberately FORKED this file and means to keep its own
+   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
+   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
+   the fork survives, this guard stops refusing it, and the divergence is
+   declared where the next person can see it rather than discovered later.
+
+   Take this route only if the fork is intended. A file edited locally WITHOUT
+   being ignored is not a fork, it is an edit with a deletion scheduled against
+   it, and it stops receiving upstream fixes while still looking current.
+
+5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
 
 If a human explicitly asked for this edit, they can re-run with

--- a/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
@@ -106,6 +106,21 @@ lisaignored() {
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
+    # A leading `!` is not gitignore negation here. The real matcher passes
+    # patterns to minimatch, which negates by default, and it combines them with
+    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
+    # ignored. Measured:
+    #
+    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
+    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
+    #
+    # Reproducing that faithfully would mean disabling this guard on a typo.
+    # Reproducing the intuitive gitignore reading would mean blocking files the
+    # matcher considers ignored. Both are wrong, so the file is treated as
+    # claimed and the write is allowed — the same direction this function errs
+    # everywhere else. Filed upstream; when the matcher stops negating, delete
+    # this branch rather than teaching it a second wrong answer.
+    case "$pattern" in !*) return 0 ;; esac
     case "$pattern" in
       */)
         case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac

--- a/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 # PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
 #
-# Lisa ships templates in three modes, and only one of them destroys host edits:
+# Lisa ships templates in three modes, and only one of them is unsafe to edit:
 #
-#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
-#                    gone at the next `bun install`, silently.
+#   copy-overwrite — see below; the harm depends on the file.
 #   copy-contents  — Lisa APPENDS its lines; host content survives.
 #   create-only    — skipped when the file exists; the host owns it outright.
 #
 # So this guard covers copy-overwrite and nothing else. Blocking the other two
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
+#
+# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
+# and an earlier version of this guard described only one of them:
+#
+#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
+#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
+#       The file silently forks and stops receiving upstream fixes while looking
+#       current. Nothing is deleted; that is what makes it hard to notice.
+#   everything else (`.json` configs and friends)
+#     — replaced wholesale on the next apply, which runs on every install.
+#       The edit vanishes.
+#
+# The refusal branches on ledger membership so it states the consequence that
+# actually applies, rather than describing both and leaving the reader to work
+# out which they are in.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -110,6 +124,13 @@ lisaignored() {
   return 1
 }
 
+# A candidate rewritten relative to the project, so an absolute target from a
+# tool payload and a relative one from a shell command classify identically.
+relative_path() {
+  local rel="${1#"$project_root"/}"
+  printf '%s' "${rel#./}"
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -120,9 +141,8 @@ managed_source() {
   case "$candidate" in
     */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
   esac
-  # Normalise to a project-relative path so an absolute target still matches.
-  local rel="${candidate#"$project_root"/}"
-  rel="${rel#./}"
+  local rel
+  rel="$(relative_path "$candidate")"
   [ -n "$rel" ] || return 1
   # Claimed by the project, so not ours to refuse.
   lisaignored "$rel" && return 1
@@ -137,19 +157,44 @@ managed_source() {
   return 1
 }
 
+# Whether a destination is a ledger-tracked Lisa-owned guard.
+#
+# The two populations behind this guard have OPPOSITE consequences, so the
+# refusal has to know which one it is looking at rather than describing both and
+# leaving the reader to guess. A guard in the content-hash ledger classifies as
+# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
+# replaced wholesale. Both are bad, for different reasons, and the right next
+# step differs too.
+ledger_tracked() {
+  local rel="$1"
+  local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
+  [ -f "$ledger" ] || return 1
+  grep -q "\"$rel\"" "$ledger" 2>/dev/null
+}
+
 refuse() {
   local target="$1"
   local source="$2"
+  local rel="$3"
+  local consequence
+  if ledger_tracked "$rel"; then
+    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
+will PRESERVE your edit rather than overwrite it — and that is the trap. The
+file silently forks: it keeps looking current while every upstream fix stops
+reaching it. One repository in this fleet is carrying 243 lines of divergence
+nobody knew about, in a guard that had quietly stopped receiving fixes."
+  else
+    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
+wholesale — and apply runs on every \`bun install\`. Your edit survives until the
+next install and then vanishes, with nothing reporting that it had."
+  fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
 
-WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
-(\`$source\` in the installed package) and is replaced wholesale on every
-\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
-until the next install and then vanish, with nothing reporting that it had.
+WHY: this file is Lisa-managed, shipped as a **copy-overwrite** template
+(\`$source\` in the installed package).
 
-That is not hypothetical: downstream copies edited this way diverged silently
-until they stopped receiving upstream fixes entirely.
+$consequence
 
 WHERE IT GOES INSTEAD — take the first one that fits:
 
@@ -168,14 +213,20 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
-   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
-   the fork survives, this guard stops refusing it, and the divergence is
-   declared where the next person can see it rather than discovered later.
+   version. What to do depends on which population it is, and \`.lisaignore\` is
+   the WRONG answer for a hash-tracked guard:
 
-   Take this route only if the fork is intended. A file edited locally WITHOUT
-   being ignored is not a fork, it is an edit with a deletion scheduled against
-   it, and it stops receiving upstream fixes while still looking current.
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
+     ledger already preserves your version, so ignoring it buys nothing — and it
+     silences the standoff \`lisa doctor\` reports on every run, replacing a true
+     warning with the line "Enforcement guards match the installed Lisa
+     version", which is then false. A visible, resolvable fork becomes a silent
+     permanent one. Keep the warning and resolve the fork: upstream what is
+     general, or accept the standoff knowingly. To make this one edit, use the
+     override below.
+   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
+     preserves it, and the entry declares the divergence where the next person
+     can see it.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
@@ -197,7 +248,7 @@ case "$tool_name" in
     while IFS= read -r candidate; do
       [ -n "$candidate" ] || continue
       if source_path="$(managed_source "$candidate")"; then
-        refuse "$candidate" "$source_path"
+        refuse "$candidate" "$source_path" "$(relative_path "$candidate")"
       fi
     done <<EOF
 $paths
@@ -212,7 +263,7 @@ EOF
     while IFS= read -r token; do
       [ -n "$token" ] || continue
       if source_path="$(managed_source "$token")"; then
-        refuse "$token" "$source_path"
+        refuse "$token" "$source_path" "$(relative_path "$token")"
       fi
     done <<EOF
 $(printf '%s' "$command_str" |

--- a/plugins/lisa/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa/hooks/block-managed-file-edits.sh
@@ -67,6 +67,49 @@ if [ -f "$project_root/package.json" ] &&
   exit 0
 fi
 
+# Whether the project has claimed a path in `.lisaignore`.
+#
+# THIS IS THE OWNERSHIP QUESTION, and it decides whether blocking is right at
+# all. `lisa apply` skips an ignored path — it logs `Kept (.lisaignore)` and
+# counts it as ignored rather than overwritten — so the file is the project's,
+# its edits survive, and refusing them would be refusing someone access to their
+# own file. `doctor-lisa-owned-artifacts` already consults this list; this guard
+# did not, which would have blocked deliberate forks.
+#
+# The real matcher is minimatch in `src/utils/ignore-patterns.ts` and cannot be
+# reproduced faithfully in shell. This covers the common shapes — exact path,
+# directory prefix, glob, and a bare pattern matching any segment — and where it
+# is unsure it ALLOWS. Wrongly allowing costs an edit that apply may overwrite,
+# which is the behaviour before this guard existed; wrongly blocking locks
+# someone out of a file they own.
+lisaignored() {
+  local rel="$1"
+  local list="$project_root/.lisaignore"
+  [ -f "$list" ] || return 1
+  local pattern
+  while IFS= read -r pattern || [ -n "$pattern" ]; do
+    pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [ -n "$pattern" ] || continue
+    case "$pattern" in \#*) continue ;; esac
+    case "$pattern" in
+      */)
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        ;;
+    esac
+    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+    case "$rel" in $pattern) return 0 ;; esac
+    case "$pattern" in
+      */*) ;;
+      *)
+        # shellcheck disable=SC2254 -- ditto, matched against the basename.
+        case "${rel##*/}" in $pattern) return 0 ;; esac
+        ;;
+    esac
+  done <"$list"
+  return 1
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -81,6 +124,8 @@ managed_source() {
   local rel="${candidate#"$project_root"/}"
   rel="${rel#./}"
   [ -n "$rel" ] || return 1
+  # Claimed by the project, so not ours to refuse.
+  lisaignored "$rel" && return 1
   local stack
   for stack in "$package_root"/*/copy-overwrite; do
     [ -d "$stack" ] || continue
@@ -122,7 +167,17 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    proves each one, so a project can substitute its own task without touching a
    shipped file.
 
-4. You believe this file should not be Lisa-managed at all. That is a real
+4. This project has deliberately FORKED this file and means to keep its own
+   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
+   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
+   the fork survives, this guard stops refusing it, and the divergence is
+   declared where the next person can see it rather than discovered later.
+
+   Take this route only if the fork is intended. A file edited locally WITHOUT
+   being ignored is not a fork, it is an edit with a deletion scheduled against
+   it, and it stops receiving upstream fixes while still looking current.
+
+5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
 
 If a human explicitly asked for this edit, they can re-run with

--- a/plugins/lisa/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa/hooks/block-managed-file-edits.sh
@@ -106,6 +106,21 @@ lisaignored() {
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
+    # A leading `!` is not gitignore negation here. The real matcher passes
+    # patterns to minimatch, which negates by default, and it combines them with
+    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
+    # ignored. Measured:
+    #
+    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
+    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
+    #
+    # Reproducing that faithfully would mean disabling this guard on a typo.
+    # Reproducing the intuitive gitignore reading would mean blocking files the
+    # matcher considers ignored. Both are wrong, so the file is treated as
+    # claimed and the write is allowed — the same direction this function errs
+    # everywhere else. Filed upstream; when the matcher stops negating, delete
+    # this branch rather than teaching it a second wrong answer.
+    case "$pattern" in !*) return 0 ;; esac
     case "$pattern" in
       */)
         case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac

--- a/plugins/lisa/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa/hooks/block-managed-file-edits.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 # PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
 #
-# Lisa ships templates in three modes, and only one of them destroys host edits:
+# Lisa ships templates in three modes, and only one of them is unsafe to edit:
 #
-#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
-#                    gone at the next `bun install`, silently.
+#   copy-overwrite — see below; the harm depends on the file.
 #   copy-contents  — Lisa APPENDS its lines; host content survives.
 #   create-only    — skipped when the file exists; the host owns it outright.
 #
 # So this guard covers copy-overwrite and nothing else. Blocking the other two
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
+#
+# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
+# and an earlier version of this guard described only one of them:
+#
+#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
+#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
+#       The file silently forks and stops receiving upstream fixes while looking
+#       current. Nothing is deleted; that is what makes it hard to notice.
+#   everything else (`.json` configs and friends)
+#     — replaced wholesale on the next apply, which runs on every install.
+#       The edit vanishes.
+#
+# The refusal branches on ledger membership so it states the consequence that
+# actually applies, rather than describing both and leaving the reader to work
+# out which they are in.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -110,6 +124,13 @@ lisaignored() {
   return 1
 }
 
+# A candidate rewritten relative to the project, so an absolute target from a
+# tool payload and a relative one from a shell command classify identically.
+relative_path() {
+  local rel="${1#"$project_root"/}"
+  printf '%s' "${rel#./}"
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -120,9 +141,8 @@ managed_source() {
   case "$candidate" in
     */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
   esac
-  # Normalise to a project-relative path so an absolute target still matches.
-  local rel="${candidate#"$project_root"/}"
-  rel="${rel#./}"
+  local rel
+  rel="$(relative_path "$candidate")"
   [ -n "$rel" ] || return 1
   # Claimed by the project, so not ours to refuse.
   lisaignored "$rel" && return 1
@@ -137,19 +157,44 @@ managed_source() {
   return 1
 }
 
+# Whether a destination is a ledger-tracked Lisa-owned guard.
+#
+# The two populations behind this guard have OPPOSITE consequences, so the
+# refusal has to know which one it is looking at rather than describing both and
+# leaving the reader to guess. A guard in the content-hash ledger classifies as
+# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
+# replaced wholesale. Both are bad, for different reasons, and the right next
+# step differs too.
+ledger_tracked() {
+  local rel="$1"
+  local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
+  [ -f "$ledger" ] || return 1
+  grep -q "\"$rel\"" "$ledger" 2>/dev/null
+}
+
 refuse() {
   local target="$1"
   local source="$2"
+  local rel="$3"
+  local consequence
+  if ledger_tracked "$rel"; then
+    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
+will PRESERVE your edit rather than overwrite it — and that is the trap. The
+file silently forks: it keeps looking current while every upstream fix stops
+reaching it. One repository in this fleet is carrying 243 lines of divergence
+nobody knew about, in a guard that had quietly stopped receiving fixes."
+  else
+    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
+wholesale — and apply runs on every \`bun install\`. Your edit survives until the
+next install and then vanishes, with nothing reporting that it had."
+  fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
 
-WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
-(\`$source\` in the installed package) and is replaced wholesale on every
-\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
-until the next install and then vanish, with nothing reporting that it had.
+WHY: this file is Lisa-managed, shipped as a **copy-overwrite** template
+(\`$source\` in the installed package).
 
-That is not hypothetical: downstream copies edited this way diverged silently
-until they stopped receiving upstream fixes entirely.
+$consequence
 
 WHERE IT GOES INSTEAD — take the first one that fits:
 
@@ -168,14 +213,20 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
-   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
-   the fork survives, this guard stops refusing it, and the divergence is
-   declared where the next person can see it rather than discovered later.
+   version. What to do depends on which population it is, and \`.lisaignore\` is
+   the WRONG answer for a hash-tracked guard:
 
-   Take this route only if the fork is intended. A file edited locally WITHOUT
-   being ignored is not a fork, it is an edit with a deletion scheduled against
-   it, and it stops receiving upstream fixes while still looking current.
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
+     ledger already preserves your version, so ignoring it buys nothing — and it
+     silences the standoff \`lisa doctor\` reports on every run, replacing a true
+     warning with the line "Enforcement guards match the installed Lisa
+     version", which is then false. A visible, resolvable fork becomes a silent
+     permanent one. Keep the warning and resolve the fork: upstream what is
+     general, or accept the standoff knowingly. To make this one edit, use the
+     override below.
+   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
+     preserves it, and the entry declares the divergence where the next person
+     can see it.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
@@ -197,7 +248,7 @@ case "$tool_name" in
     while IFS= read -r candidate; do
       [ -n "$candidate" ] || continue
       if source_path="$(managed_source "$candidate")"; then
-        refuse "$candidate" "$source_path"
+        refuse "$candidate" "$source_path" "$(relative_path "$candidate")"
       fi
     done <<EOF
 $paths
@@ -212,7 +263,7 @@ EOF
     while IFS= read -r token; do
       [ -n "$token" ] || continue
       if source_path="$(managed_source "$token")"; then
-        refuse "$token" "$source_path"
+        refuse "$token" "$source_path" "$(relative_path "$token")"
       fi
     done <<EOF
 $(printf '%s' "$command_str" |

--- a/plugins/src/base/hooks/block-managed-file-edits.sh
+++ b/plugins/src/base/hooks/block-managed-file-edits.sh
@@ -67,6 +67,49 @@ if [ -f "$project_root/package.json" ] &&
   exit 0
 fi
 
+# Whether the project has claimed a path in `.lisaignore`.
+#
+# THIS IS THE OWNERSHIP QUESTION, and it decides whether blocking is right at
+# all. `lisa apply` skips an ignored path — it logs `Kept (.lisaignore)` and
+# counts it as ignored rather than overwritten — so the file is the project's,
+# its edits survive, and refusing them would be refusing someone access to their
+# own file. `doctor-lisa-owned-artifacts` already consults this list; this guard
+# did not, which would have blocked deliberate forks.
+#
+# The real matcher is minimatch in `src/utils/ignore-patterns.ts` and cannot be
+# reproduced faithfully in shell. This covers the common shapes — exact path,
+# directory prefix, glob, and a bare pattern matching any segment — and where it
+# is unsure it ALLOWS. Wrongly allowing costs an edit that apply may overwrite,
+# which is the behaviour before this guard existed; wrongly blocking locks
+# someone out of a file they own.
+lisaignored() {
+  local rel="$1"
+  local list="$project_root/.lisaignore"
+  [ -f "$list" ] || return 1
+  local pattern
+  while IFS= read -r pattern || [ -n "$pattern" ]; do
+    pattern="${pattern#"${pattern%%[![:space:]]*}"}"
+    pattern="${pattern%"${pattern##*[![:space:]]}"}"
+    [ -n "$pattern" ] || continue
+    case "$pattern" in \#*) continue ;; esac
+    case "$pattern" in
+      */)
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        ;;
+    esac
+    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+    case "$rel" in $pattern) return 0 ;; esac
+    case "$pattern" in
+      */*) ;;
+      *)
+        # shellcheck disable=SC2254 -- ditto, matched against the basename.
+        case "${rel##*/}" in $pattern) return 0 ;; esac
+        ;;
+    esac
+  done <"$list"
+  return 1
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -81,6 +124,8 @@ managed_source() {
   local rel="${candidate#"$project_root"/}"
   rel="${rel#./}"
   [ -n "$rel" ] || return 1
+  # Claimed by the project, so not ours to refuse.
+  lisaignored "$rel" && return 1
   local stack
   for stack in "$package_root"/*/copy-overwrite; do
     [ -d "$stack" ] || continue
@@ -122,7 +167,17 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    proves each one, so a project can substitute its own task without touching a
    shipped file.
 
-4. You believe this file should not be Lisa-managed at all. That is a real
+4. This project has deliberately FORKED this file and means to keep its own
+   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
+   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
+   the fork survives, this guard stops refusing it, and the divergence is
+   declared where the next person can see it rather than discovered later.
+
+   Take this route only if the fork is intended. A file edited locally WITHOUT
+   being ignored is not a fork, it is an edit with a deletion scheduled against
+   it, and it stops receiving upstream fixes while still looking current.
+
+5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
 
 If a human explicitly asked for this edit, they can re-run with

--- a/plugins/src/base/hooks/block-managed-file-edits.sh
+++ b/plugins/src/base/hooks/block-managed-file-edits.sh
@@ -106,6 +106,21 @@ lisaignored() {
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
+    # A leading `!` is not gitignore negation here. The real matcher passes
+    # patterns to minimatch, which negates by default, and it combines them with
+    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
+    # ignored. Measured:
+    #
+    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
+    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
+    #
+    # Reproducing that faithfully would mean disabling this guard on a typo.
+    # Reproducing the intuitive gitignore reading would mean blocking files the
+    # matcher considers ignored. Both are wrong, so the file is treated as
+    # claimed and the write is allowed — the same direction this function errs
+    # everywhere else. Filed upstream; when the matcher stops negating, delete
+    # this branch rather than teaching it a second wrong answer.
+    case "$pattern" in !*) return 0 ;; esac
     case "$pattern" in
       */)
         case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac

--- a/plugins/src/base/hooks/block-managed-file-edits.sh
+++ b/plugins/src/base/hooks/block-managed-file-edits.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 # PreToolUse hook: refuse agent writes to files Lisa overwrites on every apply.
 #
-# Lisa ships templates in three modes, and only one of them destroys host edits:
+# Lisa ships templates in three modes, and only one of them is unsafe to edit:
 #
-#   copy-overwrite — replaced wholesale on every `lisa apply`. An edit here is
-#                    gone at the next `bun install`, silently.
+#   copy-overwrite — see below; the harm depends on the file.
 #   copy-contents  — Lisa APPENDS its lines; host content survives.
 #   create-only    — skipped when the file exists; the host owns it outright.
 #
 # So this guard covers copy-overwrite and nothing else. Blocking the other two
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
+#
+# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
+# and an earlier version of this guard described only one of them:
+#
+#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
+#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
+#       The file silently forks and stops receiving upstream fixes while looking
+#       current. Nothing is deleted; that is what makes it hard to notice.
+#   everything else (`.json` configs and friends)
+#     — replaced wholesale on the next apply, which runs on every install.
+#       The edit vanishes.
+#
+# The refusal branches on ledger membership so it states the consequence that
+# actually applies, rather than describing both and leaving the reader to work
+# out which they are in.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -110,6 +124,13 @@ lisaignored() {
   return 1
 }
 
+# A candidate rewritten relative to the project, so an absolute target from a
+# tool payload and a relative one from a shell command classify identically.
+relative_path() {
+  local rel="${1#"$project_root"/}"
+  printf '%s' "${rel#./}"
+}
+
 # Whether a host-relative path is shipped as a copy-overwrite template.
 #
 # A few stat calls rather than an enumeration: the same relative path is probed
@@ -120,9 +141,8 @@ managed_source() {
   case "$candidate" in
     */node_modules/* | node_modules/* | */dist/* | dist/*) return 1 ;;
   esac
-  # Normalise to a project-relative path so an absolute target still matches.
-  local rel="${candidate#"$project_root"/}"
-  rel="${rel#./}"
+  local rel
+  rel="$(relative_path "$candidate")"
   [ -n "$rel" ] || return 1
   # Claimed by the project, so not ours to refuse.
   lisaignored "$rel" && return 1
@@ -137,19 +157,44 @@ managed_source() {
   return 1
 }
 
+# Whether a destination is a ledger-tracked Lisa-owned guard.
+#
+# The two populations behind this guard have OPPOSITE consequences, so the
+# refusal has to know which one it is looking at rather than describing both and
+# leaving the reader to guess. A guard in the content-hash ledger classifies as
+# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
+# replaced wholesale. Both are bad, for different reasons, and the right next
+# step differs too.
+ledger_tracked() {
+  local rel="$1"
+  local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
+  [ -f "$ledger" ] || return 1
+  grep -q "\"$rel\"" "$ledger" 2>/dev/null
+}
+
 refuse() {
   local target="$1"
   local source="$2"
+  local rel="$3"
+  local consequence
+  if ledger_tracked "$rel"; then
+    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
+will PRESERVE your edit rather than overwrite it — and that is the trap. The
+file silently forks: it keeps looking current while every upstream fix stops
+reaching it. One repository in this fleet is carrying 243 lines of divergence
+nobody knew about, in a guard that had quietly stopped receiving fixes."
+  else
+    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
+wholesale — and apply runs on every \`bun install\`. Your edit survives until the
+next install and then vanishes, with nothing reporting that it had."
+  fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
 
-WHY: this file is Lisa-managed. It is shipped as a **copy-overwrite** template
-(\`$source\` in the installed package) and is replaced wholesale on every
-\`lisa apply\` — which runs on every \`bun install\`. Your edit would survive
-until the next install and then vanish, with nothing reporting that it had.
+WHY: this file is Lisa-managed, shipped as a **copy-overwrite** template
+(\`$source\` in the installed package).
 
-That is not hypothetical: downstream copies edited this way diverged silently
-until they stopped receiving upstream fixes entirely.
+$consequence
 
 WHERE IT GOES INSTEAD — take the first one that fits:
 
@@ -168,14 +213,20 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. Then say so: add the path to \`.lisaignore\`. \`lisa apply\` skips an
-   ignored path — it reports \`Kept (.lisaignore)\` rather than overwriting — so
-   the fork survives, this guard stops refusing it, and the divergence is
-   declared where the next person can see it rather than discovered later.
+   version. What to do depends on which population it is, and \`.lisaignore\` is
+   the WRONG answer for a hash-tracked guard:
 
-   Take this route only if the fork is intended. A file edited locally WITHOUT
-   being ignored is not a fork, it is an edit with a deletion scheduled against
-   it, and it stops receiving upstream fixes while still looking current.
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
+     ledger already preserves your version, so ignoring it buys nothing — and it
+     silences the standoff \`lisa doctor\` reports on every run, replacing a true
+     warning with the line "Enforcement guards match the installed Lisa
+     version", which is then false. A visible, resolvable fork becomes a silent
+     permanent one. Keep the warning and resolve the fork: upstream what is
+     general, or accept the standoff knowingly. To make this one edit, use the
+     override below.
+   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
+     preserves it, and the entry declares the divergence where the next person
+     can see it.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.
@@ -197,7 +248,7 @@ case "$tool_name" in
     while IFS= read -r candidate; do
       [ -n "$candidate" ] || continue
       if source_path="$(managed_source "$candidate")"; then
-        refuse "$candidate" "$source_path"
+        refuse "$candidate" "$source_path" "$(relative_path "$candidate")"
       fi
     done <<EOF
 $paths
@@ -212,7 +263,7 @@ EOF
     while IFS= read -r token; do
       [ -n "$token" ] || continue
       if source_path="$(managed_source "$token")"; then
-        refuse "$token" "$source_path"
+        refuse "$token" "$source_path" "$(relative_path "$token")"
       fi
     done <<EOF
 $(printf '%s' "$command_str" |

--- a/src/cli/doctor-lisa-owned-artifacts.ts
+++ b/src/cli/doctor-lisa-owned-artifacts.ts
@@ -208,7 +208,12 @@ export async function checkLisaOwnedArtifacts(
 
   const results = await Promise.all(
     [...shipped].map(async ([destination, sources]) => {
-      if (matchesAnyPattern(destination, ignorePatterns)) return undefined;
+      // Ignored is UNASSESSED, not clean. Reported as such below, because a
+      // `.lisaignore` entry on a Lisa-owned guard suppresses the divergence
+      // warning while changing nothing about the divergence — and the ok line
+      // then states conformance that was never established.
+      if (matchesAnyPattern(destination, ignorePatterns))
+        return [destination, "ignored"] as const;
       const installedPath = path.join(targetPath, destination);
       const installed = await readFile(installedPath).catch(() => undefined);
       if (installed === undefined) return undefined;
@@ -234,8 +239,8 @@ export async function checkLisaOwnedArtifacts(
   );
 }
 
-/** Which of the two findings an artifact produced. */
-type Finding = "stale" | "modified";
+/** Which finding an artifact produced. */
+type Finding = "stale" | "modified" | "ignored";
 
 /**
  * Turn the per-artifact findings into one doctor line.
@@ -253,11 +258,19 @@ function summarise(
 
   const stale = pick("stale");
   const modified = pick("modified");
+  const ignored = pick("ignored");
   if (stale.length === 0 && modified.length === 0) {
+    // Named rather than folded into the pass. A guard excluded by
+    // `.lisaignore` was never compared, so claiming it matches asserts
+    // something no comparison established — and the file it most often hides
+    // is a fork the project has stopped noticing.
     return {
       name: CHECK_NAME,
       status: "ok",
-      detail: "Enforcement guards match the installed Lisa version",
+      detail:
+        ignored.length > 0
+          ? `Enforcement guards match the installed Lisa version; ${ignored.length} not assessed (.lisaignore): ${ignored.join(", ")}`
+          : "Enforcement guards match the installed Lisa version",
     };
   }
 

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -219,6 +219,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
   ]),
   "scripts/lisa-hooks/block-managed-file-edits.sh": Object.freeze([
+    "133acf329582c5d4df9deb6a297df13216993c1bfec0b7df0663c69a1e2bb0db",
     "18aebaef5ea9bf6af220dc9beef80a5cfb37282c6a53047783b4cc96d8daa4e3",
   ]),
   "scripts/lisa-hooks/block-no-verify.sh": Object.freeze([

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -222,6 +222,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "133acf329582c5d4df9deb6a297df13216993c1bfec0b7df0663c69a1e2bb0db",
     "18aebaef5ea9bf6af220dc9beef80a5cfb37282c6a53047783b4cc96d8daa4e3",
     "3882bd338e65b9db9e97aa9e70426f0f7a0d191539df51636e1a5e93a2501137",
+    "c1b2abf324269c0248136500eb37d7c43559552f152a7c5d07a23c219fdc70b2",
   ]),
   "scripts/lisa-hooks/block-no-verify.sh": Object.freeze([
     "031ef7a53fc49cb18665105b834b7b50ad6a43317e0821949809e877e0562ce4",

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -221,6 +221,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/lisa-hooks/block-managed-file-edits.sh": Object.freeze([
     "133acf329582c5d4df9deb6a297df13216993c1bfec0b7df0663c69a1e2bb0db",
     "18aebaef5ea9bf6af220dc9beef80a5cfb37282c6a53047783b4cc96d8daa4e3",
+    "3882bd338e65b9db9e97aa9e70426f0f7a0d191539df51636e1a5e93a2501137",
   ]),
   "scripts/lisa-hooks/block-no-verify.sh": Object.freeze([
     "031ef7a53fc49cb18665105b834b7b50ad6a43317e0821949809e877e0562ce4",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -25,7 +25,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
     "all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh":
-      "18aebaef5ea9bf6af220dc9beef80a5cfb37282c6a53047783b4cc96d8daa4e3",
+      "133acf329582c5d4df9deb6a297df13216993c1bfec0b7df0663c69a1e2bb0db",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
       "83a8b8108654086afb6a6f23a8f09f9f041eb2cd4094c5531fa7ab1f75e873dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
@@ -679,7 +679,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-instruction-file-edits.sh":
       "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
     "plugins/src/base/hooks/block-managed-file-edits.sh":
-      "abdbcd889925879aa43fe0420971cf1a79a7b9a534c06e681fe3f0fbb5475894",
+      "f649bee5fc993a18c3364f4df912ea27dae075f2420d337c4bf8ac816e35fa30",
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "81c51041f8cb47bf79692c485c4f42ac7ed0a5a830821dc514cb468bc7a06b83",
     "plugins/src/base/hooks/block-no-verify.sh":
@@ -8908,6 +8908,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/block-direct-issue-create.test.ts": true,
     "tests/unit/hooks/block-generated-artifact-edits.test.ts": true,
     "tests/unit/hooks/block-instruction-file-edits.test.ts": true,
+    "tests/unit/hooks/block-managed-file-edits.test.ts": true,
     "tests/unit/hooks/block-no-verify-missing-jq.test.ts": true,
     "tests/unit/hooks/block-no-verify.test.ts": true,
     "tests/unit/hooks/block-shell-json-parsing-missing-deps.test.ts": true,

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -25,7 +25,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
     "all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh":
-      "3882bd338e65b9db9e97aa9e70426f0f7a0d191539df51636e1a5e93a2501137",
+      "c1b2abf324269c0248136500eb37d7c43559552f152a7c5d07a23c219fdc70b2",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
       "83a8b8108654086afb6a6f23a8f09f9f041eb2cd4094c5531fa7ab1f75e873dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
@@ -679,7 +679,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-instruction-file-edits.sh":
       "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
     "plugins/src/base/hooks/block-managed-file-edits.sh":
-      "c1f0e3d8b7a0b627c527ca0188e954fc21221b405db972912f147913cb5ca703",
+      "c363505f94d3716e51972bbff33845b0bf41c92b4e909288d02b2d7c3e87fa61",
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "81c51041f8cb47bf79692c485c4f42ac7ed0a5a830821dc514cb468bc7a06b83",
     "plugins/src/base/hooks/block-no-verify.sh":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -25,7 +25,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
     "all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh":
-      "133acf329582c5d4df9deb6a297df13216993c1bfec0b7df0663c69a1e2bb0db",
+      "3882bd338e65b9db9e97aa9e70426f0f7a0d191539df51636e1a5e93a2501137",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
       "83a8b8108654086afb6a6f23a8f09f9f041eb2cd4094c5531fa7ab1f75e873dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
@@ -679,7 +679,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-instruction-file-edits.sh":
       "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
     "plugins/src/base/hooks/block-managed-file-edits.sh":
-      "f649bee5fc993a18c3364f4df912ea27dae075f2420d337c4bf8ac816e35fa30",
+      "c1f0e3d8b7a0b627c527ca0188e954fc21221b405db972912f147913cb5ca703",
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "81c51041f8cb47bf79692c485c4f42ac7ed0a5a830821dc514cb468bc7a06b83",
     "plugins/src/base/hooks/block-no-verify.sh":

--- a/tests/unit/hooks/block-managed-file-edits.test.ts
+++ b/tests/unit/hooks/block-managed-file-edits.test.ts
@@ -164,6 +164,19 @@ describe(".lisaignore declares project ownership", () => {
     expect(runGuard(MANAGED)).toBe(0);
   });
 
+  it("allows when any pattern uses a leading !, matching the real matcher", () => {
+    // Not gitignore negation. The real matcher hands patterns to minimatch,
+    // which negates by default and combines them with `.some()`, so one `!x`
+    // line reports every OTHER path as ignored. Measured upstream:
+    //   patterns=["!scripts/a.mjs"] path=scripts/b.mjs -> ignored=true
+    // Reproducing that exactly would disable the guard on a typo; reproducing
+    // the intuitive reading would block files the matcher treats as ignored.
+    // Both are wrong, so it allows — the direction this function errs
+    // everywhere else.
+    ignoreFile("!scripts/something-else.mjs\n");
+    expect(runGuard(MANAGED)).toBe(0);
+  });
+
   it.each([
     ["comments and blank lines only", "# nothing here\n\n"],
     ["an unrelated entry", "scripts/other.mjs\n"],

--- a/tests/unit/hooks/block-managed-file-edits.test.ts
+++ b/tests/unit/hooks/block-managed-file-edits.test.ts
@@ -80,6 +80,30 @@ beforeEach(() => {
   mkdirSync(shipped, { recursive: true });
   writeFileSync(path.join(shipped, "classify-maestro-failures.mjs"), "x");
   writeFileSync(path.join(shipped, "render.mjs"), "y");
+  // Only the first is hash-tracked, which is what the refusal branches on.
+  const ledgerDir = path.join(
+    project,
+    "node_modules/@codyswann/lisa/dist/core"
+  );
+  mkdirSync(ledgerDir, { recursive: true });
+  writeFileSync(
+    path.join(ledgerDir, "lisa-owned-hash-ledger.js"),
+    `const L={"scripts/classify-maestro-failures.mjs":true};\n`
+  );
+  mkdirSync(
+    path.join(
+      project,
+      "node_modules/@codyswann/lisa/typescript/copy-overwrite"
+    ),
+    { recursive: true }
+  );
+  writeFileSync(
+    path.join(
+      project,
+      "node_modules/@codyswann/lisa/typescript/copy-overwrite/.lintstagedrc.json"
+    ),
+    "{}"
+  );
   mkdirSync(
     path.join(project, "node_modules/@codyswann/lisa/typescript/create-only"),
     {
@@ -148,6 +172,50 @@ describe(".lisaignore declares project ownership", () => {
     // name this path must not read as blanket ownership.
     ignoreFile(body);
     expect(runGuard(MANAGED)).toBe(2);
+  });
+});
+
+describe("the refusal states the consequence that actually applies", () => {
+  /**
+   * Capture the refusal text for a target.
+   * @param filePath - Target the tool would write
+   * @returns stderr from the guard
+   */
+  function refusalFor(filePath: string): string {
+    try {
+      execFileSync(BASH, [GUARD], {
+        input: JSON.stringify({
+          tool_name: "Write",
+          tool_input: { file_path: filePath },
+        }),
+        env: { ...process.env, CLAUDE_PROJECT_DIR: project },
+        stdio: "pipe",
+      });
+      return "";
+    } catch (error) {
+      return String((error as { stderr?: Buffer }).stderr ?? "");
+    }
+  }
+
+  it("tells a hash-tracked guard its edit is PRESERVED and forks silently", () => {
+    // The correction: apply does not delete these. It keeps them, which is why
+    // a fork goes unnoticed. Saying "your edit vanishes" here was simply false.
+    const text = refusalFor(MANAGED);
+    expect(text).toContain("PRESERVE your edit");
+    expect(text).not.toContain("REPLACES it");
+  });
+
+  it("tells an untracked template its edit is REPLACED wholesale", () => {
+    const text = refusalFor(".lintstagedrc.json");
+    expect(text).toContain("REPLACES it");
+    expect(text).not.toContain("PRESERVE your edit");
+  });
+
+  it("steers a hash-tracked fork AWAY from .lisaignore", () => {
+    // Ignoring a tracked guard buys nothing (the ledger already preserves it)
+    // and silences the standoff doctor reports — replacing a true warning with
+    // a false statement of conformance.
+    expect(refusalFor(MANAGED)).toContain("Do NOT add it to");
   });
 });
 

--- a/tests/unit/hooks/block-managed-file-edits.test.ts
+++ b/tests/unit/hooks/block-managed-file-edits.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests the guard that refuses agent writes to Lisa-managed templates.
+ *
+ * The load-bearing case is `.lisaignore`. `lisa apply` SKIPS an ignored path —
+ * it reports `Kept (.lisaignore)` rather than overwriting — so the file is the
+ * project's, its edits survive, and refusing them would lock someone out of
+ * their own file. The guard shipped without consulting that list, which a peer
+ * caught against two real files in one repository pointing opposite ways:
+ * `scripts/bdd/render.mjs`, where local fixes revert and the change belongs
+ * upstream, and `scripts/classify-maestro-failures.mjs`, a deliberate fork that
+ * must be edited locally and never upstreamed.
+ *
+ * Both are copy-overwrite. Only `.lisaignore` distinguishes them, and without
+ * it the guard gave the fork exactly the wrong instruction.
+ * @module tests/unit/hooks/block-managed-file-edits
+ */
+
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const GUARD = path.join(
+  REPO_ROOT,
+  "plugins",
+  "src",
+  "base",
+  "hooks",
+  "block-managed-file-edits.sh"
+);
+
+/** Absolute interpreter path; resolving `bash` through PATH is not permitted. */
+const BASH = "/bin/bash";
+
+/** A copy-overwrite template used across the cases. */
+const MANAGED = "scripts/classify-maestro-failures.mjs";
+
+let project: string;
+
+/**
+ * Run the guard against a tool payload.
+ * @param filePath - Target the tool would write
+ * @returns Exit status; 2 means refused
+ */
+function runGuard(filePath: string): number {
+  try {
+    execFileSync(BASH, [GUARD], {
+      input: JSON.stringify({
+        tool_name: "Write",
+        tool_input: { file_path: filePath },
+      }),
+      env: { ...process.env, CLAUDE_PROJECT_DIR: project },
+      stdio: "pipe",
+    });
+    return 0;
+  } catch (error) {
+    return (error as { status?: number }).status ?? -1;
+  }
+}
+
+/**
+ * Write a `.lisaignore` for the fixture project.
+ * @param body - File contents
+ * @returns Nothing.
+ */
+const ignoreFile = (body: string): void =>
+  writeFileSync(path.join(project, ".lisaignore"), body, "utf8");
+
+beforeEach(() => {
+  project = mkdtempSync(path.join(tmpdir(), "lisa-guard-"));
+  const shipped = path.join(
+    project,
+    "node_modules/@codyswann/lisa/all/copy-overwrite/scripts"
+  );
+  mkdirSync(shipped, { recursive: true });
+  writeFileSync(path.join(shipped, "classify-maestro-failures.mjs"), "x");
+  writeFileSync(path.join(shipped, "render.mjs"), "y");
+  mkdirSync(
+    path.join(project, "node_modules/@codyswann/lisa/typescript/create-only"),
+    {
+      recursive: true,
+    }
+  );
+  writeFileSync(
+    path.join(
+      project,
+      "node_modules/@codyswann/lisa/typescript/create-only/eslint.config.local.ts"
+    ),
+    "z"
+  );
+  writeFileSync(
+    path.join(project, "package.json"),
+    JSON.stringify({ name: "host-project" })
+  );
+});
+
+afterEach(() => {
+  rmSync(project, { recursive: true, force: true });
+});
+
+describe("what the guard refuses", () => {
+  it("refuses a copy-overwrite template", () => {
+    expect(runGuard(MANAGED)).toBe(2);
+  });
+
+  it("allows a create-only file, which the host owns", () => {
+    expect(runGuard("eslint.config.local.ts")).toBe(0);
+  });
+
+  it("allows a file Lisa does not ship", () => {
+    expect(runGuard("src/app.ts")).toBe(0);
+  });
+});
+
+describe(".lisaignore declares project ownership", () => {
+  it("allows an ignored template, because apply will not overwrite it", () => {
+    // The fork case. Without this the guard told a deliberate fork to go
+    // upstream, which is the one place its change must never go.
+    ignoreFile(`${MANAGED}\n`);
+    expect(runGuard(MANAGED)).toBe(0);
+  });
+
+  it("still refuses a DIFFERENT managed file in the same project", () => {
+    // The two-directions case: one file forked, one not, in one repository.
+    ignoreFile(`${MANAGED}\n`);
+    expect(runGuard("scripts/render.mjs")).toBe(2);
+  });
+
+  it.each([
+    ["a directory pattern", "scripts/\n"],
+    ["a glob", "*.mjs\n"],
+    ["a bare basename", "classify-maestro-failures.mjs\n"],
+  ])("honours %s", (_label, body) => {
+    ignoreFile(body);
+    expect(runGuard(MANAGED)).toBe(0);
+  });
+
+  it.each([
+    ["comments and blank lines only", "# nothing here\n\n"],
+    ["an unrelated entry", "scripts/other.mjs\n"],
+  ])("still refuses with %s", (_label, body) => {
+    // The exemption has to be earned. A `.lisaignore` that exists but does not
+    // name this path must not read as blanket ownership.
+    ignoreFile(body);
+    expect(runGuard(MANAGED)).toBe(2);
+  });
+});
+
+describe("the refusal explains the fork route", () => {
+  it("names .lisaignore, so a genuine fork is not told to go upstream", () => {
+    let stderr = "";
+    try {
+      execFileSync(BASH, [GUARD], {
+        input: JSON.stringify({
+          tool_name: "Write",
+          tool_input: { file_path: MANAGED },
+        }),
+        env: { ...process.env, CLAUDE_PROJECT_DIR: project },
+        stdio: "pipe",
+      });
+    } catch (error) {
+      stderr = String((error as { stderr?: Buffer }).stderr ?? "");
+    }
+    expect(stderr).toContain(".lisaignore");
+    expect(stderr).toContain("LISA_ALLOW_MANAGED_FILE_WRITE");
+  });
+});


### PR DESCRIPTION
## The bug

The guard that refuses agent writes to Lisa-managed files does not read
`.lisaignore`.

That list is how a project says "this file is mine now". `lisa apply` skips an
ignored path — it reports `Kept (.lisaignore)` instead of overwriting — so the
file genuinely belongs to the project and its edits genuinely survive. The
existing artifact check already reads that list. The new guard did not, so it
would refuse people access to their own files.

## Why it matters, from a real repository

One project has two Lisa-managed files that need **opposite** handling:

- `scripts/bdd/render.mjs` — local fixes get reverted on the next install, so
  the change has to go upstream.
- `scripts/classify-maestro-failures.mjs` — a **deliberate fork**, carrying
  local platform handling. It must be edited locally and must never be sent
  upstream.

Both are copy-overwrite. Nothing distinguishes them except `.lisaignore`. So the
guard, as shipped, told the fork to go upstream — the one place its change must
never go.

## The fix

Two parts.

**The guard now treats an ignored path as the project's.** If `.lisaignore`
names the file, the write is allowed and no refusal appears.

**The refusal now names `.lisaignore` as a route**, with the distinction stated:
declaring a fork is legitimate, but a file edited locally *without* being
ignored is not a fork — it is an edit with a deletion already scheduled against
it, which keeps looking current while it stops receiving fixes.

## An honest limit

The real matcher supports full globbing and cannot be reproduced faithfully in
shell. This covers exact paths, directory prefixes, simple globs and bare
filenames, and **where it is unsure it allows the edit**. Wrongly allowing costs
an edit that a later install may overwrite — which is exactly the behaviour
before this guard existed. Wrongly refusing locks someone out of their own file.

## Done when

- [x] A path named in `.lisaignore` is not refused
- [x] Another managed file in the same project is still refused
- [x] Directory, glob and bare-filename patterns all work
- [x] A `.lisaignore` that exists but does not name the file does not excuse it
- [x] The refusal explains the fork route

Work-Item: CodySwannGT/lisa#2624


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects can now declare intentional local forks in `.lisaignore`.
  * Ignored files are allowed to be edited and preserved by `lisa apply`.
  * Support added for exact paths, directories, globs, and filename patterns.

* **Bug Fixes**
  * Managed-file protection now distinguishes intentional forks from unapproved edits.
  * Refusal messages explain how to use `.lisaignore` and the override option.

* **Tests**
  * Added coverage for managed-file blocking, allowed files, ignore patterns, and guidance messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->