### PR TITLE
fix(ignore): `!` in .lisaignore un-ignored the whole project

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh
@@ -112,43 +112,61 @@ lisaignored() {
   local rel="$1"
   local list="$project_root/.lisaignore"
   [ -f "$list" ] || return 1
+  # Gitignore precedence: patterns are read in order and the LAST one to select
+  # the path decides, so `!x` re-includes something an earlier line ignored.
+  # This mirrors `matchesAnyPattern` in `src/utils/ignore-patterns.ts`; the two
+  # must agree, or an agent gets blocked on a file apply considers the
+  # project's, or waved through on one it does not.
+  #
+  # `ignored` carries shell truth: 0 = ignored, 1 = not.
+  local ignored=1
   local pattern
   while IFS= read -r pattern || [ -n "$pattern" ]; do
     pattern="${pattern#"${pattern%%[![:space:]]*}"}"
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
-    # A leading `!` is not gitignore negation here. The real matcher passes
-    # patterns to minimatch, which negates by default, and it combines them with
-    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
-    # ignored. Measured:
-    #
-    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
-    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
-    #
-    # Reproducing that faithfully would mean disabling this guard on a typo.
-    # Reproducing the intuitive gitignore reading would mean blocking files the
-    # matcher considers ignored. Both are wrong, so the file is treated as
-    # claimed and the write is allowed — the same direction this function errs
-    # everywhere else. Filed upstream; when the matcher stops negating, delete
-    # this branch rather than teaching it a second wrong answer.
-    case "$pattern" in !*) return 0 ;; esac
+    local negated=1
+    case "$pattern" in
+      # A bare `!` selects nothing rather than everything.
+      !) continue ;;
+      !*)
+        negated=0
+        pattern="${pattern#!}"
+        ;;
+      # `\!x` is a literal leading `!`, not a negation.
+      \\!*) pattern="${pattern#\\}" ;;
+    esac
+    local selected=1
     case "$pattern" in
       */)
-        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") selected=0 ;; esac
         ;;
     esac
-    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
-    case "$rel" in $pattern) return 0 ;; esac
-    case "$pattern" in
-      */*) ;;
-      *)
-        # shellcheck disable=SC2254 -- ditto, matched against the basename.
-        case "${rel##*/}" in $pattern) return 0 ;; esac
-        ;;
-    esac
+    if [ "$selected" -ne 0 ]; then
+      # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+      case "$rel" in $pattern) selected=0 ;; esac
+    fi
+    if [ "$selected" -ne 0 ]; then
+      case "$pattern" in
+        */*) ;;
+        *)
+          # shellcheck disable=SC2254 -- ditto, matched against the basename.
+          case "${rel##*/}" in $pattern) selected=0 ;; esac
+          ;;
+      esac
+    fi
+    [ "$selected" -eq 0 ] || continue
+    # A positive match ignores the path; a negated one un-ignores it. Both
+    # OVERWRITE any earlier verdict rather than short-circuiting — that is what
+    # makes the last matching pattern win.
+    if [ "$negated" -eq 0 ]; then
+      ignored=1
+    else
+      ignored=0
+    fi
   done <"$list"
-  return 1
+  return "$ignored"
 }
 
 # A candidate rewritten relative to the project, so an absolute target from a

--- a/all/create-only/.lisaignore
+++ b/all/create-only/.lisaignore
@@ -5,3 +5,18 @@
 #   - Exact file names: eslint.config.mjs
 #   - Directory patterns: .claude/hooks/
 #   - Glob patterns: *.example.json, **/*.custom.ts
+#   - Negation: !scripts/keep.mjs re-includes a path an earlier line ignored.
+#     Patterns are read in order and the LAST one to match a path wins.
+#
+# What ignoring actually does: `lisa apply` skips the path entirely and reports
+# `Kept (.lisaignore)`. The file becomes yours outright — which also means it
+# stops receiving upstream fixes, permanently and silently. That is the point
+# when you mean it, and a trap when you do not.
+#
+# So ignore a file to DECLARE a fork you have decided on, never to quiet a
+# warning you have not read. In particular, do not ignore a Lisa-owned guard
+# (anything under scripts/, or any path with a `lisa-` segment) to silence
+# `lisa doctor` — apply already preserves your edits to those, so ignoring buys
+# nothing and replaces a true warning with the false line "Enforcement guards
+# match the installed Lisa version". Declare what your version defends with a
+# `lisa-guard-capabilities:` line instead.

