### PR TITLE
chore(coderabbit): keep only repo-specific config in the overlay

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,13 +1,34 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# This file is an OVERLAY on the organisation's web configuration, not a
+# replacement for it — that is what `inheritance: true` means. So it should
+# carry only what is a fact about THIS repository. Anything that would be
+# identical in every repo is an org-level preference and belongs in the web
+# console, where it also applies to repos that never take a Lisa release.
+#
+# Removed on 2026-08-16 and moved to org web settings — all of it inert if the
+# console never re-creates it, which is why only this class was moved:
+#
+#   - the `tools:` block: fifteen linters disabled for PHP, Go, Swift, Kotlin,
+#     C++ and other languages Lisa does not ship. Losing it means CodeRabbit
+#     runs a Go linter over a repo with no Go in it, which finds nothing.
+#   - review cosmetics: `poem`, `sequence_diagrams`, `in_progress_fortune`,
+#     `collapse_walkthrough`, `estimate_code_review_effort`. Losing any of them
+#     makes a review wordier, nothing more.
+#
+# DELIBERATELY NOT MOVED, though they could live at org level: the settings
+# below that GATE a merge. `pre_merge_checks` at `mode: error` fails a pull
+# request outright, and `request_changes_workflow` is what lets CodeRabbit post
+# a blocking CHANGES_REQUESTED. Moving those is only safe once the web console
+# demonstrably carries them; move them first and the failure is silent — merges
+# start passing a gate nobody notices has stopped running. That is the exact
+# shape of defect this repository keeps finding, so the enforcement half stays
+# here until someone can point at the console entry that replaces it.
 early_access: true
 inheritance: true
 reviews:
+  # Enforcement, not preference. See the header before moving these.
   request_changes_workflow: true
-  collapse_walkthrough: false
-  sequence_diagrams: false
-  estimate_code_review_effort: false
-  in_progress_fortune: false
-  poem: false
   auto_review:
     drafts: true
   pre_merge_checks:
@@ -17,39 +38,9 @@ reviews:
       mode: error
     description:
       mode: error
-  tools:
-    markdownlint:
-      enabled: false
-    swiftlint:
-      enabled: false
-    phpstan:
-      enabled: false
-    phpmd:
-      enabled: false
-    phpcs:
-      enabled: false
-    golangci-lint:
-      enabled: false
-    detekt:
-      enabled: false
-    fortitudeLint:
-      enabled: false
-    buf:
-      enabled: false
-    regal:
-      enabled: false
-    pmd:
-      enabled: false
-    clang:
-      enabled: false
-    cppcheck:
-      enabled: false
-    circleci:
-      enabled: false
-    checkmake:
-      enabled: false
 knowledge_base:
   code_guidelines:
+    # Repo-specific path: Lisa's agent-facing guidance lives under .claude/.
     filePatterns:
       - '**/.claude/**/*'
 issue_enrichment:
@@ -75,6 +66,9 @@ issue_enrichment:
     # `human-needed` is deliberately absent too. Whether a human must rule on
     # something is a human's call, and Lisa applies it itself through the
     # `[lisa-human-gate]` marker at filing time.
+    #
+    # This block is the reason the file still exists. It is an allowlist over
+    # THIS repository's label taxonomy, so it cannot move to org settings.
     labeling_instructions:
       - label: 'type:Bug'
         instructions: 'Apply when the issue reports incorrect behaviour in shipped code.'


### PR DESCRIPTION

`.coderabbit.yml` sets `inheritance: true`, so it was already an OVERLAY on the
organisation's web configuration rather than a replacement. About half of its
123 lines were global preference that reads identically in any repository, and
which therefore belongs in the web console — where it also applies to repos that
never take a Lisa release.

Moved out (all of it inert if the console never re-creates it, which is why only
this class was moved):

- the `tools:` block — fifteen linters disabled for PHP, Go, Swift, Kotlin, C++
  and other languages Lisa does not ship. Losing it means CodeRabbit runs a Go
  linter over a repo with no Go in it.
- review cosmetics — `poem`, `sequence_diagrams`, `in_progress_fortune`,
  `collapse_walkthrough`, `estimate_code_review_effort`. Losing any of them makes
  a review wordier, nothing more.

DELIBERATELY KEPT, against the first draft of this change: `pre_merge_checks`
(`mode: error` on docstrings, title, description) and `request_changes_workflow`.
I had classified those as org policy. They are ENFORCEMENT — they gate merges,
and `request_changes_workflow` is what lets CodeRabbit post a blocking
CHANGES_REQUESTED at all. Moving them before the console demonstrably carries
them fails SILENTLY: merges start passing a gate nobody notices has stopped
running. That is the defect shape this repository keeps finding, so the
enforcement half stays until someone can point at the console entry that
replaces it. The file header records that split so the next reader does not
undo it.

Also kept, and the reason the file still exists at all:

- `labeling_instructions` — an allowlist over THIS repository's label taxonomy,
  inexpressible at org level. Its comment records the measured incident behind
  it: CodeRabbit auto-applied `status:done` to fresh issues five times on
  2026-08-15, fastest at EIGHT SECONDS, once over a `status:in-progress` a human
  had just set. `status:done` is terminal, so the work-item gate then refused to
  bind and each of those issues blocked its own pull request.
- `knowledge_base.code_guidelines.filePatterns` — repo-specific paths.

Note what this change does NOT do: it does not ship a `.coderabbit.yml` to
consumers. Lisa ships none today, and creating one would add a copy-overwrite
surface that drifts out of band, against the standing preference for exposing
behaviour through the npm package rather than copied files. The consumer-side
noise (twelve findings against Lisa's shipped surface in a single bump, reported
by a consumer session) is better answered by org-level path exclusions in the
console, which need no file and no release.

Work-Item: CodySwannGT/lisa#2633

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository-specific review guidance and configuration behavior.
  * Documented which review enforcement and labeling settings remain managed locally.
* **Chores**
  * Simplified review configuration by removing cosmetic options and language/tool exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->