### PR TITLE
fix(scripts): three shipped guards could report success without doing the work

### DIFF
--- a/all/copy-overwrite/scripts/check-state-classification.mjs
+++ b/all/copy-overwrite/scripts/check-state-classification.mjs
@@ -560,6 +560,37 @@ export function run(options = {}) {
     };
   }
 
+  // Parsed is not the same as shaped. `readJsonFile` proves only that the bytes
+  // were JSON, and `compareInventory` reads `inventory.entities` — so `null`
+  // throws a TypeError on property access and the CLI dies with a stack trace
+  // instead of emitting an `invalid` envelope, while an array or a string
+  // silently yields zero entities and every declared entity reads as
+  // unconfirmed. A wrong-shaped inventory must be reported as invalid, not
+  // mistaken for an empty one.
+  const inventoryValue = inventoryRead.value;
+  if (
+    inventoryValue === null ||
+    typeof inventoryValue !== "object" ||
+    Array.isArray(inventoryValue) ||
+    !Array.isArray(inventoryValue.entities)
+  ) {
+    return {
+      findings: [
+        {
+          code: "invalid-inventory",
+          subject: path.relative(root, inventoryPath),
+          message:
+            "parsed as JSON but is not an inventory: expected an object with an `entities` array. Regenerate it with the project's `state:inventory` adapter.",
+          severity: "error",
+        },
+      ],
+      envelope: envelopeFor("invalid", {
+        contractVersion: contract.contractVersion,
+        reason: `runtime inventory at ${path.relative(root, inventoryPath)} parsed but has the wrong shape — an inventory that cannot be read is not an empty inventory.`,
+      }),
+    };
+  }
+
   const verdict = compareInventory({
     contract,
     inventory: inventoryRead.value,

--- a/all/copy-overwrite/scripts/lisa-gates.mjs
+++ b/all/copy-overwrite/scripts/lisa-gates.mjs
@@ -63,6 +63,8 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
+
 /** Enforcement levels a moment may carry. */
 export const LEVELS = ["required", "optional", "off"];
 
@@ -1307,7 +1309,14 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Realpath both sides rather than comparing URL strings. A raw comparison
+// answers "no" through a symlinked checkout, a git worktree, or a /tmp path on
+// macOS — all three of which this fleet runs in — so the module would load, run
+// nothing, and exit 0. For THIS file that is the worst possible silence: the
+// quality workflow pipes its output into a resolver that reads empty input as
+// `[]`, reports `configured=false` for every job, and runs the fallback. The
+// whole gate registry would be bypassed with nothing reporting it.
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
+++ b/plugins/lisa-agy/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
@@ -202,7 +202,29 @@ function parseInline(text) {
   return nodes.length > 0 ? nodes : [{ type: "text", text: "" }];
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", chunk => {

--- a/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-agy/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,14 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { commandsIn } from "./commands.mjs";
@@ -583,7 +590,29 @@ export function proposedEntries(proposal) {
   };
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const proposals = detectTooling();
   if (process.argv.includes("--json")) {
     console.log(JSON.stringify(proposals, null, 2));

--- a/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-agy/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -20,7 +20,13 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -495,7 +501,29 @@ async function main() {
   console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: one dispatch path is async, so a synchronous
   // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
   // reporting dispatched work that was never accepted.

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -18,6 +18,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { validateNote } from "./note-format.mjs";
 import { fetchAll, fetchRotatable } from "./providers.mjs";
@@ -239,7 +241,29 @@ function main() {
   if (errors) throw new Error(`${errors} secrets configuration error(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/inspect-vault.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/inspect-vault.mjs
@@ -115,6 +115,28 @@ function main() {
   console.log(`\n${rows.length} secret(s). Values are never printed.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   main();
 }

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -30,6 +30,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   BOOTSTRAP_KEY,
@@ -454,7 +455,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/read-secret-note.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/read-secret-note.mjs
@@ -13,7 +13,8 @@
  * @module read-secret-note
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { materializedPaths, readConfig } from "./surfaces.mjs";
 
@@ -72,7 +73,29 @@ function main() {
   console.log(noteFor(name, loadNotes(notesFile)));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/resolve-secret.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/resolve-secret.mjs
@@ -27,7 +27,8 @@
  * @module resolve-secret
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { parseEnv } from "./envfile.mjs";
 import { validateNote } from "./note-format.mjs";
@@ -252,7 +253,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -27,7 +27,8 @@
  * @module rotate-secret
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { hostname } from "node:os";
 
 import {
@@ -264,7 +265,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
@@ -48,6 +48,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { ENV_KEY, fetchAll } from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
@@ -471,7 +473,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -16,7 +16,8 @@
  * @module validate-config
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
@@ -517,7 +518,29 @@ function main() {
   throw new Error(`${problems.length} configuration problem(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -17,7 +17,14 @@
  * @module generate-workflow
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 /** Where a generated loop workflow lands. */
@@ -249,7 +256,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-agy/skills/lisa-setup-local-env/scripts/local-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-local-env/scripts/local-env.mjs
@@ -23,7 +23,7 @@
  * @module local-env
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -159,7 +159,29 @@ export async function run(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const argv = {
     installTools: process.argv.includes("--install-tools"),
     dryRun: process.argv.includes("--dry-run"),

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1519,7 +1519,29 @@ async function main() {
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: main is async, so a synchronous try/catch
   // would let a rejected promise escape as an unhandled rejection and exit 0 —
   // reporting a prepared environment that was never prepared.

--- a/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-agy/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 
 import { probe, readRemoteEnvConfig } from "./setup-remote-env.mjs";
@@ -213,7 +214,29 @@ function main() {
   console.log("\nRemote environment verified without revealing any value.");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
+++ b/plugins/lisa-copilot/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
@@ -202,7 +202,29 @@ function parseInline(text) {
   return nodes.length > 0 ? nodes : [{ type: "text", text: "" }];
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", chunk => {

--- a/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-copilot/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,14 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { commandsIn } from "./commands.mjs";
@@ -583,7 +590,29 @@ export function proposedEntries(proposal) {
   };
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const proposals = detectTooling();
   if (process.argv.includes("--json")) {
     console.log(JSON.stringify(proposals, null, 2));

--- a/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-copilot/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -20,7 +20,13 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -495,7 +501,29 @@ async function main() {
   console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: one dispatch path is async, so a synchronous
   // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
   // reporting dispatched work that was never accepted.

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -18,6 +18,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { validateNote } from "./note-format.mjs";
 import { fetchAll, fetchRotatable } from "./providers.mjs";
@@ -239,7 +241,29 @@ function main() {
   if (errors) throw new Error(`${errors} secrets configuration error(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/inspect-vault.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/inspect-vault.mjs
@@ -115,6 +115,28 @@ function main() {
   console.log(`\n${rows.length} secret(s). Values are never printed.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   main();
 }

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -30,6 +30,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   BOOTSTRAP_KEY,
@@ -454,7 +455,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/read-secret-note.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/read-secret-note.mjs
@@ -13,7 +13,8 @@
  * @module read-secret-note
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { materializedPaths, readConfig } from "./surfaces.mjs";
 
@@ -72,7 +73,29 @@ function main() {
   console.log(noteFor(name, loadNotes(notesFile)));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/resolve-secret.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/resolve-secret.mjs
@@ -27,7 +27,8 @@
  * @module resolve-secret
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { parseEnv } from "./envfile.mjs";
 import { validateNote } from "./note-format.mjs";
@@ -252,7 +253,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -27,7 +27,8 @@
  * @module rotate-secret
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { hostname } from "node:os";
 
 import {
@@ -264,7 +265,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
@@ -48,6 +48,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { ENV_KEY, fetchAll } from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
@@ -471,7 +473,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -16,7 +16,8 @@
  * @module validate-config
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
@@ -517,7 +518,29 @@ function main() {
   throw new Error(`${problems.length} configuration problem(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -17,7 +17,14 @@
  * @module generate-workflow
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 /** Where a generated loop workflow lands. */
@@ -249,7 +256,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-copilot/skills/lisa-setup-local-env/scripts/local-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-local-env/scripts/local-env.mjs
@@ -23,7 +23,7 @@
  * @module local-env
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -159,7 +159,29 @@ export async function run(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const argv = {
     installTools: process.argv.includes("--install-tools"),
     dryRun: process.argv.includes("--dry-run"),

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1519,7 +1519,29 @@ async function main() {
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: main is async, so a synchronous try/catch
   // would let a rejected promise escape as an unhandled rejection and exit 0 —
   // reporting a prepared environment that was never prepared.

--- a/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-copilot/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 
 import { probe, readRemoteEnvConfig } from "./setup-remote-env.mjs";
@@ -213,7 +214,29 @@ function main() {
   console.log("\nRemote environment verified without revealing any value.");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
+++ b/plugins/lisa-cursor/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
@@ -202,7 +202,29 @@ function parseInline(text) {
   return nodes.length > 0 ? nodes : [{ type: "text", text: "" }];
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", chunk => {

--- a/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa-cursor/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,14 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { commandsIn } from "./commands.mjs";
@@ -583,7 +590,29 @@ export function proposedEntries(proposal) {
   };
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const proposals = detectTooling();
   if (process.argv.includes("--json")) {
     console.log(JSON.stringify(proposals, null, 2));

--- a/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa-cursor/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -20,7 +20,13 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -495,7 +501,29 @@ async function main() {
   console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: one dispatch path is async, so a synchronous
   // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
   // reporting dispatched work that was never accepted.

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -18,6 +18,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { validateNote } from "./note-format.mjs";
 import { fetchAll, fetchRotatable } from "./providers.mjs";
@@ -239,7 +241,29 @@ function main() {
   if (errors) throw new Error(`${errors} secrets configuration error(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/inspect-vault.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/inspect-vault.mjs
@@ -115,6 +115,28 @@ function main() {
   console.log(`\n${rows.length} secret(s). Values are never printed.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   main();
 }

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -30,6 +30,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   BOOTSTRAP_KEY,
@@ -454,7 +455,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/read-secret-note.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/read-secret-note.mjs
@@ -13,7 +13,8 @@
  * @module read-secret-note
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { materializedPaths, readConfig } from "./surfaces.mjs";
 
@@ -72,7 +73,29 @@ function main() {
   console.log(noteFor(name, loadNotes(notesFile)));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/resolve-secret.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/resolve-secret.mjs
@@ -27,7 +27,8 @@
  * @module resolve-secret
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { parseEnv } from "./envfile.mjs";
 import { validateNote } from "./note-format.mjs";
@@ -252,7 +253,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -27,7 +27,8 @@
  * @module rotate-secret
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { hostname } from "node:os";
 
 import {
@@ -264,7 +265,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
@@ -48,6 +48,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { ENV_KEY, fetchAll } from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
@@ -471,7 +473,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -16,7 +16,8 @@
  * @module validate-config
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
@@ -517,7 +518,29 @@ function main() {
   throw new Error(`${problems.length} configuration problem(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -17,7 +17,14 @@
  * @module generate-workflow
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 /** Where a generated loop workflow lands. */
@@ -249,7 +256,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa-cursor/skills/lisa-setup-local-env/scripts/local-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-local-env/scripts/local-env.mjs
@@ -23,7 +23,7 @@
  * @module local-env
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -159,7 +159,29 @@ export async function run(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const argv = {
     installTools: process.argv.includes("--install-tools"),
     dryRun: process.argv.includes("--dry-run"),

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1519,7 +1519,29 @@ async function main() {
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: main is async, so a synchronous try/catch
   // would let a rejected promise escape as an unhandled rejection and exit 0 —
   // reporting a prepared environment that was never prepared.

--- a/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa-cursor/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 
 import { probe, readRemoteEnvConfig } from "./setup-remote-env.mjs";
@@ -213,7 +214,29 @@ function main() {
   console.log("\nRemote environment verified without revealing any value.");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
@@ -202,7 +202,29 @@ function parseInline(text) {
   return nodes.length > 0 ? nodes : [{ type: "text", text: "" }];
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", chunk => {

--- a/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,14 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { commandsIn } from "./commands.mjs";
@@ -583,7 +590,29 @@ export function proposedEntries(proposal) {
   };
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const proposals = detectTooling();
   if (process.argv.includes("--json")) {
     console.log(JSON.stringify(proposals, null, 2));

--- a/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -20,7 +20,13 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -495,7 +501,29 @@ async function main() {
   console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: one dispatch path is async, so a synchronous
   // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
   // reporting dispatched work that was never accepted.

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -18,6 +18,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { validateNote } from "./note-format.mjs";
 import { fetchAll, fetchRotatable } from "./providers.mjs";
@@ -239,7 +241,29 @@ function main() {
   if (errors) throw new Error(`${errors} secrets configuration error(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/inspect-vault.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/inspect-vault.mjs
@@ -115,6 +115,28 @@ function main() {
   console.log(`\n${rows.length} secret(s). Values are never printed.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   main();
 }

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -30,6 +30,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   BOOTSTRAP_KEY,
@@ -454,7 +455,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/read-secret-note.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/read-secret-note.mjs
@@ -13,7 +13,8 @@
  * @module read-secret-note
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { materializedPaths, readConfig } from "./surfaces.mjs";
 
@@ -72,7 +73,29 @@ function main() {
   console.log(noteFor(name, loadNotes(notesFile)));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/resolve-secret.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/resolve-secret.mjs
@@ -27,7 +27,8 @@
  * @module resolve-secret
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { parseEnv } from "./envfile.mjs";
 import { validateNote } from "./note-format.mjs";
@@ -252,7 +253,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -27,7 +27,8 @@
  * @module rotate-secret
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { hostname } from "node:os";
 
 import {
@@ -264,7 +265,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
@@ -48,6 +48,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { ENV_KEY, fetchAll } from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
@@ -471,7 +473,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -16,7 +16,8 @@
  * @module validate-config
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
@@ -517,7 +518,29 @@ function main() {
   throw new Error(`${problems.length} configuration problem(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -17,7 +17,14 @@
  * @module generate-workflow
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 /** Where a generated loop workflow lands. */
@@ -249,7 +256,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-local-env/scripts/local-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-local-env/scripts/local-env.mjs
@@ -23,7 +23,7 @@
  * @module local-env
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -159,7 +159,29 @@ export async function run(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const argv = {
     installTools: process.argv.includes("--install-tools"),
     dryRun: process.argv.includes("--dry-run"),

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1519,7 +1519,29 @@ async function main() {
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: main is async, so a synchronous try/catch
   // would let a rejected promise escape as an unhandled rejection and exit 0 —
   // reporting a prepared environment that was never prepared.

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 
 import { probe, readRemoteEnvConfig } from "./setup-remote-env.mjs";
@@ -213,7 +214,29 @@ function main() {
   console.log("\nRemote environment verified without revealing any value.");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
+++ b/plugins/lisa/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
@@ -202,7 +202,29 @@ function parseInline(text) {
   return nodes.length > 0 ? nodes : [{ type: "text", text: "" }];
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", chunk => {

--- a/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/lisa/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,14 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { commandsIn } from "./commands.mjs";
@@ -583,7 +590,29 @@ export function proposedEntries(proposal) {
   };
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const proposals = detectTooling();
   if (process.argv.includes("--json")) {
     console.log(JSON.stringify(proposals, null, 2));

--- a/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/lisa/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -20,7 +20,13 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -495,7 +501,29 @@ async function main() {
   console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: one dispatch path is async, so a synchronous
   // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
   // reporting dispatched work that was never accepted.

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -18,6 +18,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { validateNote } from "./note-format.mjs";
 import { fetchAll, fetchRotatable } from "./providers.mjs";
@@ -239,7 +241,29 @@ function main() {
   if (errors) throw new Error(`${errors} secrets configuration error(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/inspect-vault.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/inspect-vault.mjs
@@ -115,6 +115,28 @@ function main() {
   console.log(`\n${rows.length} secret(s). Values are never printed.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   main();
 }

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -30,6 +30,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   BOOTSTRAP_KEY,
@@ -454,7 +455,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/read-secret-note.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/read-secret-note.mjs
@@ -13,7 +13,8 @@
  * @module read-secret-note
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { materializedPaths, readConfig } from "./surfaces.mjs";
 
@@ -72,7 +73,29 @@ function main() {
   console.log(noteFor(name, loadNotes(notesFile)));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/resolve-secret.mjs
@@ -27,7 +27,8 @@
  * @module resolve-secret
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { parseEnv } from "./envfile.mjs";
 import { validateNote } from "./note-format.mjs";
@@ -252,7 +253,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -27,7 +27,8 @@
  * @module rotate-secret
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { hostname } from "node:os";
 
 import {
@@ -264,7 +265,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
@@ -48,6 +48,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { ENV_KEY, fetchAll } from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
@@ -471,7 +473,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -16,7 +16,8 @@
  * @module validate-config
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
@@ -517,7 +518,29 @@ function main() {
   throw new Error(`${problems.length} configuration problem(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/lisa/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -17,7 +17,14 @@
  * @module generate-workflow
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 /** Where a generated loop workflow lands. */
@@ -249,7 +256,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/lisa/skills/lisa-setup-local-env/scripts/local-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-local-env/scripts/local-env.mjs
@@ -23,7 +23,7 @@
  * @module local-env
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -159,7 +159,29 @@ export async function run(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const argv = {
     installTools: process.argv.includes("--install-tools"),
     dryRun: process.argv.includes("--dry-run"),

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1519,7 +1519,29 @@ async function main() {
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: main is async, so a synchronous try/catch
   // would let a rejected promise escape as an unhandled rejection and exit 0 —
   // reporting a prepared environment that was never prepared.

--- a/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/lisa/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 
 import { probe, readRemoteEnvConfig } from "./setup-remote-env.mjs";
@@ -213,7 +214,29 @@ function main() {
   console.log("\nRemote environment verified without revealing any value.");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
+++ b/plugins/src/base/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs
@@ -202,7 +202,29 @@ function parseInline(text) {
   return nodes.length > 0 ? nodes : [{ type: "text", text: "" }];
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   let input = "";
   process.stdin.setEncoding("utf8");
   process.stdin.on("data", chunk => {

--- a/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
+++ b/plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs
@@ -22,7 +22,14 @@
  * @module detect-tooling
  */
 
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { commandsIn } from "./commands.mjs";
@@ -583,7 +590,29 @@ export function proposedEntries(proposal) {
   };
 }
 
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const proposals = detectTooling();
   if (process.argv.includes("--json")) {
     console.log(JSON.stringify(proposals, null, 2));

--- a/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
+++ b/plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs
@@ -20,7 +20,13 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -495,7 +501,29 @@ async function main() {
   console.log(`recorded in ${LEDGER}; not polling — this process is done.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: one dispatch path is async, so a synchronous
   // try/catch would let a rejection escape as an unhandled rejection and exit 0 —
   // reporting dispatched work that was never accepted.

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs
@@ -18,6 +18,8 @@
  */
 
 import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { validateNote } from "./note-format.mjs";
 import { fetchAll, fetchRotatable } from "./providers.mjs";
@@ -239,7 +241,29 @@ function main() {
   if (errors) throw new Error(`${errors} secrets configuration error(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/inspect-vault.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/inspect-vault.mjs
@@ -115,6 +115,28 @@ function main() {
   console.log(`\n${rows.length} secret(s). Values are never printed.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   main();
 }

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs
@@ -30,6 +30,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import {
   BOOTSTRAP_KEY,
@@ -454,7 +455,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs
@@ -13,7 +13,8 @@
  * @module read-secret-note
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { materializedPaths, readConfig } from "./surfaces.mjs";
 
@@ -72,7 +73,29 @@ function main() {
   console.log(noteFor(name, loadNotes(notesFile)));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/resolve-secret.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/resolve-secret.mjs
@@ -27,7 +27,8 @@
  * @module resolve-secret
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { parseEnv } from "./envfile.mjs";
 import { validateNote } from "./note-format.mjs";
@@ -252,7 +253,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs
@@ -27,7 +27,8 @@
  * @module rotate-secret
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { hostname } from "node:os";
 
 import {
@@ -264,7 +265,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs
@@ -48,6 +48,8 @@
  */
 
 import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
 
 import { ENV_KEY, fetchAll } from "./providers.mjs";
 import { readConfig } from "./surfaces.mjs";
@@ -471,7 +473,29 @@ function main() {
   );
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs
@@ -16,7 +16,8 @@
  * @module validate-config
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 import { SURFACES as SURFACE_CAPABILITIES } from "./surfaces.mjs";
@@ -517,7 +518,29 @@ function main() {
   throw new Error(`${problems.length} configuration problem(s)`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs
+++ b/plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs
@@ -17,7 +17,14 @@
  * @module generate-workflow
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  realpathSync,
+} from "node:fs";
+import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
 /** Where a generated loop workflow lands. */
@@ -249,7 +256,29 @@ function main() {
   }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/plugins/src/base/skills/lisa-setup-local-env/scripts/local-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-local-env/scripts/local-env.mjs
@@ -23,7 +23,7 @@
  * @module local-env
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
@@ -159,7 +159,29 @@ export async function run(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   const argv = {
     installTools: process.argv.includes("--install-tools"),
     dryRun: process.argv.includes("--dry-run"),

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs
@@ -1519,7 +1519,29 @@ async function main() {
   console.log(`\nRemote environment ${dryRun ? "plan complete" : "ready"}.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   // Awaited rather than called bare: main is async, so a synchronous try/catch
   // would let a rejected promise escape as an unhandled rejection and exit 0 —
   // reporting a prepared environment that was never prepared.

--- a/plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
+++ b/plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs
@@ -22,7 +22,8 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { existsSync, readFileSync, statSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 
 import { probe, readRemoteEnvConfig } from "./setup-remote-env.mjs";
@@ -213,7 +214,29 @@ function main() {
   console.log("\nRemote environment verified without revealing any value.");
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+/**
+ * Whether this module is the one node was asked to run.
+ *
+ * Both sides are realpath'd: a raw URL comparison answers "no" through a
+ * symlinked checkout, a git worktree, or a /tmp path on macOS, so the module
+ * loads, runs nothing and exits 0 — a silent no-op that reads as success.
+ *
+ * A local copy rather than an import: plugin payload scripts ship standalone,
+ * with no `lib/` sibling to import from once installed.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string | undefined} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the caller should run its CLI body.
+ */
+function invokedAsScript(moduleUrl, argv1 = process.argv[1]) {
+  if (!argv1) return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
   try {
     main();
   } catch (err) {

--- a/scripts/generate-agy-plugin-artifacts.mjs
+++ b/scripts/generate-agy-plugin-artifacts.mjs
@@ -42,6 +42,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { nestCommandsUnderLisa } from "./lib/nest-plugin-commands.mjs";
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -345,7 +346,7 @@ function emitAgyPluginHooks(srcDir, outDir, sourceHooks, installDirName) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (invokedAsScript(import.meta.url)) {
   const [srcDir, outDir, version] = process.argv.slice(2);
   if (!srcDir || !outDir || !version) {
     console.error(

--- a/scripts/generate-copilot-plugin-artifacts.mjs
+++ b/scripts/generate-copilot-plugin-artifacts.mjs
@@ -31,6 +31,7 @@ import {
   filterScriptsForAgent,
 } from "./lib/per-agent-hook-filter.mjs";
 import { nestCommandsUnderLisa } from "./lib/nest-plugin-commands.mjs";
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -270,7 +271,7 @@ export function generateCopilotVariant(srcDir, outDir, version) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (invokedAsScript(import.meta.url)) {
   const [srcDir, outDir, version] = process.argv.slice(2);
   if (!srcDir || !outDir || !version) {
     console.error(

--- a/scripts/generate-cursor-plugin-artifacts.mjs
+++ b/scripts/generate-cursor-plugin-artifacts.mjs
@@ -50,6 +50,7 @@ import {
   filterScriptsForAgent,
 } from "./lib/per-agent-hook-filter.mjs";
 import { nestCommandsUnderLisa } from "./lib/nest-plugin-commands.mjs";
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
 
 const REPO_ROOT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -366,7 +367,7 @@ export function generateCursorVariant(srcDir, outDir, version) {
 }
 
 // CLI entrypoint.
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (invokedAsScript(import.meta.url)) {
   const [srcDir, outDir, version] = process.argv.slice(2);
   if (!srcDir || !outDir || !version) {
     console.error(

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -114,6 +114,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/check-skipped-required-checks.mjs": Object.freeze([
     "0a8b14790f38e00e5abfc665d3e3d2c29e0a139a2a22c4a65e0c08547b42fb7f",
     "1bcd3f065465731df4eb02b93b73a0162d287e365ed1a396138d97d71d403b31",
+    "444210c8fbfca1d3e6ae0e180fe95752e10152610ad349ffea377136f4ae8cf7",
     "48d3fa3043e144bcf52feb0e20db887d75c7ebda3b1fa708fe93f6554f6bec78",
     "5af5f112ba258c4874a65c72c8bed12165e75e4df407265eb46ee9c89c4e0e53",
     "86de31fbda9dd26a938bf30846c5fc70744cf199df7d475a35f3f25dbc0f7c2f",
@@ -123,6 +124,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   ]),
   "scripts/check-state-classification.mjs": Object.freeze([
     "94dc98e0bbfcf8d43cba035d4805a1c5d61a3a0db88faa791e8e06e34e741f46",
+    "96599f9cf25d7d96afc82a92c477ca851e3fa1f918a06a5b81a29dd1b0039f38",
     "ac539349c86a7b5b0083ec0e6aaf0eb4c3e40fbd4dc31511c6460a2bad7af9a5",
     "b218927f64a3db4f37762b60014e29d85a46899f4a0d17fcecc7782ce48bc499",
   ]),
@@ -196,6 +198,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "79b646d543b541c096d79526fa09dbda3408667ba1a99ee833f94668b181433b",
     "7d89a49da89895a3e377702d0049e1dbcc7ea666dcfa3749874f0986db31ee1a",
     "9195c267d98f2fa8071fc0bd2d5623a7ab82f82d136bdb23061f89a2c1db6efe",
+    "98652623c7451d05e48239e1678ad7977a323eaf7ff5ca4b4f3bbc0798396859",
     "bba52f26e70e0dc399a8ed8ea9cbd3885a18f08401b28bd18871a1af4fbca375",
     "cc4270e365f53c60a5eefb58a8ac8e22be184c0821fcdcc8fe67bcfc1df5e3dd",
     "dbca450e5a17133841ab015e71808feb028996f8297fda362dbeca4f07af2352",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -7,7 +7,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-contents/gitignore":
       "8104ccd32d7e6137cae706511c5037d11d6b6045b8e2a9bb7b3a48a81c053cfa",
     "all/copy-overwrite/scripts/check-state-classification.mjs":
-      "b218927f64a3db4f37762b60014e29d85a46899f4a0d17fcecc7782ce48bc499",
+      "96599f9cf25d7d96afc82a92c477ca851e3fa1f918a06a5b81a29dd1b0039f38",
     "all/copy-overwrite/scripts/lib/invoked-as-script.mjs":
       "fbb9b88fc85a3e22f21af39e1c17acf67ff83fc6b5a6cdc8081bde333c48faa7",
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
@@ -19,7 +19,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-floor-collisions.mjs":
       "2d11968f6852ab745cba939de03c6d6cb5f413975d2cfc8fc447bdd0b218e91a",
     "all/copy-overwrite/scripts/lisa-gates.mjs":
-      "bba52f26e70e0dc399a8ed8ea9cbd3885a18f08401b28bd18871a1af4fbca375",
+      "98652623c7451d05e48239e1678ad7977a323eaf7ff5ca4b4f3bbc0798396859",
     "all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh":
       "8d1f04ef5c5da9db9190e22b37a435e118e39d6e7deafc5402b4593c8e9db2b2",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
@@ -977,7 +977,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-atlassian-access/SKILL.md":
       "6366ccce961217d1c7bcac4dad9c2293ee4dcc395b27c142a3b59c62f00b685c",
     "plugins/src/base/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs":
-      "538e5a3d91482b9e2a055e133b7c1fcf809be51d4ae72a10776aaeeb8df4832a",
+      "8ea94fa2b3fbe860cee365a6dd935a0f7ef9e749a2ab59c8b8dfc1838cdb0d37",
     "plugins/src/base/skills/lisa-attribute-failure/SKILL.md":
       "5d737b9fda916f02aaf13b208316cd54995d83aa06d27ba5daa19b6ebed6b4d9",
     "plugins/src/base/skills/lisa-automation-status/SKILL.md":
@@ -1009,7 +1009,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-detect-tooling/scripts/commands.mjs":
       "e28bd61fdde4a336b56ae3395423026943a5816015719d31d04f0d5a0ab50eec",
     "plugins/src/base/skills/lisa-detect-tooling/scripts/detect-tooling.mjs":
-      "9d06590e6b99cce33e5fb10bd5b9e7515318133e3635368ef47162abc123bdfa",
+      "3a79e0a09112268c2bfe51575355c10c2fa5305fdac6629cada2028ab3f07a00",
     "plugins/src/base/skills/lisa-doctor/SKILL.md":
       "f015bd91a615fa22b8e9f2bcb89a8bbce4a3f7d4fd977bfe94970e8d21d640d8",
     "plugins/src/base/skills/lisa-drive-pr-to-merge/SKILL.md":
@@ -1229,7 +1229,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-remote-dispatch/SKILL.md":
       "f3c48120a206d01db45f849ca5b61690d572abc16bc36d559a4cacc8f9422c06",
     "plugins/src/base/skills/lisa-remote-dispatch/scripts/dispatch.mjs":
-      "475963ed64d9e72a6cbd6cbb61c8b57a419f2e1805e3ddfa76066047c590deeb",
+      "3cf5802d8154ea8ec6c531db6d54c37dd38ab2573e3a0cb38fdfef535150b933",
     "plugins/src/base/skills/lisa-repair-intake/SKILL.md":
       "b9cc5064f24eead0c2f446951eb098a31b8e34c1d5e78929112d0685a6ce9de9",
     "plugins/src/base/skills/lisa-reproduce-bug/SKILL.md":
@@ -1251,13 +1251,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/bootstrap-store.mjs":
       "8dd5ca2c99394ead696093dd10caf664ce2609d39fb8d8ae8f4d4f236dbddbe6",
     "plugins/src/base/skills/lisa-secrets-access/scripts/doctor-secrets.mjs":
-      "5e3b936279d663ad714f0c699af1cd8f487b1212657cd4ad30dbe563d8dee9f8",
+      "71fd7a3f26d7e4424bb8ef80caaaa3db136595a5b9e620a32084a00521277ba3",
     "plugins/src/base/skills/lisa-secrets-access/scripts/envfile.mjs":
       "be4e38ce85f9268b52b29dbde264ecd8d50973c2b63a15410336234a921d9644",
     "plugins/src/base/skills/lisa-secrets-access/scripts/inspect-vault.mjs":
-      "ce48f609f1434d75d00422ab3251f327233596ccac46d5f6437523b435dda164",
+      "d2841042eda0f0c50f995ccc34e09e25aced0abbf3a96bce52a9f604e4009520",
     "plugins/src/base/skills/lisa-secrets-access/scripts/materialize-secrets.mjs":
-      "694f2660df23871d470701d1fb9fc7e24fcf7be137d9c275059ae7f7383340e9",
+      "ebfd1bad8cd6ff85b746c2d69393997e7a6793b4cb2b9695efb2033bd3420ae6",
     "plugins/src/base/skills/lisa-secrets-access/scripts/note-format.mjs":
       "09bd6904bc84a5a93a32499ac94db5ec7728db68908a661698445ef5e6974f3e",
     "plugins/src/base/skills/lisa-secrets-access/scripts/preflight-secrets.mjs":
@@ -1267,21 +1267,21 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
       "f295709e2d14267db89d03d7d61cec9611897d816d5b31eed4b397b9c52d54af",
     "plugins/src/base/skills/lisa-secrets-access/scripts/read-secret-note.mjs":
-      "1471d2108058f3059e242f9c71208c99fdbc212bde32de34b798eaa9a27ffbcc",
+      "735434e25bf1db9f2f7eb3d5ede8361cba01b922d65931393bd36e6f96531654",
     "plugins/src/base/skills/lisa-secrets-access/scripts/resolve-secret.mjs":
-      "75ae143c971a7d442d513f2458ac64322d2394dec77ec806af82f39c5ed815be",
+      "4170220c95f410072f3871f58938b7575684254480d0645e3dbb1535cf09d7a7",
     "plugins/src/base/skills/lisa-secrets-access/scripts/rotate-secret.mjs":
-      "546dc1c2f279cee6db56c0f55c01aabae0c316842f32d3219c5af6d638936a9c",
+      "adada60f766760395858c69ef784654e9e096943485ed237c395c8fc2ca8e20f",
     "plugins/src/base/skills/lisa-secrets-access/scripts/routing-floor.mjs":
       "fa1bdeda4e38bbd149f993ab0288f11b7ba6f2a3b9bf91a5918de7356e21f786",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
       "945957bbb54d184a07703cf727844f0838810d33dd385b068934b571252934e6",
     "plugins/src/base/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs":
-      "4887a65b7589a47c7da3b5ed04907bfcb9773289c0dd3597c69a35ba239f14d9",
+      "563ab35320a0ba58269ac3dd81155ffe3a299f6835210073e6fc9012ab436f41",
     "plugins/src/base/skills/lisa-secrets-access/scripts/tools-from-notes.mjs":
       "360f740cac081151491428043b04fec2f5db6f3ba36394f7378af312396d53ca",
     "plugins/src/base/skills/lisa-secrets-access/scripts/validate-config.mjs":
-      "b521aa3e3e4049d2c40f81382c28b8d81ecad9221d147d3be8c94a444ae518a5",
+      "85c5ec348e0f38128f44f3207fcbc047952ae88f48adf81b7879c24b1a66cbf0",
     "plugins/src/base/skills/lisa-security-review/SKILL.md":
       "5a980eaf5efc4fcce66e75521ec5b1eda143a5b0d36e7157234a705dac94e3f5",
     "plugins/src/base/skills/lisa-security-zap-scan/SKILL.md":
@@ -1293,7 +1293,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-automations/SKILL.md":
       "4bf86639bca29641686fd124d7d4b6c177775063930a309e2c33f808e33d505f",
     "plugins/src/base/skills/lisa-setup-automations/scripts/generate-workflow.mjs":
-      "f639c3f174378f0068b9c9d56e59b356c6da988730a1390c61e4348b4a4073ac",
+      "c13e287c8beb6f847b03c93298b8a3fb211e65ce897e63692933377f8c4303f1",
     "plugins/src/base/skills/lisa-setup-confluence/SKILL.md":
       "e92d762dbdaeae671c3e52dfe8e10d40a10b606b5e050589181a3898649faedc",
     "plugins/src/base/skills/lisa-setup-github-repo/SKILL.md":
@@ -1309,7 +1309,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-local-env/SKILL.md":
       "4d4b8c92e3616256f5f689fbe433f09c31d39c623508bc4ec0d8c1770caddf22",
     "plugins/src/base/skills/lisa-setup-local-env/scripts/local-env.mjs":
-      "bff68aa66d6d4cd7cb9d0e39be691c6daa232edb097f8a601815432a32cca6a6",
+      "6f3713451139d9d4fd8eed8f11f49e472667394c4f9a7cae63897b7702115687",
     "plugins/src/base/skills/lisa-setup-notion/SKILL.md":
       "a00121623871aa7578281779214d2a8ed871c7dfba19937f80374e76d6aa2b7f",
     "plugins/src/base/skills/lisa-setup-remote-aws/SKILL.md":
@@ -1325,13 +1325,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/preflight-tools.mjs":
       "eb8ee672fbfdb0ab41dde5f17337dae59912f18eafa6f15a05fd203906d16352",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/setup-remote-env.mjs":
-      "b4b831f8900360bbb36922edcddaef6bbe4b3730cb21cf0a365d76b914bcbe4e",
+      "c34250b56a158f3876a4134b92210b2b7ed1f26261901840928ef9fa3ce87789",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/tool-floor.mjs":
       "8bf279a2b198c7a6d4163420ec73f871fb9c9cb70d7c87d852026bc5dbf97091",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/toolchain.mjs":
       "496de5aed034692fee421dc3a1fbad9f85ed9e1d0c83a1080f781a486d0274e6",
     "plugins/src/base/skills/lisa-setup-remote-env/scripts/verify-remote-env.mjs":
-      "362ff4a8196cbdcac3633e7d41437b0e8f966eb628924c8dba64646dd1e671c1",
+      "97f83b16a0ee5fc84c3b793afce24602b9fd0f67ae89501f424eae804eaead12",
     "plugins/src/base/skills/lisa-setup-sonar/SKILL.md":
       "b18e07ae942f75aad5730c0535840ef5f7115072f1b6cc62afac83196b28d6a3",
     "plugins/src/base/skills/lisa-setup-workstation/SKILL.md":
@@ -2143,13 +2143,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/fix-test-assertions.mjs":
       "59b5e8cc31e7c7323d20bd180f2ae97c08a9685758483b6fe00ba77317a845f2",
     "scripts/generate-agy-plugin-artifacts.mjs":
-      "61aef7c20d92839a394f459f3012eb0b4e73d93ff56fa512b0244c68d96c72b4",
+      "55328577509da3bb47c5a775ecbac6063a94b4ba52adf71d3de9322600a336c3",
     "scripts/generate-codex-plugin-artifacts.mjs":
       "1d1a362afb8dba408741a3eed9fe583296f6bcb048608979f73f359cd609c03d",
     "scripts/generate-copilot-plugin-artifacts.mjs":
-      "70d283eed7cb7c1351d13cf0497f06dec175562c5918921c404393a76f11278f",
+      "2e5ce9a9f7390149bd3c24374960a51bda35afd1332cd2ad82a34bc0d50b8f50",
     "scripts/generate-cursor-plugin-artifacts.mjs":
-      "d8806197a723f0c2b50a8155ffc5b6f0abc30c68dc2385cb80b0dd066d061231",
+      "19cadeae80428a932d9f7a6d36eba4f14e95761ede26ab773ca26bfbeaa9252e",
     "scripts/generate-lisa-owned-hash-ledger.mjs":
       "4e7a6dd9325fff77faec49c1dcbf8a8cfeb987052eeed89885deb4f7b0a107bc",
     "scripts/generate-upstream-evidence-manifest.mjs":
@@ -2307,7 +2307,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/scripts/check-nightly-e2e-health.mjs":
       "5f47f02563671a25ad14dc69210f1f52e9141e0e53a27bafce52d41899aa9d21",
     "typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs":
-      "5af5f112ba258c4874a65c72c8bed12165e75e4df407265eb46ee9c89c4e0e53",
+      "444210c8fbfca1d3e6ae0e180fe95752e10152610ad349ffea377136f4ae8cf7",
     "typescript/copy-overwrite/scripts/check-threshold-ratchet.mjs":
       "6bcf8b88b1d5ade1aa7c7902ba12af1df7b0b13d4e69c49a24f76a92474c93ec",
     "typescript/copy-overwrite/scripts/check-verification-coverage.mjs":

--- a/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
+++ b/typescript/copy-overwrite/scripts/check-skipped-required-checks.mjs
@@ -189,7 +189,7 @@
  */
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
 import { invokedAsScript } from "./lib/invoked-as-script.mjs";
@@ -1241,9 +1241,20 @@ function main(argv) {
   const report = `${lines.join("\n")}\n`;
   process.stdout.write(report);
   if (process.env.GITHUB_STEP_SUMMARY) {
-    import("node:fs").then(({ appendFileSync }) => {
+    // Synchronous, and failure-tolerant, because this is reporting rather than
+    // verdict. The dynamic import returned a promise `main` did not await, so an
+    // unwritable path, a removed directory or a full disk produced an unhandled
+    // rejection — which Node exits non-zero on. A clean run then reported a CI
+    // failure while the printed report said the guard passed, inverting the exit
+    // code this file works hard to make meaningful. Losing a summary line is the
+    // acceptable failure here; losing the verdict is not.
+    try {
       appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
-    });
+    } catch (error) {
+      console.error(
+        `[skipped-required-checks] step summary not written: ${error.message}`
+      );
+    }
   }
   // Refusal is a failure, not a pass: an explicit run must never be mistaken
   // for a clean bill of health. `warn` — which only Lisa's untranscribed seeds


### PR DESCRIPTION
## Where these came from

CodeRabbit raised ten findings against Lisa's shipped files — **inside a
consumer's pull request**, while that project was bumping Lisa. The consumer
correctly routed them here rather than fixing them locally, because editing a
Lisa-managed file makes it `host-modified`, which Lisa then preserves forever:
a local fix would have permanently cut those files off from upstream updates to
satisfy one review.

Three had enough detail to act on. All three are the same family this project
keeps finding — **something reporting success without having done the work**.

## 1. The gate resolver could silently do nothing

`lisa-gates.mjs` decided whether to run by comparing two path strings. That
comparison answers "no" whenever the two sides resolve differently — through a
symlinked checkout, a git worktree, or a `/tmp` path on macOS, all of which this
fleet runs in. The script would then load, run nothing, and exit successfully.

For this file that is the worst possible silence. The quality workflow pipes its
output into a reader that treats empty input as "no gates configured", so
**every gate would fall back to Lisa's built-in tooling with nothing reporting
it.** Measured through a symlink: fixed version prints the gate list, old
version prints nothing.

The same comparison was in three build scripts and fifteen plugin scripts. All
fixed — the ones that can import the shared helper do; the standalone ones carry
a local copy, which is the documented pattern for scripts that ship alone.

**This is the third time today this exact bug has been fixed in a different
file.** It was fixed in the EAS profile guard this morning and left everywhere
else, which is how a defect class survives being found.

## 2. A guard could fail a clean run

`check-skipped-required-checks.mjs` wrote its summary through a promise nothing
waited on. If that write failed — unwritable path, removed directory, full disk
— the process exited non-zero on an unhandled rejection. **A clean run would
report a CI failure while its own printed report said the guard passed**,
inverting the exit code the file works hard to make meaningful. Now written
synchronously, with a failure to write the summary reported and tolerated:
losing a summary line is acceptable, losing the verdict is not.

## 3. A malformed inventory read as an empty one

`check-state-classification.mjs` proved only that its inventory file parsed as
JSON, then read a property off it. A `null` inventory crashed with a stack trace
instead of reporting invalid; an array or a wrong-shaped object silently yielded
**zero entities**, so every declared entity read as unconfirmed and the gate
passed on an inventory it could not actually read. It now reports `invalid` —
an inventory that cannot be read is not an empty inventory.

## Done when

- [x] No shipped script decides whether to run by comparing path strings
- [x] The step-summary write cannot turn a passing run into a failing one
- [x] A wrong-shaped inventory is reported invalid rather than treated as empty

Work-Item: CodySwannGT/lisa#2626