--- a/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-copilot/hooks/block-managed-file-edits.sh
@@ -109,43 +109,61 @@ lisaignored() {
   local rel="$1"
   local list="$project_root/.lisaignore"
   [ -f "$list" ] || return 1
+  # Gitignore precedence: patterns are read in order and the LAST one to select
+  # the path decides, so `!x` re-includes something an earlier line ignored.
+  # This mirrors `matchesAnyPattern` in `src/utils/ignore-patterns.ts`; the two
+  # must agree, or an agent gets blocked on a file apply considers the
+  # project's, or waved through on one it does not.
+  #
+  # `ignored` carries shell truth: 0 = ignored, 1 = not.
+  local ignored=1
   local pattern
   while IFS= read -r pattern || [ -n "$pattern" ]; do
     pattern="${pattern#"${pattern%%[![:space:]]*}"}"
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
-    # A leading `!` is not gitignore negation here. The real matcher passes
-    # patterns to minimatch, which negates by default, and it combines them with
-    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
-    # ignored. Measured:
-    #
-    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
-    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
-    #
-    # Reproducing that faithfully would mean disabling this guard on a typo.
-    # Reproducing the intuitive gitignore reading would mean blocking files the
-    # matcher considers ignored. Both are wrong, so the file is treated as
-    # claimed and the write is allowed — the same direction this function errs
-    # everywhere else. Filed upstream; when the matcher stops negating, delete
-    # this branch rather than teaching it a second wrong answer.
-    case "$pattern" in !*) return 0 ;; esac
+    local negated=1
+    case "$pattern" in
+      # A bare `!` selects nothing rather than everything.
+      !) continue ;;
+      !*)
+        negated=0
+        pattern="${pattern#!}"
+        ;;
+      # `\!x` is a literal leading `!`, not a negation.
+      \\!*) pattern="${pattern#\\}" ;;
+    esac
+    local selected=1
     case "$pattern" in
       */)
-        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") selected=0 ;; esac
         ;;
     esac
-    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
-    case "$rel" in $pattern) return 0 ;; esac
-    case "$pattern" in
-      */*) ;;
-      *)
-        # shellcheck disable=SC2254 -- ditto, matched against the basename.
-        case "${rel##*/}" in $pattern) return 0 ;; esac
-        ;;
-    esac
+    if [ "$selected" -ne 0 ]; then
+      # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+      case "$rel" in $pattern) selected=0 ;; esac
+    fi
+    if [ "$selected" -ne 0 ]; then
+      case "$pattern" in
+        */*) ;;
+        *)
+          # shellcheck disable=SC2254 -- ditto, matched against the basename.
+          case "${rel##*/}" in $pattern) selected=0 ;; esac
+          ;;
+      esac
+    fi
+    [ "$selected" -eq 0 ] || continue
+    # A positive match ignores the path; a negated one un-ignores it. Both
+    # OVERWRITE any earlier verdict rather than short-circuiting — that is what
+    # makes the last matching pattern win.
+    if [ "$negated" -eq 0 ]; then
+      ignored=1
+    else
+      ignored=0
+    fi
   done <"$list"
-  return 1
+  return "$ignored"
 }
 
 # A candidate rewritten relative to the project, so an absolute target from a

--- a/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa-cursor/hooks/block-managed-file-edits.sh
@@ -109,43 +109,61 @@ lisaignored() {
   local rel="$1"
   local list="$project_root/.lisaignore"
   [ -f "$list" ] || return 1
+  # Gitignore precedence: patterns are read in order and the LAST one to select
+  # the path decides, so `!x` re-includes something an earlier line ignored.
+  # This mirrors `matchesAnyPattern` in `src/utils/ignore-patterns.ts`; the two
+  # must agree, or an agent gets blocked on a file apply considers the
+  # project's, or waved through on one it does not.
+  #
+  # `ignored` carries shell truth: 0 = ignored, 1 = not.
+  local ignored=1
   local pattern
   while IFS= read -r pattern || [ -n "$pattern" ]; do
     pattern="${pattern#"${pattern%%[![:space:]]*}"}"
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
-    # A leading `!` is not gitignore negation here. The real matcher passes
-    # patterns to minimatch, which negates by default, and it combines them with
-    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
-    # ignored. Measured:
-    #
-    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
-    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
-    #
-    # Reproducing that faithfully would mean disabling this guard on a typo.
-    # Reproducing the intuitive gitignore reading would mean blocking files the
-    # matcher considers ignored. Both are wrong, so the file is treated as
-    # claimed and the write is allowed — the same direction this function errs
-    # everywhere else. Filed upstream; when the matcher stops negating, delete
-    # this branch rather than teaching it a second wrong answer.
-    case "$pattern" in !*) return 0 ;; esac
+    local negated=1
+    case "$pattern" in
+      # A bare `!` selects nothing rather than everything.
+      !) continue ;;
+      !*)
+        negated=0
+        pattern="${pattern#!}"
+        ;;
+      # `\!x` is a literal leading `!`, not a negation.
+      \\!*) pattern="${pattern#\\}" ;;
+    esac
+    local selected=1
     case "$pattern" in
       */)
