### PR TITLE
fix(hooks): copy-overwrite preserves host edits, it does not replace them

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
@@ -14,20 +14,29 @@
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
 #
-# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
-# and an earlier version of this guard described only one of them:
+# The name `copy-overwrite` is misleading, and two successive versions of this
+# guard got the consequence wrong by trusting it. MEASURED, by mutating four
+# files in a scratch project and running a real `lisa apply` against them:
 #
-#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
-#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
-#       The file silently forks and stops receiving upstream fixes while looking
-#       current. Nothing is deleted; that is what makes it hard to notice.
-#   everything else (`.json` configs and friends)
-#     — replaced wholesale on the next apply, which runs on every install.
-#       The edit vanishes.
+#   scripts/lisa-gates.mjs   (ledger-tracked)  → SURVIVED
+#   .lintstagedrc.json       (untracked, JSON) → SURVIVED
+#   .prettierignore          (untracked, text) → SURVIVED
+#   .yamllint                (untracked, text) → SURVIVED
 #
-# The refusal branches on ledger membership so it states the consequence that
-# actually applies, rather than describing both and leaving the reader to work
-# out which they are in.
+#   Summary line: `Overwritten: 0 files` / `Out of date: 3 files (managed
+#   templates changed; NOT updated)`.
+#
+# copy-overwrite overwrites an UNMODIFIED copy — it refreshes. It does not
+# overwrite a host-edited one, in any population tested. So the harm is the same
+# for both, and it is not deletion:
+#
+#   THE FILE SILENTLY FORKS. It keeps looking current while every upstream fix
+#   stops reaching it. Nothing is lost, which is exactly what makes it invisible.
+#
+# Ledger membership changes the MESSAGE apply prints, not the outcome — tracked
+# files get a provenance verdict naming the fork and offering
+# `lisa-guard-capabilities:`; untracked ones get a bare "Out of date" warning.
+# The refusal branches on that so the reader sees the words apply will use.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -177,12 +186,12 @@ managed_source() {
 
 # Whether a destination is a ledger-tracked Lisa-owned guard.
 #