-        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") selected=0 ;; esac
         ;;
     esac
-    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
-    case "$rel" in $pattern) return 0 ;; esac
-    case "$pattern" in
-      */*) ;;
-      *)
-        # shellcheck disable=SC2254 -- ditto, matched against the basename.
-        case "${rel##*/}" in $pattern) return 0 ;; esac
-        ;;
-    esac
+    if [ "$selected" -ne 0 ]; then
+      # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+      case "$rel" in $pattern) selected=0 ;; esac
+    fi
+    if [ "$selected" -ne 0 ]; then
+      case "$pattern" in
+        */*) ;;
+        *)
+          # shellcheck disable=SC2254 -- ditto, matched against the basename.
+          case "${rel##*/}" in $pattern) selected=0 ;; esac
+          ;;
+      esac
+    fi
+    [ "$selected" -eq 0 ] || continue
+    # A positive match ignores the path; a negated one un-ignores it. Both
+    # OVERWRITE any earlier verdict rather than short-circuiting — that is what
+    # makes the last matching pattern win.
+    if [ "$negated" -eq 0 ]; then
+      ignored=1
+    else
+      ignored=0
+    fi
   done <"$list"
-  return 1
+  return "$ignored"
 }
 
 # A candidate rewritten relative to the project, so an absolute target from a

--- a/plugins/lisa/hooks/block-managed-file-edits.sh
+++ b/plugins/lisa/hooks/block-managed-file-edits.sh
@@ -109,43 +109,61 @@ lisaignored() {
   local rel="$1"
   local list="$project_root/.lisaignore"
   [ -f "$list" ] || return 1
+  # Gitignore precedence: patterns are read in order and the LAST one to select
+  # the path decides, so `!x` re-includes something an earlier line ignored.
+  # This mirrors `matchesAnyPattern` in `src/utils/ignore-patterns.ts`; the two
+  # must agree, or an agent gets blocked on a file apply considers the
+  # project's, or waved through on one it does not.
+  #
+  # `ignored` carries shell truth: 0 = ignored, 1 = not.
+  local ignored=1
   local pattern
   while IFS= read -r pattern || [ -n "$pattern" ]; do
     pattern="${pattern#"${pattern%%[![:space:]]*}"}"
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
-    # A leading `!` is not gitignore negation here. The real matcher passes
-    # patterns to minimatch, which negates by default, and it combines them with
-    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
-    # ignored. Measured:
-    #
-    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
-    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
-    #
-    # Reproducing that faithfully would mean disabling this guard on a typo.
-    # Reproducing the intuitive gitignore reading would mean blocking files the
-    # matcher considers ignored. Both are wrong, so the file is treated as
-    # claimed and the write is allowed — the same direction this function errs
-    # everywhere else. Filed upstream; when the matcher stops negating, delete
-    # this branch rather than teaching it a second wrong answer.
-    case "$pattern" in !*) return 0 ;; esac
+    local negated=1
+    case "$pattern" in
+      # A bare `!` selects nothing rather than everything.
+      !) continue ;;
+      !*)
+        negated=0
+        pattern="${pattern#!}"
+        ;;
+      # `\!x` is a literal leading `!`, not a negation.
+      \\!*) pattern="${pattern#\\}" ;;
+    esac
+    local selected=1
     case "$pattern" in
       */)
-        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") selected=0 ;; esac
         ;;
     esac
-    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
-    case "$rel" in $pattern) return 0 ;; esac
-    case "$pattern" in
-      */*) ;;
-      *)
-        # shellcheck disable=SC2254 -- ditto, matched against the basename.
-        case "${rel##*/}" in $pattern) return 0 ;; esac
-        ;;
-    esac
+    if [ "$selected" -ne 0 ]; then
+      # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+      case "$rel" in $pattern) selected=0 ;; esac
+    fi
+    if [ "$selected" -ne 0 ]; then
+      case "$pattern" in
+        */*) ;;
+        *)
+          # shellcheck disable=SC2254 -- ditto, matched against the basename.
+          case "${rel##*/}" in $pattern) selected=0 ;; esac
+          ;;
+      esac
+    fi
+    [ "$selected" -eq 0 ] || continue
+    # A positive match ignores the path; a negated one un-ignores it. Both
+    # OVERWRITE any earlier verdict rather than short-circuiting — that is what
+    # makes the last matching pattern win.
+    if [ "$negated" -eq 0 ]; then
+      ignored=1
+    else
+      ignored=0
+    fi
   done <"$list"
-  return 1
+  return "$ignored"
 }
 
 # A candidate rewritten relative to the project, so an absolute target from a

--- a/plugins/src/base/hooks/block-managed-file-edits.sh
+++ b/plugins/src/base/hooks/block-managed-file-edits.sh
@@ -109,43 +109,61 @@ lisaignored() {
   local rel="$1"
   local list="$project_root/.lisaignore"
   [ -f "$list" ] || return 1
+  # Gitignore precedence: patterns are read in order and the LAST one to select
+  # the path decides, so `!x` re-includes something an earlier line ignored.
+  # This mirrors `matchesAnyPattern` in `src/utils/ignore-patterns.ts`; the two
+  # must agree, or an agent gets blocked on a file apply considers the
+  # project's, or waved through on one it does not.
+  #
+  # `ignored` carries shell truth: 0 = ignored, 1 = not.
+  local ignored=1
   local pattern
   while IFS= read -r pattern || [ -n "$pattern" ]; do
     pattern="${pattern#"${pattern%%[![:space:]]*}"}"
     pattern="${pattern%"${pattern##*[![:space:]]}"}"
     [ -n "$pattern" ] || continue
     case "$pattern" in \#*) continue ;; esac
-    # A leading `!` is not gitignore negation here. The real matcher passes
-    # patterns to minimatch, which negates by default, and it combines them with
-    # `.some()` — so a single `!scripts/a.mjs` line reports EVERY OTHER PATH as
-    # ignored. Measured:
-    #
-    #   patterns=["!scripts/a.mjs"]  path=scripts/a.mjs -> ignored=false
-    #   patterns=["!scripts/a.mjs"]  path=scripts/b.mjs -> ignored=TRUE
-    #
-    # Reproducing that faithfully would mean disabling this guard on a typo.
-    # Reproducing the intuitive gitignore reading would mean blocking files the
-    # matcher considers ignored. Both are wrong, so the file is treated as
-    # claimed and the write is allowed — the same direction this function errs
-    # everywhere else. Filed upstream; when the matcher stops negating, delete
-    # this branch rather than teaching it a second wrong answer.
-    case "$pattern" in !*) return 0 ;; esac
+    local negated=1
+    case "$pattern" in
+      # A bare `!` selects nothing rather than everything.
+      !) continue ;;
+      !*)
+        negated=0
+        pattern="${pattern#!}"
+        ;;
+      # `\!x` is a literal leading `!`, not a negation.
+      \\!*) pattern="${pattern#\\}" ;;
+    esac
+    local selected=1
     case "$pattern" in
       */)
-        case "$rel" in "${pattern%/}"/* | "${pattern%/}") return 0 ;; esac
+        case "$rel" in "${pattern%/}"/* | "${pattern%/}") selected=0 ;; esac
         ;;
     esac
-    # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
-    case "$rel" in $pattern) return 0 ;; esac
-    case "$pattern" in
-      */*) ;;
-      *)
-        # shellcheck disable=SC2254 -- ditto, matched against the basename.
-        case "${rel##*/}" in $pattern) return 0 ;; esac
-        ;;
-    esac
+    if [ "$selected" -ne 0 ]; then
+      # shellcheck disable=SC2254 -- the pattern is a glob on purpose.
+      case "$rel" in $pattern) selected=0 ;; esac
+    fi
+    if [ "$selected" -ne 0 ]; then
+      case "$pattern" in
+        */*) ;;
+        *)
+          # shellcheck disable=SC2254 -- ditto, matched against the basename.
+          case "${rel##*/}" in $pattern) selected=0 ;; esac
+          ;;
+      esac
+    fi
+    [ "$selected" -eq 0 ] || continue
+    # A positive match ignores the path; a negated one un-ignores it. Both
+    # OVERWRITE any earlier verdict rather than short-circuiting — that is what
+    # makes the last matching pattern win.
+    if [ "$negated" -eq 0 ]; then
+      ignored=1
+    else
+      ignored=0
+    fi
   done <"$list"
-  return 1
+  return "$ignored"
 }
 
 # A candidate rewritten relative to the project, so an absolute target from a

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -227,6 +227,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "3882bd338e65b9db9e97aa9e70426f0f7a0d191539df51636e1a5e93a2501137",
     "92e0ff52fcb29bc112ddcf1c3d85432032596572a84f3c5806a5b0c286ae55b3",
     "c1b2abf324269c0248136500eb37d7c43559552f152a7c5d07a23c219fdc70b2",