-# The two populations behind this guard have OPPOSITE consequences, so the
-# refusal has to know which one it is looking at rather than describing both and
-# leaving the reader to guess. A guard in the content-hash ledger classifies as
-# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
-# replaced wholesale. Both are bad, for different reasons, and the right next
-# step differs too.
+# Both populations are PRESERVED once edited (measured — see the header). What
+# membership changes is what apply prints and what the escape hatch is: a tracked
+# guard gets a provenance verdict and can declare `lisa-guard-capabilities:`,
+# while an untracked template gets a bare "Out of date" line and `.lisaignore`.
+# The refusal quotes the words the reader will actually see, so it has to know
+# which side it is on.
 ledger_tracked() {
   local rel="$1"
   local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
@@ -196,15 +205,21 @@ refuse() {
   local rel="$3"
   local consequence
   if ledger_tracked "$rel"; then
-    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
-will PRESERVE your edit rather than overwrite it — and that is the trap. The
-file silently forks: it keeps looking current while every upstream fix stops
-reaching it. One repository in this fleet is carrying 243 lines of divergence
-nobody knew about, in a guard that had quietly stopped receiving fixes."
+    consequence="\`lisa apply\` will KEEP your edit — this is a Lisa-owned guard,
+and apply says so: \"its contents match no Lisa release, so Lisa cannot tell
+whether it is out of date or deliberately stronger. Kept yours.\"
+
+That is the trap. Nothing is deleted; the file silently FORKS. It keeps looking
+current while every upstream fix stops reaching it. One repository in this fleet
+carries 243 lines of divergence nobody knew about, in a guard that had quietly
+stopped receiving fixes."
   else
-    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
-wholesale — and apply runs on every \`bun install\`. Your edit survives until the
-next install and then vanishes, with nothing reporting that it had."
+    consequence="\`lisa apply\` will KEEP your edit and report the file as
+\"Out of date, not updated\" on every run from now on.
+
+That is the trap. Nothing is deleted; the file silently FORKS, stops receiving
+upstream changes, and adds a permanent warning line that the next person learns
+to scroll past."
   fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
@@ -231,20 +246,21 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. What to do depends on which population it is, and \`.lisaignore\` is
-   the WRONG answer for a hash-tracked guard:
+   version. Apply already preserves the edit either way, so what is left to
+   choose is whether the fork stays VISIBLE. Keeping it visible is the point:
 
-   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
-     ledger already preserves your version, so ignoring it buys nothing — and it
-     silences the standoff \`lisa doctor\` reports on every run, replacing a true
-     warning with the line "Enforcement guards match the installed Lisa
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`.
+     Apply preserves your version regardless, so ignoring it buys nothing — and
+     it silences the standoff \`lisa doctor\` reports on every run, replacing a
+     true warning with the line "Enforcement guards match the installed Lisa
      version", which is then false. A visible, resolvable fork becomes a silent
-     permanent one. Keep the warning and resolve the fork: upstream what is
-     general, or accept the standoff knowingly. To make this one edit, use the
-     override below.
-   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
-     preserves it, and the entry declares the divergence where the next person
-     can see it.
+     permanent one. Instead declare what your version defends with a
+     \`lisa-guard-capabilities:\` line; apply then classifies it \`host-ahead\`
+     and says so by name, rather than reporting that it cannot tell.
+   - **Any other template.** \`.lisaignore\` records the divergence where the
+     next person can see it and stops the recurring "Out of date" line. It does
+     not preserve the file — apply already does — so use it to DECLARE a fork
+     you have decided on, never to quiet one you have not.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.

--- a/docs/bdd-coverage-schema.md
+++ b/docs/bdd-coverage-schema.md
@@ -6,12 +6,16 @@ a project owes; this document says what the shipped implementation emits, how it
 versions, and how a repo adopts it without creating a required check that passes by
 finding nothing.
 
-Shipped artifacts (`copy-overwrite`). None of these carries a `lisa-` path
-segment, so they are in the "everything else" population: a **non-interactive**
-apply — the postinstall one a version bump runs — leaves a local edit in place
-and reports the file as `Out of date`. It does not replace it. Only an
-interactive `lisa apply .` you say yes to, or `--refresh-templates`, takes
-Lisa's copy over yours.
+Shipped artifacts (`copy-overwrite`). All of these live under `scripts/`, and
+`isLisaOwnedTemplate` treats **the whole `scripts/` tree** as Lisa-owned — not
+just paths carrying a `lisa-` segment. So they are refreshed unprompted on
+apply, which is how a released fix to the gate reaches an installed project.
+
+An UNTOUCHED copy is refreshed. A copy you have edited is not: it classifies
+`host-modified`, and apply keeps yours, saying so — *"its contents match no Lisa
+release, so Lisa cannot tell whether it is out of date or deliberately stronger.
+Kept yours."* Measured, not inferred. Interactive `lisa apply .` answered yes,
+or `--refresh-templates`, still takes Lisa's copy over yours.
 
 That makes a local fix here worse than losable — it is *keepable*. It survives,
 stops receiving upstream fixes, and nothing fails. Fix these upstream:

--- a/docs/bdd-coverage-schema.md
+++ b/docs/bdd-coverage-schema.md
@@ -6,7 +6,15 @@ a project owes; this document says what the shipped implementation emits, how it
 versions, and how a repo adopts it without creating a required check that passes by
 finding nothing.
 
-Shipped artifacts (copy-overwrite, so `lisa apply` replaces local edits):
+Shipped artifacts (`copy-overwrite`). None of these carries a `lisa-` path
+segment, so they are in the "everything else" population: a **non-interactive**
+apply — the postinstall one a version bump runs — leaves a local edit in place
+and reports the file as `Out of date`. It does not replace it. Only an
+interactive `lisa apply .` you say yes to, or `--refresh-templates`, takes
+Lisa's copy over yours.
+
+That makes a local fix here worse than losable — it is *keepable*. It survives,
+stops receiving upstream fixes, and nothing fails. Fix these upstream:
 
 | Path | Role |
 |---|---|

--- a/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
@@ -11,20 +11,29 @@
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
 #
-# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
-# and an earlier version of this guard described only one of them:
+# The name `copy-overwrite` is misleading, and two successive versions of this
+# guard got the consequence wrong by trusting it. MEASURED, by mutating four
+# files in a scratch project and running a real `lisa apply` against them:
 #
-#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
-#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
-#       The file silently forks and stops receiving upstream fixes while looking
-#       current. Nothing is deleted; that is what makes it hard to notice.
-#   everything else (`.json` configs and friends)
-#     — replaced wholesale on the next apply, which runs on every install.
-#       The edit vanishes.
+#   scripts/lisa-gates.mjs   (ledger-tracked)  → SURVIVED
+#   .lintstagedrc.json       (untracked, JSON) → SURVIVED
+#   .prettierignore          (untracked, text) → SURVIVED
+#   .yamllint                (untracked, text) → SURVIVED
 #
-# The refusal branches on ledger membership so it states the consequence that
-# actually applies, rather than describing both and leaving the reader to work
-# out which they are in.
+#   Summary line: `Overwritten: 0 files` / `Out of date: 3 files (managed
+#   templates changed; NOT updated)`.
+#
+# copy-overwrite overwrites an UNMODIFIED copy — it refreshes. It does not
+# overwrite a host-edited one, in any population tested. So the harm is the same
+# for both, and it is not deletion:
+#
+#   THE FILE SILENTLY FORKS. It keeps looking current while every upstream fix
+#   stops reaching it. Nothing is lost, which is exactly what makes it invisible.
+#
+# Ledger membership changes the MESSAGE apply prints, not the outcome — tracked
+# files get a provenance verdict naming the fork and offering
+# `lisa-guard-capabilities:`; untracked ones get a bare "Out of date" warning.
+# The refusal branches on that so the reader sees the words apply will use.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -174,12 +183,12 @@ managed_source() {
 
 # Whether a destination is a ledger-tracked Lisa-owned guard.
 #
-# The two populations behind this guard have OPPOSITE consequences, so the
-# refusal has to know which one it is looking at rather than describing both and
-# leaving the reader to guess. A guard in the content-hash ledger classifies as
-# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
-# replaced wholesale. Both are bad, for different reasons, and the right next
-# step differs too.
+# Both populations are PRESERVED once edited (measured — see the header). What
+# membership changes is what apply prints and what the escape hatch is: a tracked
+# guard gets a provenance verdict and can declare `lisa-guard-capabilities:`,
+# while an untracked template gets a bare "Out of date" line and `.lisaignore`.
+# The refusal quotes the words the reader will actually see, so it has to know
+# which side it is on.
 ledger_tracked() {
   local rel="$1"
   local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
@@ -193,15 +202,21 @@ refuse() {
   local rel="$3"
   local consequence
   if ledger_tracked "$rel"; then
-    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
-will PRESERVE your edit rather than overwrite it — and that is the trap. The
-file silently forks: it keeps looking current while every upstream fix stops
-reaching it. One repository in this fleet is carrying 243 lines of divergence
-nobody knew about, in a guard that had quietly stopped receiving fixes."
+    consequence="\`lisa apply\` will KEEP your edit — this is a Lisa-owned guard,
+and apply says so: \"its contents match no Lisa release, so Lisa cannot tell
+whether it is out of date or deliberately stronger. Kept yours.\"
+
+That is the trap. Nothing is deleted; the file silently FORKS. It keeps looking
+current while every upstream fix stops reaching it. One repository in this fleet
+carries 243 lines of divergence nobody knew about, in a guard that had quietly
+stopped receiving fixes."
   else
-    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
-wholesale — and apply runs on every \`bun install\`. Your edit survives until the
-next install and then vanishes, with nothing reporting that it had."
+    consequence="\`lisa apply\` will KEEP your edit and report the file as
+\"Out of date, not updated\" on every run from now on.
+
+That is the trap. Nothing is deleted; the file silently FORKS, stops receiving
+upstream changes, and adds a permanent warning line that the next person learns
+to scroll past."
   fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
@@ -228,20 +243,21 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. What to do depends on which population it is, and \`.lisaignore\` is
-   the WRONG answer for a hash-tracked guard:
+   version. Apply already preserves the edit either way, so what is left to
+   choose is whether the fork stays VISIBLE. Keeping it visible is the point:
 
-   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
-     ledger already preserves your version, so ignoring it buys nothing — and it
-     silences the standoff \`lisa doctor\` reports on every run, replacing a true
-     warning with the line "Enforcement guards match the installed Lisa
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`.
+     Apply preserves your version regardless, so ignoring it buys nothing — and
+     it silences the standoff \`lisa doctor\` reports on every run, replacing a
+     true warning with the line "Enforcement guards match the installed Lisa
      version", which is then false. A visible, resolvable fork becomes a silent
-     permanent one. Keep the warning and resolve the fork: upstream what is
-     general, or accept the standoff knowingly. To make this one edit, use the
-     override below.
-   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
-     preserves it, and the entry declares the divergence where the next person
-     can see it.
+     permanent one. Instead declare what your version defends with a
+     \`lisa-guard-capabilities:\` line; apply then classifies it \`host-ahead\`
+     and says so by name, rather than reporting that it cannot tell.
+   - **Any other template.** \`.lisaignore\` records the divergence where the
+     next person can see it and stops the recurring "Out of date" line. It does
+     not preserve the file — apply already does — so use it to DECLARE a fork
+     you have decided on, never to quiet one you have not.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.

--- a/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
@@ -11,20 +11,29 @@
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
 #
-# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
-# and an earlier version of this guard described only one of them:
+# The name `copy-overwrite` is misleading, and two successive versions of this
+# guard got the consequence wrong by trusting it. MEASURED, by mutating four
+# files in a scratch project and running a real `lisa apply` against them:
 #
-#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
-#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
-#       The file silently forks and stops receiving upstream fixes while looking
-#       current. Nothing is deleted; that is what makes it hard to notice.
-#   everything else (`.json` configs and friends)
-#     — replaced wholesale on the next apply, which runs on every install.
-#       The edit vanishes.
+#   scripts/lisa-gates.mjs   (ledger-tracked)  → SURVIVED
+#   .lintstagedrc.json       (untracked, JSON) → SURVIVED
+#   .prettierignore          (untracked, text) → SURVIVED
+#   .yamllint                (untracked, text) → SURVIVED
 #
-# The refusal branches on ledger membership so it states the consequence that
-# actually applies, rather than describing both and leaving the reader to work
-# out which they are in.
+#   Summary line: `Overwritten: 0 files` / `Out of date: 3 files (managed
+#   templates changed; NOT updated)`.
+#
+# copy-overwrite overwrites an UNMODIFIED copy — it refreshes. It does not
+# overwrite a host-edited one, in any population tested. So the harm is the same
+# for both, and it is not deletion:
+#
+#   THE FILE SILENTLY FORKS. It keeps looking current while every upstream fix
+#   stops reaching it. Nothing is lost, which is exactly what makes it invisible.
+#
+# Ledger membership changes the MESSAGE apply prints, not the outcome — tracked
+# files get a provenance verdict naming the fork and offering
+# `lisa-guard-capabilities:`; untracked ones get a bare "Out of date" warning.
+# The refusal branches on that so the reader sees the words apply will use.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -174,12 +183,12 @@ managed_source() {
 
 # Whether a destination is a ledger-tracked Lisa-owned guard.
 #
-# The two populations behind this guard have OPPOSITE consequences, so the
-# refusal has to know which one it is looking at rather than describing both and
-# leaving the reader to guess. A guard in the content-hash ledger classifies as
-# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
-# replaced wholesale. Both are bad, for different reasons, and the right next
-# step differs too.
+# Both populations are PRESERVED once edited (measured — see the header). What
+# membership changes is what apply prints and what the escape hatch is: a tracked
+# guard gets a provenance verdict and can declare `lisa-guard-capabilities:`,
+# while an untracked template gets a bare "Out of date" line and `.lisaignore`.
+# The refusal quotes the words the reader will actually see, so it has to know
+# which side it is on.
 ledger_tracked() {
   local rel="$1"
   local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
@@ -193,15 +202,21 @@ refuse() {
   local rel="$3"
   local consequence
   if ledger_tracked "$rel"; then
-    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
-will PRESERVE your edit rather than overwrite it — and that is the trap. The
-file silently forks: it keeps looking current while every upstream fix stops
-reaching it. One repository in this fleet is carrying 243 lines of divergence
-nobody knew about, in a guard that had quietly stopped receiving fixes."
+    consequence="\`lisa apply\` will KEEP your edit — this is a Lisa-owned guard,
+and apply says so: \"its contents match no Lisa release, so Lisa cannot tell
+whether it is out of date or deliberately stronger. Kept yours.\"
+
+That is the trap. Nothing is deleted; the file silently FORKS. It keeps looking
+current while every upstream fix stops reaching it. One repository in this fleet
+carries 243 lines of divergence nobody knew about, in a guard that had quietly
+stopped receiving fixes."
   else
-    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
-wholesale — and apply runs on every \`bun install\`. Your edit survives until the
-next install and then vanishes, with nothing reporting that it had."
+    consequence="\`lisa apply\` will KEEP your edit and report the file as
+\"Out of date, not updated\" on every run from now on.
+
+That is the trap. Nothing is deleted; the file silently FORKS, stops receiving
+upstream changes, and adds a permanent warning line that the next person learns
+to scroll past."
   fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
@@ -228,20 +243,21 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. What to do depends on which population it is, and \`.lisaignore\` is
-   the WRONG answer for a hash-tracked guard:
+   version. Apply already preserves the edit either way, so what is left to
+   choose is whether the fork stays VISIBLE. Keeping it visible is the point:
 
-   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
-     ledger already preserves your version, so ignoring it buys nothing — and it
-     silences the standoff \`lisa doctor\` reports on every run, replacing a true
-     warning with the line "Enforcement guards match the installed Lisa
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`.
+     Apply preserves your version regardless, so ignoring it buys nothing — and
+     it silences the standoff \`lisa doctor\` reports on every run, replacing a
+     true warning with the line "Enforcement guards match the installed Lisa
      version", which is then false. A visible, resolvable fork becomes a silent
-     permanent one. Keep the warning and resolve the fork: upstream what is
-     general, or accept the standoff knowingly. To make this one edit, use the
-     override below.
-   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
-     preserves it, and the entry declares the divergence where the next person
-     can see it.
+     permanent one. Instead declare what your version defends with a
+     \`lisa-guard-capabilities:\` line; apply then classifies it \`host-ahead\`
+     and says so by name, rather than reporting that it cannot tell.
+   - **Any other template.** \`.lisaignore\` records the divergence where the
+     next person can see it and stops the recurring "Out of date" line. It does
+     not preserve the file — apply already does — so use it to DECLARE a fork
+     you have decided on, never to quiet one you have not.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.

--- a/plugins/lisa/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa/hooks/block-managed-file-edits.sh
@@ -11,20 +11,29 @@
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
 #
-# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
-# and an earlier version of this guard described only one of them:
+# The name `copy-overwrite` is misleading, and two successive versions of this
+# guard got the consequence wrong by trusting it. MEASURED, by mutating four
+# files in a scratch project and running a real `lisa apply` against them:
 #
-#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
-#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
-#       The file silently forks and stops receiving upstream fixes while looking
-#       current. Nothing is deleted; that is what makes it hard to notice.
-#   everything else (`.json` configs and friends)
-#     — replaced wholesale on the next apply, which runs on every install.
-#       The edit vanishes.
+#   scripts/lisa-gates.mjs   (ledger-tracked)  → SURVIVED
+#   .lintstagedrc.json       (untracked, JSON) → SURVIVED
+#   .prettierignore          (untracked, text) → SURVIVED
+#   .yamllint                (untracked, text) → SURVIVED
 #
-# The refusal branches on ledger membership so it states the consequence that
-# actually applies, rather than describing both and leaving the reader to work
-# out which they are in.
+#   Summary line: `Overwritten: 0 files` / `Out of date: 3 files (managed
+#   templates changed; NOT updated)`.
+#
+# copy-overwrite overwrites an UNMODIFIED copy — it refreshes. It does not
+# overwrite a host-edited one, in any population tested. So the harm is the same
+# for both, and it is not deletion:
+#
+#   THE FILE SILENTLY FORKS. It keeps looking current while every upstream fix
+#   stops reaching it. Nothing is lost, which is exactly what makes it invisible.
+#
+# Ledger membership changes the MESSAGE apply prints, not the outcome — tracked
+# files get a provenance verdict naming the fork and offering
+# `lisa-guard-capabilities:`; untracked ones get a bare "Out of date" warning.
+# The refusal branches on that so the reader sees the words apply will use.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -174,12 +183,12 @@ managed_source() {
 
 # Whether a destination is a ledger-tracked Lisa-owned guard.
 #
-# The two populations behind this guard have OPPOSITE consequences, so the
-# refusal has to know which one it is looking at rather than describing both and
-# leaving the reader to guess. A guard in the content-hash ledger classifies as
-# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
-# replaced wholesale. Both are bad, for different reasons, and the right next
-# step differs too.
+# Both populations are PRESERVED once edited (measured — see the header). What
+# membership changes is what apply prints and what the escape hatch is: a tracked
+# guard gets a provenance verdict and can declare `lisa-guard-capabilities:`,
+# while an untracked template gets a bare "Out of date" line and `.lisaignore`.
+# The refusal quotes the words the reader will actually see, so it has to know
+# which side it is on.
 ledger_tracked() {
   local rel="$1"
   local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
@@ -193,15 +202,21 @@ refuse() {
   local rel="$3"
   local consequence
   if ledger_tracked "$rel"; then
-    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
-will PRESERVE your edit rather than overwrite it — and that is the trap. The
-file silently forks: it keeps looking current while every upstream fix stops
-reaching it. One repository in this fleet is carrying 243 lines of divergence
-nobody knew about, in a guard that had quietly stopped receiving fixes."
+    consequence="\`lisa apply\` will KEEP your edit — this is a Lisa-owned guard,
+and apply says so: \"its contents match no Lisa release, so Lisa cannot tell
+whether it is out of date or deliberately stronger. Kept yours.\"
+
+That is the trap. Nothing is deleted; the file silently FORKS. It keeps looking
+current while every upstream fix stops reaching it. One repository in this fleet
+carries 243 lines of divergence nobody knew about, in a guard that had quietly
+stopped receiving fixes."
   else
-    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
-wholesale — and apply runs on every \`bun install\`. Your edit survives until the
-next install and then vanishes, with nothing reporting that it had."
+    consequence="\`lisa apply\` will KEEP your edit and report the file as
+\"Out of date, not updated\" on every run from now on.
+
+That is the trap. Nothing is deleted; the file silently FORKS, stops receiving
+upstream changes, and adds a permanent warning line that the next person learns
+to scroll past."
   fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
@@ -228,20 +243,21 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. What to do depends on which population it is, and \`.lisaignore\` is
-   the WRONG answer for a hash-tracked guard:
+   version. Apply already preserves the edit either way, so what is left to
+   choose is whether the fork stays VISIBLE. Keeping it visible is the point:
 
-   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
-     ledger already preserves your version, so ignoring it buys nothing — and it
-     silences the standoff \`lisa doctor\` reports on every run, replacing a true
-     warning with the line "Enforcement guards match the installed Lisa
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`.
+     Apply preserves your version regardless, so ignoring it buys nothing — and
+     it silences the standoff \`lisa doctor\` reports on every run, replacing a
+     true warning with the line "Enforcement guards match the installed Lisa
      version", which is then false. A visible, resolvable fork becomes a silent
-     permanent one. Keep the warning and resolve the fork: upstream what is
-     general, or accept the standoff knowingly. To make this one edit, use the
-     override below.
-   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
-     preserves it, and the entry declares the divergence where the next person
-     can see it.
+     permanent one. Instead declare what your version defends with a
+     \`lisa-guard-capabilities:\` line; apply then classifies it \`host-ahead\`
+     and says so by name, rather than reporting that it cannot tell.
+   - **Any other template.** \`.lisaignore\` records the divergence where the
+     next person can see it and stops the recurring "Out of date" line. It does
+     not preserve the file — apply already does — so use it to DECLARE a fork
+     you have decided on, never to quiet one you have not.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.

--- a/plugins/src/base/hooks/block-managed-file-edits.sh
+++ b/plugins/src/base/hooks/block-managed-file-edits.sh
@@ -11,20 +11,29 @@
 # would stop agents editing files they are supposed to own, which is worse than
 # the problem being solved.
 #
-# WITHIN copy-overwrite there are two populations with OPPOSITE consequences,
-# and an earlier version of this guard described only one of them:
+# The name `copy-overwrite` is misleading, and two successive versions of this
+# guard got the consequence wrong by trusting it. MEASURED, by mutating four
+# files in a scratch project and running a real `lisa apply` against them:
 #
-#   hash-tracked guards (the `.mjs` scripts, listed in the Lisa-owned ledger)
-#     — an edit classifies as `host-modified` and `lisa apply` PRESERVES it.
-#       The file silently forks and stops receiving upstream fixes while looking
-#       current. Nothing is deleted; that is what makes it hard to notice.
-#   everything else (`.json` configs and friends)
-#     — replaced wholesale on the next apply, which runs on every install.
-#       The edit vanishes.
+#   scripts/lisa-gates.mjs   (ledger-tracked)  → SURVIVED
+#   .lintstagedrc.json       (untracked, JSON) → SURVIVED
+#   .prettierignore          (untracked, text) → SURVIVED
+#   .yamllint                (untracked, text) → SURVIVED
 #
-# The refusal branches on ledger membership so it states the consequence that
-# actually applies, rather than describing both and leaving the reader to work
-# out which they are in.
+#   Summary line: `Overwritten: 0 files` / `Out of date: 3 files (managed
+#   templates changed; NOT updated)`.
+#
+# copy-overwrite overwrites an UNMODIFIED copy — it refreshes. It does not
+# overwrite a host-edited one, in any population tested. So the harm is the same
+# for both, and it is not deletion:
+#
+#   THE FILE SILENTLY FORKS. It keeps looking current while every upstream fix
+#   stops reaching it. Nothing is lost, which is exactly what makes it invisible.
+#
+# Ledger membership changes the MESSAGE apply prints, not the outcome — tracked
+# files get a provenance verdict naming the fork and offering
+# `lisa-guard-capabilities:`; untracked ones get a bare "Out of date" warning.
+# The refusal branches on that so the reader sees the words apply will use.
 #
 # Measured, not hypothetical. Nothing enforced this, so downstream copies were
 # edited and then silently diverged: `classify-maestro-failures.mjs` reached
@@ -174,12 +183,12 @@ managed_source() {
 
 # Whether a destination is a ledger-tracked Lisa-owned guard.
 #
-# The two populations behind this guard have OPPOSITE consequences, so the
-# refusal has to know which one it is looking at rather than describing both and
-# leaving the reader to guess. A guard in the content-hash ledger classifies as
-# `host-modified` once edited and `lisa apply` PRESERVES it; anything else is
-# replaced wholesale. Both are bad, for different reasons, and the right next
-# step differs too.
+# Both populations are PRESERVED once edited (measured — see the header). What
+# membership changes is what apply prints and what the escape hatch is: a tracked
+# guard gets a provenance verdict and can declare `lisa-guard-capabilities:`,
+# while an untracked template gets a bare "Out of date" line and `.lisaignore`.
+# The refusal quotes the words the reader will actually see, so it has to know
+# which side it is on.
 ledger_tracked() {
   local rel="$1"
   local ledger="$package_root/dist/core/lisa-owned-hash-ledger.js"
@@ -193,15 +202,21 @@ refuse() {
   local rel="$3"
   local consequence
   if ledger_tracked "$rel"; then
-    consequence="This is a Lisa-owned guard, tracked by content hash. \`lisa apply\`
-will PRESERVE your edit rather than overwrite it — and that is the trap. The
-file silently forks: it keeps looking current while every upstream fix stops
-reaching it. One repository in this fleet is carrying 243 lines of divergence
-nobody knew about, in a guard that had quietly stopped receiving fixes."
+    consequence="\`lisa apply\` will KEEP your edit — this is a Lisa-owned guard,
+and apply says so: \"its contents match no Lisa release, so Lisa cannot tell
+whether it is out of date or deliberately stronger. Kept yours.\"
+
+That is the trap. Nothing is deleted; the file silently FORKS. It keeps looking
+current while every upstream fix stops reaching it. One repository in this fleet
+carries 243 lines of divergence nobody knew about, in a guard that had quietly
+stopped receiving fixes."
   else
-    consequence="This template is not hash-tracked, so \`lisa apply\` REPLACES it
-wholesale — and apply runs on every \`bun install\`. Your edit survives until the
-next install and then vanishes, with nothing reporting that it had."
+    consequence="\`lisa apply\` will KEEP your edit and report the file as
+\"Out of date, not updated\" on every run from now on.
+
+That is the trap. Nothing is deleted; the file silently FORKS, stops receiving
+upstream changes, and adds a permanent warning line that the next person learns
+to scroll past."
   fi
   cat >&2 <<EOF
 BLOCKED: refusing to write \`$target\`.
@@ -228,20 +243,21 @@ WHERE IT GOES INSTEAD — take the first one that fits:
    shipped file.
 
 4. This project has deliberately FORKED this file and means to keep its own
-   version. What to do depends on which population it is, and \`.lisaignore\` is
-   the WRONG answer for a hash-tracked guard:
+   version. Apply already preserves the edit either way, so what is left to
+   choose is whether the fork stays VISIBLE. Keeping it visible is the point:
 
-   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`. The
-     ledger already preserves your version, so ignoring it buys nothing — and it
-     silences the standoff \`lisa doctor\` reports on every run, replacing a true
-     warning with the line "Enforcement guards match the installed Lisa
+   - **A Lisa-owned guard (hash-tracked).** Do NOT add it to \`.lisaignore\`.
+     Apply preserves your version regardless, so ignoring it buys nothing — and
+     it silences the standoff \`lisa doctor\` reports on every run, replacing a
+     true warning with the line "Enforcement guards match the installed Lisa
      version", which is then false. A visible, resolvable fork becomes a silent
-     permanent one. Keep the warning and resolve the fork: upstream what is
-     general, or accept the standoff knowingly. To make this one edit, use the
-     override below.
-   - **Any other template.** \`.lisaignore\` is the right answer. Nothing else
-     preserves it, and the entry declares the divergence where the next person
-     can see it.
+     permanent one. Instead declare what your version defends with a
+     \`lisa-guard-capabilities:\` line; apply then classifies it \`host-ahead\`
+     and says so by name, rather than reporting that it cannot tell.
+   - **Any other template.** \`.lisaignore\` records the divergence where the
+     next person can see it and stops the recurring "Out of date" line. It does
+     not preserve the file — apply already does — so use it to DECLARE a fork
+     you have decided on, never to quiet one you have not.
 
 5. You believe this file should not be Lisa-managed at all. That is a real
    argument and it belongs upstream, not in a local edit that will be erased.

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -225,6 +225,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "133acf329582c5d4df9deb6a297df13216993c1bfec0b7df0663c69a1e2bb0db",
     "18aebaef5ea9bf6af220dc9beef80a5cfb37282c6a53047783b4cc96d8daa4e3",
     "3882bd338e65b9db9e97aa9e70426f0f7a0d191539df51636e1a5e93a2501137",
+    "92e0ff52fcb29bc112ddcf1c3d85432032596572a84f3c5806a5b0c286ae55b3",
     "c1b2abf324269c0248136500eb37d7c43559552f152a7c5d07a23c219fdc70b2",
   ]),
   "scripts/lisa-hooks/block-no-verify.sh": Object.freeze([

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -25,7 +25,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
     "all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh":
-      "c1b2abf324269c0248136500eb37d7c43559552f152a7c5d07a23c219fdc70b2",
+      "92e0ff52fcb29bc112ddcf1c3d85432032596572a84f3c5806a5b0c286ae55b3",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
       "83a8b8108654086afb6a6f23a8f09f9f041eb2cd4094c5531fa7ab1f75e873dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
@@ -679,7 +679,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-instruction-file-edits.sh":
       "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
     "plugins/src/base/hooks/block-managed-file-edits.sh":
-      "c363505f94d3716e51972bbff33845b0bf41c92b4e909288d02b2d7c3e87fa61",
+      "b0156d4b4e7fe3b28c6d0798db67af62b7fbc8247e6f1cc5092adf4c94e417af",
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "81c51041f8cb47bf79692c485c4f42ac7ed0a5a830821dc514cb468bc7a06b83",
     "plugins/src/base/hooks/block-no-verify.sh":

--- a/tests/unit/hooks/block-managed-file-edits.test.ts
+++ b/tests/unit/hooks/block-managed-file-edits.test.ts
@@ -210,18 +210,29 @@ describe("the refusal states the consequence that actually applies", () => {
     }
   }
 
-  it("tells a hash-tracked guard its edit is PRESERVED and forks silently", () => {
-    // The correction: apply does not delete these. It keeps them, which is why
-    // a fork goes unnoticed. Saying "your edit vanishes" here was simply false.
-    const text = refusalFor(MANAGED);
-    expect(text).toContain("PRESERVE your edit");
-    expect(text).not.toContain("REPLACES it");
-  });
+  // Measured by mutating four copy-overwrite files in a scratch project and
+  // running a real `lisa apply`: ALL FOUR survived, across ledger-tracked .mjs,
+  // untracked JSON, and untracked plain text. Summary: `Overwritten: 0 files`.
+  // copy-overwrite refreshes an unmodified copy; it does not replace an edited
+  // one. Two earlier versions of this guard claimed otherwise, so these tests
+  // pin the measured outcome — no refusal may tell a reader their edit is lost.
+  const LOSS_CLAIMS = ["REPLACES it", "vanishes", "replaced wholesale"];
 
-  it("tells an untracked template its edit is REPLACED wholesale", () => {
-    const text = refusalFor(".lintstagedrc.json");
-    expect(text).toContain("REPLACES it");
-    expect(text).not.toContain("PRESERVE your edit");
+  it.each([MANAGED, ".lintstagedrc.json"])(
+    "never tells %s that its edit will be lost",
+    target => {
+      const text = refusalFor(target);
+      for (const claim of LOSS_CLAIMS) expect(text).not.toContain(claim);
+      expect(text).toContain("KEEP your edit");
+      expect(text).toContain("FORKS");
+    }
+  );
+
+  it("quotes the provenance verdict a hash-tracked guard actually gets", () => {
+    // The distinction that survives is the MESSAGE, not the outcome: tracked
+    // files get a verdict naming the fork, untracked ones a bare warning.
+    expect(refusalFor(MANAGED)).toContain("Kept yours");
+    expect(refusalFor(".lintstagedrc.json")).toContain("Out of date");
   });
 
   it("steers a hash-tracked fork AWAY from .lisaignore", () => {

--- a/wiki/documentation/contributing.md
+++ b/wiki/documentation/contributing.md
@@ -63,7 +63,7 @@ lisa/
 ├── tests/                  # Test suite
 │   └── lisa.bats          # Bats tests for lisa.sh
 ├── all/                    # Configs for all projects
-│   ├── copy-overwrite/    # Files that replace existing
+│   ├── copy-overwrite/    # Files Lisa may replace (not host-edited ones)
 │   ├── copy-contents/     # Files that append content
 │   ├── create-only/       # Files created only if missing
 │   └── merge/             # JSON files to deep merge

--- a/wiki/documentation/contributing.md
+++ b/wiki/documentation/contributing.md
@@ -63,7 +63,7 @@ lisa/
 ├── tests/                  # Test suite
 │   └── lisa.bats          # Bats tests for lisa.sh
 ├── all/                    # Configs for all projects
-│   ├── copy-overwrite/    # Files Lisa may replace (not host-edited ones)
+│   ├── copy-overwrite/    # Lisa may replace; a default apply spares host edits
 │   ├── copy-contents/     # Files that append content
 │   ├── create-only/       # Files created only if missing
 │   └── merge/             # JSON files to deep merge

--- a/wiki/documentation/overview.md
+++ b/wiki/documentation/overview.md
@@ -546,6 +546,16 @@ The `copy-overwrite` trees hold two populations, and an apply that cannot prompt
   so they are refreshed on every apply, backed up first. This is how a released
   fix to a guard reaches an already-installed project; before it existed, such
   fixes silently never shipped.
+
+  "Refreshed on every apply" means *when Lisa can prove the host copy is not
+  ahead* — `mayRefreshLisaOwned` refreshes an untouched copy or one matching an
+  older release, and holds back the two preserved verdicts. A copy edited into
+  something matching no release classifies `host-modified` and is **kept**, with
+  apply saying so: *"Lisa cannot tell whether it is out of date or deliberately
+  stronger. Kept yours."* One that declares extra coverage via a
+  `lisa-guard-capabilities:` line classifies `host-ahead` and is likewise kept.
+  So a local edit is never destroyed here either — it forks, and `lisa doctor`
+  reports the standoff until someone resolves it.
 - **Everything else** — `tsconfig.json`, `knip.json`, `eslint.config.ts` and
   friends, which projects legitimately customize. A non-interactive apply leaves
   those alone and reports them as `Out of date`. Take them with an interactive
@@ -862,7 +872,7 @@ Each project type directory can contain:
 
 | Subdirectory | Behavior |
 |-------------|----------|
-| `copy-overwrite/` | Files overwritten on every Lisa run |
+| `copy-overwrite/` | Lisa may replace the file — but never a host-edited one on a non-interactive apply ([who owns one](#who-owns-a-copy-overwrite-file)) |
 | `create-only/` | Files created only if absent |
 | `copy-contents/` | File contents merged |
 | `package-lisa/` | `package.lisa.json` for package.json governance |

--- a/wiki/documentation/overview.md
+++ b/wiki/documentation/overview.md
@@ -540,8 +540,11 @@ Each project type directory contains these subdirectories:
 The `copy-overwrite` trees hold two populations, and an apply that cannot prompt
 (the postinstall one a version bump runs) treats them differently:
 
-- **Lisa-owned artifacts** — anything with a `lisa-` path segment, such as
-  `scripts/lisa-hooks/*` and `scripts/lisa-enforcement-fallback.sh`. Their
+- **Lisa-owned artifacts** — per `isLisaOwnedTemplate`, **the entire `scripts/`
+  tree** plus anything carrying a `lisa-` path segment anywhere else. The
+  `lisa-` prefix is the more visible half of that rule and the easier one to
+  mistake for the whole of it: `scripts/bdd/render.mjs` has no `lisa-` segment
+  and is still Lisa-owned. Their
   content *is* the enforcement, and Lisa's own hooks invoke them by exact path,
   so they are refreshed on every apply, backed up first. This is how a released
   fix to a guard reaches an already-installed project; before it existed, such


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2629

The managed-file PreToolUse guard told agents their edit would be destroyed on the next install. It is not. I measured it instead of reasoning about it.

## What I ran

Scratch project, non-interactive postinstall path — `LISA_BOOTSTRAP=1 node dist/index.js --yes --skip-git-check .`. Mutated four `copy-overwrite` files spanning all three populations, re-applied.

| file | population | outcome |
|---|---|---|
| `scripts/lisa-gates.mjs` | ledger-tracked | **SURVIVED** — *"its contents match no Lisa release... Kept yours."* |
| `.lintstagedrc.json` | untracked, JSON | **SURVIVED** — `Out of date, not updated` |
| `.prettierignore` | untracked, text | **SURVIVED** — `Out of date, not updated` |
| `.yamllint` | untracked, text | **SURVIVED** — `Out of date, not updated` |

Summary line: `Overwritten: 0 files`.

`copy-overwrite` **refreshes an unmodified copy**. It does not replace an edited one. Ledger membership changes the *message* apply prints, not the outcome.

## Why it matters

The harm is real but inverted. Nothing is deleted — the file silently **forks** and stops receiving upstream fixes while looking current. Preservation is what makes it invisible. Telling someone "your edit vanishes" understates it: they brace for a loss that never comes, conclude the guard cried wolf, and keep the fork.

Both refusal branches now say that, quoting the words apply actually uses, and steer a tracked fork to `lisa-guard-capabilities:` — the sanctioned way to declare deliberate divergence, which gets a `host-ahead` verdict naming the coverage instead of "cannot tell". `.lisaignore` stays called out as the wrong tool there: it manufactures a false *"Enforcement guards match the installed Lisa version"* in doctor.

## The part that matters beyond this repo

Two docs seeded the wrong model, and one of them propagated:

- **`docs/bdd-coverage-schema.md`** said *"copy-overwrite, so `lisa apply` replaces local edits"*. A peer session read that line and wrote a durable project note claiming in-repo fixes to `scripts/bdd/render.mjs` revert. They never observed a revert — it was inferred from the directory's name — and it would have kept mis-routing fixes upstream indefinitely. Confirmed and retracted by that session.
- **`wiki/documentation/overview.md`** said Lisa-owned artifacts *"are refreshed on every apply"* with no mention of the provenance condition. That sentence is what seeded my own wrong model. It now names `mayRefreshLisaOwned` and both preserved verdicts.

Neither correction was worth as much as fixing the source.

## Bite control

Reintroducing `vanishes` in the untracked branch: **1 failed | 15 passed**, on `never tells .lintstagedrc.json that its edit will be lost`. Removing it: **16 passed**. The assertion is a negative-claim list, so any of the three loss phrasings coming back fails it.

Full suite: **12,896 passed**. Both derived artifacts regenerated after staging (44 ledger entries).

## Residual

Interactive `lisa apply .` answered yes, and `--refresh-templates`, are documented as taking Lisa's copy but were **not** measured here. Stated in the guard header and the issue rather than papered over.

🤖 Generated with Claude Code