+    "d517c6ab5dedf577ca713484cb41eb886f8580a6a351206901e4bf13f66421b5",
   ]),
   "scripts/lisa-hooks/block-no-verify.sh": Object.freeze([
     "031ef7a53fc49cb18665105b834b7b50ad6a43317e0821949809e877e0562ce4",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -51,7 +51,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/create-only/.agents/rules/README.md":
       "fd260fd9b2934d0d698a8098dfff07fedc071849d588e602d773666678c3d540",
     "all/create-only/.lisaignore":
-      "3c9827e7e98daa46510b5357cd6dd9406da1821e64cc46d2eea9f311cd6d06b9",
+      "735dc0a28a19e3aebc3d71b1ddf8b077e96ab17013d0f1c49d87c08558a315df",
     "all/create-only/scripts/remote-agent-aws-setup.sh":
       "bb0e67a52ea5badd0f291961c3a9fb25559f1f35e3042642d389a49eb47f7e31",
     "all/create-only/specs/.keep":

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -25,7 +25,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
     "all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh":
-      "92e0ff52fcb29bc112ddcf1c3d85432032596572a84f3c5806a5b0c286ae55b3",
+      "d517c6ab5dedf577ca713484cb41eb886f8580a6a351206901e4bf13f66421b5",
     "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh":
       "83a8b8108654086afb6a6f23a8f09f9f041eb2cd4094c5531fa7ab1f75e873dc",
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh":
@@ -679,7 +679,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-instruction-file-edits.sh":
       "d47314b66d6ce85f77d6e058f861eede4462b2b0a33d54e82ff1c931167ec3f7",
     "plugins/src/base/hooks/block-managed-file-edits.sh":
-      "b0156d4b4e7fe3b28c6d0798db67af62b7fbc8247e6f1cc5092adf4c94e417af",
+      "5b11b2a9e31f4fe1b5ed62340024269722c42eebe22987e4dce327a519506832",
     "plugins/src/base/hooks/block-no-verify.agy.sh":
       "81c51041f8cb47bf79692c485c4f42ac7ed0a5a830821dc514cb468bc7a06b83",
     "plugins/src/base/hooks/block-no-verify.sh":

--- a/src/utils/ignore-patterns.ts
+++ b/src/utils/ignore-patterns.ts
@@ -67,7 +67,64 @@ export function parseIgnorePatterns(content: string): readonly string[] {
 }
 
 /**
+ * Whether one already-normalized path is selected by one pattern.
+ *
+ * The pattern here is always positive — negation is stripped by the caller and
+ * handled as precedence, never passed through to minimatch. That matters: a `!`
+ * reaching minimatch means "match everything EXCEPT", the opposite of what a
+ * gitignore reader intends.
+ * @param normalizedPath - Forward-slash path relative to the project root
+ * @param pattern - A single positive gitignore-style pattern
+ * @returns True when the pattern selects the path
+ */
+function patternSelects(normalizedPath: string, pattern: string): boolean {
+  // Handle directory patterns (ending with /)
+  if (pattern.endsWith("/")) {
+    const dirPattern = pattern.slice(0, -1);
+    return (
+      normalizedPath.startsWith(`${dirPattern}/`) ||
+      normalizedPath === dirPattern
+    );
+  }
+
+  // Handle exact match
+  if (normalizedPath === pattern) {
+    return true;
+  }
+
+  // Handle glob patterns
+  if (minimatchFn(normalizedPath, pattern, { dot: true })) {
+    return true;
+  }
+
+  // Handle patterns that should match anywhere in path
+  if (!pattern.includes("/")) {
+    // Pattern without slashes matches any path segment
+    const segments = normalizedPath.split("/");
+    return segments.some(segment =>
+      minimatchFn(segment, pattern, { dot: true })
+    );
+  }
+
+  // Handle patterns starting with **/ (match anywhere)
+  if (pattern.startsWith("**/")) {
+    return minimatchFn(normalizedPath, pattern, { dot: true });
+  }
+
+  return false;
+}
+
+/**
  * Check if a relative path matches any of the ignore patterns
+ *
+ * Gitignore semantics: patterns are evaluated in order and the LAST one to
+ * select the path decides, so a `!` line re-includes something an earlier
+ * pattern ignored. Previously every pattern was combined with `.some()` and
+ * handed to minimatch verbatim, which negates by default — so `!scripts/a.mjs`
+ * selected every path that was NOT `scripts/a.mjs`, and one such line reported
+ * the entire project as ignored. An ignored path is not a candidate for apply,
+ * so that silently switched off Lisa's management of the whole repository, with
+ * no error and nothing to notice.
  * @param relativePath - Path relative to project root
  * @param patterns - Array of gitignore-style patterns
  * @returns True if the path should be ignored
@@ -79,42 +136,18 @@ export function matchesAnyPattern(
   // Normalize path separators
   const normalizedPath = relativePath.replace(/\\/g, "/");
 
-  return patterns.some(pattern => {
-    // Handle directory patterns (ending with /)
-    if (pattern.endsWith("/")) {
-      const dirPattern = pattern.slice(0, -1);
-      return (
-        normalizedPath.startsWith(`${dirPattern}/`) ||
-        normalizedPath === dirPattern
-      );
+  return patterns.reduce<boolean>((ignored, raw) => {
+    const negated = raw.startsWith("!");
+    // A bare `!` selects nothing rather than everything; `\!x` is a literal `!x`.
+    const pattern = negated ? raw.slice(1) : raw.replace(/^\\!/, "!");
+    if (pattern.length === 0) {
+      return ignored;
     }
-
-    // Handle exact match
-    if (normalizedPath === pattern) {
-      return true;
+    if (!patternSelects(normalizedPath, pattern)) {
+      return ignored;
     }
-
-    // Handle glob patterns
-    if (minimatchFn(normalizedPath, pattern, { dot: true })) {
-      return true;
-    }
-
-    // Handle patterns that should match anywhere in path
-    if (!pattern.includes("/")) {
-      // Pattern without slashes matches any path segment
-      const segments = normalizedPath.split("/");
-      return segments.some(segment =>
-        minimatchFn(segment, pattern, { dot: true })
-      );
-    }
-
-    // Handle patterns starting with **/ (match anywhere)
-    if (pattern.startsWith("**/")) {
-      return minimatchFn(normalizedPath, pattern, { dot: true });
-    }
-
-    return false;
-  });
+    return !negated;
+  }, false);
 }
 
 /**

--- a/tests/unit/hooks/block-managed-file-edits.test.ts
+++ b/tests/unit/hooks/block-managed-file-edits.test.ts
@@ -164,17 +164,39 @@ describe(".lisaignore declares project ownership", () => {
     expect(runGuard(MANAGED)).toBe(0);
   });
 
-  it("allows when any pattern uses a leading !, matching the real matcher", () => {
-    // Not gitignore negation. The real matcher hands patterns to minimatch,
-    // which negates by default and combines them with `.some()`, so one `!x`
-    // line reports every OTHER path as ignored. Measured upstream:
-    //   patterns=["!scripts/a.mjs"] path=scripts/b.mjs -> ignored=true
-    // Reproducing that exactly would disable the guard on a typo; reproducing
-    // the intuitive reading would block files the matcher treats as ignored.
-    // Both are wrong, so it allows — the direction this function errs
-    // everywhere else.
-    ignoreFile("!scripts/something-else.mjs\n");
-    expect(runGuard(MANAGED)).toBe(0);
+  // `!` is now real gitignore negation on both sides. It previously was not:
+  // the TS matcher handed patterns to minimatch, which negates by default and
+  // combined them with `.some()`, so one `!x` line reported every OTHER path as
+  // ignored — including `tsconfig.json`. An ignored path is not an apply
+  // candidate, so a single stray line switched Lisa off for the whole project.
+  // This guard punted on it deliberately and allowed the write. Both sides now
+  // implement last-match-wins, and these pin them to the same answers.
+  describe("negation, in parity with matchesAnyPattern", () => {
+    it("re-includes a path an earlier pattern ignored, so the guard refuses", () => {
+      ignoreFile(`scripts/\n!${MANAGED}\n`);
+      expect(runGuard(MANAGED)).toBe(2);
+    });
+
+    it("keeps the earlier ignore for paths the negation does not name", () => {
+      ignoreFile("scripts/\n!scripts/something-else.mjs\n");
+      expect(runGuard(MANAGED)).toBe(0);
+    });
+
+    it("does not let a lone negation claim the whole project", () => {
+      // The severe case. Before the fix this allowed every write.
+      ignoreFile("!scripts/something-else.mjs\n");
+      expect(runGuard(MANAGED)).toBe(2);
+    });
+
+    it("applies last-match-wins rather than first-match-wins", () => {
+      ignoreFile(`scripts/\n!${MANAGED}\n${MANAGED}\n`);
+      expect(runGuard(MANAGED)).toBe(0);
+    });
+
+    it("keeps a bare ! inert instead of matching everything", () => {
+      ignoreFile("!\n");
+      expect(runGuard(MANAGED)).toBe(2);
+    });
   });
 
   it.each([

--- a/tests/unit/utils/ignore-patterns.test.ts
+++ b/tests/unit/utils/ignore-patterns.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
@@ -230,5 +231,35 @@ describe("ignore-patterns", () => {
 
       expect(shouldIgnore("tsconfig.json")).toBe(false);
     });
+  });
+});
+
+// The shipped starter template is where a project learns this syntax. It
+// advertised "gitignore-style" and listed the forms while omitting `!`, so a
+// reader who knew gitignore would reasonably write a negation line — and before
+// the fix above, that one line reported the whole project as ignored. A fleet
+// sweep found 0 negation lines across 6 repositories, so nobody had taken the
+// invitation yet; this keeps the documented syntax and the implemented syntax
+// from drifting apart again.
+describe("the shipped .lisaignore template", () => {
+  const template = readFileSync(
+    path.join(process.cwd(), "all", "create-only", ".lisaignore"),
+    "utf8"
+  );
+
+  it("documents negation and the last-match-wins rule", () => {
+    expect(template).toContain("Negation:");
+    expect(template).toContain("LAST one to match");
+  });
+
+  it("says what ignoring costs, not just what it does", () => {
+    // Ignoring is the one action here that permanently opts a file out of
+    // upstream fixes. A template that lists it as a bare syntax form invites
+    // someone to reach for it to quiet a warning.
+    expect(template).toContain("stops receiving upstream fixes");
+  });
+
+  it("steers a Lisa-owned guard to lisa-guard-capabilities instead", () => {
+    expect(template).toContain("lisa-guard-capabilities");
   });
 });

--- a/tests/unit/utils/ignore-patterns.test.ts
+++ b/tests/unit/utils/ignore-patterns.test.ts
@@ -7,6 +7,10 @@ import {
 
 const ESLINT_CONFIG_FILE = "eslint.config.mjs";
 const PRETTIERRC_FILE = ".prettierrc.json";
+const HOOKS_DIR_PATTERN = ".claude/hooks/";
+const HOOKS_FORMAT_FILE = ".claude/hooks/format.sh";
+const HOOKS_KEEP_FILE = ".claude/hooks/keep.sh";
+const SCRIPTS_KEEP_FILE = "scripts/keep.mjs";
 
 describe("ignore-patterns", () => {
   const testDir = path.join(process.cwd(), "tests", "fixtures", "ignore-test");
@@ -79,12 +83,12 @@ describe("ignore-patterns", () => {
     it("matches directory patterns (ending with /)", async () => {
       await fs.writeFile(
         path.join(testDir, LISAIGNORE_FILENAME),
-        ".claude/hooks/"
+        HOOKS_DIR_PATTERN
       );
 
       const patterns = await loadIgnorePatterns(testDir);
 
-      expect(patterns.shouldIgnore(".claude/hooks/format.sh")).toBe(true);
+      expect(patterns.shouldIgnore(HOOKS_FORMAT_FILE)).toBe(true);
       expect(patterns.shouldIgnore(".claude/hooks/lint.sh")).toBe(true);
       expect(patterns.shouldIgnore(".claude/rules/PROJECT_RULES.md")).toBe(
         false
@@ -121,27 +125,110 @@ describe("ignore-patterns", () => {
     it("matches multiple patterns", async () => {
       await fs.writeFile(
         path.join(testDir, LISAIGNORE_FILENAME),
-        `${ESLINT_CONFIG_FILE}\n${PRETTIERRC_FILE}\n.claude/hooks/`
+        `${ESLINT_CONFIG_FILE}\n${PRETTIERRC_FILE}\n${HOOKS_DIR_PATTERN}`
       );
 
       const patterns = await loadIgnorePatterns(testDir);
 
       expect(patterns.shouldIgnore(ESLINT_CONFIG_FILE)).toBe(true);
       expect(patterns.shouldIgnore(PRETTIERRC_FILE)).toBe(true);
-      expect(patterns.shouldIgnore(".claude/hooks/format.sh")).toBe(true);
+      expect(patterns.shouldIgnore(HOOKS_FORMAT_FILE)).toBe(true);
       expect(patterns.shouldIgnore("package.json")).toBe(false);
     });
 
     it("handles Windows-style path separators", async () => {
       await fs.writeFile(
         path.join(testDir, LISAIGNORE_FILENAME),
-        ".claude/hooks/"
+        HOOKS_DIR_PATTERN
       );
 
       const patterns = await loadIgnorePatterns(testDir);
 
       // Should normalize backslashes to forward slashes
       expect(patterns.shouldIgnore(".claude\\hooks\\format.sh")).toBe(true);
+    });
+  });
+
+  // The file documents itself as gitignore-style, and gitignore's `!` re-includes
+  // a path an earlier pattern ignored. It was passed straight to minimatch, which
+  // negates by DEFAULT — so `!x` matched everything that was not `x`, and the
+  // combining `.some()` turned one such line into "ignore the whole project".
+  // Measured before the fix:
+  //
+  //   ["!scripts/a.mjs"]                    scripts/a.mjs -> false
+  //   ["!scripts/a.mjs"]                    scripts/b.mjs -> TRUE
+  //   ["!scripts/a.mjs"]                    tsconfig.json -> TRUE   <- everything
+  //   ["scripts/*.mjs","!scripts/a.mjs"]    scripts/a.mjs -> TRUE   <- inverted
+  //
+  // An ignored path is not a candidate for apply, so a project that wrote one
+  // `!` line stopped being managed by Lisa at all, silently and with no error.
+  describe("negation (`!`)", () => {
+    const ignoreWith = async (
+      lines: readonly string[]
+    ): Promise<(p: string) => boolean> => {
+      await fs.writeFile(
+        path.join(testDir, LISAIGNORE_FILENAME),
+        lines.join("\n")
+      );
+      const loaded = await loadIgnorePatterns(testDir);
+      return loaded.shouldIgnore;
+    };
+
+    it("re-includes a path an earlier pattern ignored", async () => {
+      const shouldIgnore = await ignoreWith([
+        "scripts/*.mjs",
+        "!scripts/a.mjs",
+      ]);
+
+      expect(shouldIgnore("scripts/a.mjs")).toBe(false);
+      expect(shouldIgnore("scripts/b.mjs")).toBe(true);
+    });
+
+    it("never ignores a path no pattern selected", async () => {
+      // The severe case: a lone negation must not sweep in the whole project.
+      const shouldIgnore = await ignoreWith(["!scripts/a.mjs"]);
+
+      expect(shouldIgnore("tsconfig.json")).toBe(false);
+      expect(shouldIgnore("scripts/b.mjs")).toBe(false);
+      expect(shouldIgnore("scripts/a.mjs")).toBe(false);
+    });
+
+    it("applies last-match-wins, not first-match-wins", async () => {
+      const reIncluded = await ignoreWith([
+        "scripts/",
+        `!${SCRIPTS_KEEP_FILE}`,
+      ]);
+      expect(reIncluded(SCRIPTS_KEEP_FILE)).toBe(false);
+
+      const reIgnored = await ignoreWith([
+        "scripts/",
+        `!${SCRIPTS_KEEP_FILE}`,
+        SCRIPTS_KEEP_FILE,
+      ]);
+      expect(reIgnored(SCRIPTS_KEEP_FILE)).toBe(true);
+    });
+
+    it("negates directory and bare-segment patterns too", async () => {
+      const dir = await ignoreWith([HOOKS_DIR_PATTERN, `!${HOOKS_KEEP_FILE}`]);
+      expect(dir(HOOKS_FORMAT_FILE)).toBe(true);
+      expect(dir(HOOKS_KEEP_FILE)).toBe(false);
+
+      const segment = await ignoreWith(["*.mjs", "!keep.mjs"]);
+      expect(segment("scripts/other.mjs")).toBe(true);
+      expect(segment(SCRIPTS_KEEP_FILE)).toBe(false);
+    });
+
+    it("treats a backslash-escaped bang as a literal leading `!`", async () => {
+      const shouldIgnore = await ignoreWith(["\\!weird.json"]);
+
+      expect(shouldIgnore("!weird.json")).toBe(true);
+      expect(shouldIgnore("weird.json")).toBe(false);
+    });
+
+    it("keeps the bare `!` line inert rather than matching everything", async () => {
+      const shouldIgnore = await ignoreWith(["!"]);
+
+      expect(shouldIgnore("tsconfig.json")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2628

Stacked on #2630 — it edits the same guard file, and that guard's own comment left the TODO this cashes: *"when the matcher stops negating, delete this branch rather than teaching it a second wrong answer."* Base is `fix/copy-overwrite-preserves-host-edits`; retarget to `main` once #2630 merges.

`.lisaignore` documents itself as gitignore-style, where `!x` re-includes a path an earlier pattern ignored. Patterns went straight to minimatch, which negates by **default**, combined with `.some()`. Measured before the fix:

```
["!scripts/a.mjs"]                 scripts/a.mjs -> false
["!scripts/a.mjs"]                 scripts/b.mjs -> TRUE
["!scripts/a.mjs"]                 tsconfig.json -> TRUE
["scripts/*.mjs","!scripts/a.mjs"] scripts/a.mjs -> TRUE
```

Two failures:

1. **Negation was inverted** — `!x` after a pattern that ignored `x` left `x` ignored, the opposite of what it says.
2. **A lone `!` line reported every other path as ignored**, `tsconfig.json` included. An ignored path is not an apply candidate, so **one stray line silently switched off Lisa's management of the entire repository** — no error, no warning, and `lisa doctor` would agree the project was fine.

Three call sites consumed that verdict: the apply skip decision (`src/core/lisa.ts:590`), `doctor-lisa-owned-artifacts`, and template health inspection. All three now get gitignore's real rule — patterns evaluated in order, **last match wins**.

The shell guard `lisaignored()` in `block-managed-file-edits.sh` is brought to parity and pinned to identical answers by tests on both sides. It had deliberately punted with `case "$pattern" in !*) return 0`, allowing any write once a `!` line existed anywhere.

Edge cases pinned: `\!x` is a literal leading bang, a bare `!` selects nothing rather than everything, and negation composes with directory, glob, and bare-segment patterns.

## Bite control

The six new matcher tests fail **5 of 6** against the old implementation; the five new shell tests fail **3 of 5** against the old guard.

🤖 Generated with Claude Code
