### PR TITLE
feat(gates): put test_mutation and verification_coverage behind the facade

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -758,7 +758,91 @@ jobs:
         with:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
+      # PRECONDITION FIRST, and it is a file read rather than an install.
+      #
+      # This job has never installed dependencies — it runs plain `node` against
+      # a shipped script. Resolving a gate needs the Lisa package, so a naive
+      # façade would add an unconditional install to a job that had none, on
+      # every pull request in the fleet. Reading `.lisa.config.json` for a
+      # `gates` block costs nothing and answers the only question that matters:
+      # a project that declares no gates can never resolve one, so it goes
+      # straight to the fallback and this job stays exactly as cheap as before.
+      - name: 🔎 Check whether this project declares any gates
+        id: gates_declared
+        run: |
+          set -euo pipefail
+          if [ -f ".lisa.config.json" ] && node -e 'const c = require("./.lisa.config.json"); process.exit(c.gates && Object.keys(c.gates).length ? 0 : 1)' 2>/dev/null; then
+            echo "declared=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "declared=false" >> "$GITHUB_OUTPUT"
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🍞 Setup Bun
+        if: steps.gates_declared.outputs.declared == 'true' && inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: 📦 Install dependencies
+        if: steps.gates_declared.outputs.declared == 'true'
+        run: |
+          if [ "${{ inputs.package_manager }}" = "npm" ]; then
+            npm ci
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn install --frozen-lockfile
+          elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            bun install --frozen-lockfile
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      # Gate façade — contract and fallback rationale documented in full on the
+      # 🧹 Lint job above.
+      - name: 🎛️ Resolve the coverage-adequacy gate
+        id: gate
+        if: steps.gates_declared.outputs.declared == 'true'
+        env:
+          GATE_ID: coverage-adequacy
+          FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
+        run: |
+          set -euo pipefail
+          RESOLVER=""
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+            if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
+          done
+          if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          node "$RESOLVER" list --moment="$GATE_MOMENT" --json --include-off | node -e '
+          let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
+          const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
+          if (hit && hit.level === "off") return process.stdout.write("configured=off\n");
+          const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
+          if (!task) return process.stdout.write("configured=false\n");
+          const runner = (require("./.lisa.config.json").gates || {}).runner || process.env.FALLBACK_RUNNER;
+          const plain = value => /^[A-Za-z0-9:._@\/= -]+$/.test(value);
+          if (!plain(task) || !plain(runner)) { console.error(`::error::gates.${id} resolves to "${runner} ${task}", which is not a plain command.`); process.exit(1); }
+          process.stdout.write(`configured=true\nrunner=${runner}\ntask=${task}\n`); });
+          ' >> "$GITHUB_OUTPUT"
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: ✅ Run the coverage-adequacy gate
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          GATE_RUNNER: ${{ steps.gate.outputs.runner }}
+          GATE_TASK: ${{ steps.gate.outputs.task }}
+          VERIFY_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          VERIFY_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          VERIFY_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        # Deliberate word split. Both values were validated above to be plain
+        # words, so the runner ("npm run", "bun run", "just") and a task
+        # carrying flags both reach argv without a shell metacharacter.
+        run: $GATE_RUNNER $GATE_TASK
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       - name: ✅ Require a verification (e2e) spec delta on feat/fix
+        # FALLBACK — unchanged behavior for a project with no `gates` block, and
+        # for one whose block does not name this gate.
+        if: steps.gates_declared.outputs.declared == 'false' || steps.gate.outputs.configured == 'false'
         run: node scripts/check-verification-coverage.mjs
         working-directory: ${{ inputs.working_directory || '.' }}
         env:
@@ -1338,8 +1422,62 @@ jobs:
           fi
         working-directory: ${{ inputs.working_directory || '.' }}
 
-      - name: 🧬 Run mutation-testing gate (diff-only, self-skips when disabled)
+      # Gate façade — contract and fallback rationale documented in full on the
+      # 🧹 Lint job above.
+      #
+      # Deliberately AFTER the existing `check_script` precondition, which is a
+      # grep of package.json and costs nothing. A project with no
+      # `test:mutation` script never installs and never resolves a gate, so the
+      # façade adds no runner time to the repos that do not use this. The one
+      # case that pays is a project that ships the script AND declares the gate
+      # `off` — it installs, then skips. That is a small, bounded waste and the
+      # alternative (resolving before installing) cannot work: the resolver
+      # lives inside the package the install provides.
+      - name: 🎛️ Resolve the test-meaningfulness gate
+        id: gate
         if: steps.check_script.outputs.exists == 'true'
+        env:
+          GATE_ID: test-meaningfulness
+          FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
+        run: |
+          set -euo pipefail
+          RESOLVER=""
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+            if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
+          done
+          if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          node "$RESOLVER" list --moment="$GATE_MOMENT" --json --include-off | node -e '
+          let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
+          const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
+          if (hit && hit.level === "off") return process.stdout.write("configured=off\n");
+          const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
+          if (!task) return process.stdout.write("configured=false\n");
+          const runner = (require("./.lisa.config.json").gates || {}).runner || process.env.FALLBACK_RUNNER;
+          const plain = value => /^[A-Za-z0-9:._@\/= -]+$/.test(value);
+          if (!plain(task) || !plain(runner)) { console.error(`::error::gates.${id} resolves to "${runner} ${task}", which is not a plain command.`); process.exit(1); }
+          process.stdout.write(`configured=true\nrunner=${runner}\ntask=${task}\n`); });
+          ' >> "$GITHUB_OUTPUT"
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧬 Run the test-meaningfulness gate
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
+          GATE_RUNNER: ${{ steps.gate.outputs.runner }}
+          GATE_TASK: ${{ steps.gate.outputs.task }}
+          # Diff against the PR base branch (falls back to 'main' outside PRs).
+          MUTATION_SINCE: ${{ github.base_ref || 'main' }}
+        # Deliberate word split. Both values were validated above to be plain
+        # words, so the runner ("npm run", "bun run", "just") and a task
+        # carrying flags both reach argv without a shell metacharacter.
+        run: $GATE_RUNNER $GATE_TASK
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      - name: 🧬 Run mutation-testing gate (diff-only, self-skips when disabled)
+        # FALLBACK — unchanged behavior for a project with no `gates` block, and
+        # for one whose block does not name this gate.
+        if: steps.gate.outputs.configured == 'false'
         run: |
           if [ "${{ inputs.package_manager }}" = "npm" ]; then
             npm run test:mutation

--- a/tests/integration/quality-gate-facade-fixture.ts
+++ b/tests/integration/quality-gate-facade-fixture.ts
@@ -193,6 +193,25 @@ export const CONVERTED: ConvertedJob[] = [
       "⏭️ AST Grep Skipped (no config)",
     ],
   },
+  {
+    job: "test_mutation",
+    jobName: "🧬 Mutation Testing Gate",
+    gate: "test-meaningfulness",
+    gateStep: "🧬 Run the test-meaningfulness gate",
+    // The ⏭️ notice hangs off `check_script`, not off the gate, so it stays on
+    // the no-script path rather than the no-gate one. A project that ships the
+    // script and declares no gate still runs the fallback.
+    fallbackSteps: [
+      "🧬 Run mutation-testing gate (diff-only, self-skips when disabled)",
+    ],
+  },
+  {
+    job: "verification_coverage",
+    jobName: "✅ Verification Coverage",
+    gate: "coverage-adequacy",
+    gateStep: "✅ Run the coverage-adequacy gate",
+    fallbackSteps: ["✅ Require a verification (e2e) spec delta on feat/fix"],
+  },
 ];
 
 /**

--- a/tests/integration/quality-gate-facade.test.ts
+++ b/tests/integration/quality-gate-facade.test.ts
@@ -265,7 +265,21 @@ describe("quality.yml gate façade", () => {
   describe("skip_jobs is documented as the unsafe route", () => {
     it("still accepts skip_jobs, because installed repositories pass it today", () => {
       expect(source).toContain("      skip_jobs:");
+      // Every job that was skip_jobs-gated BEFORE the façade must still be, so
+      // converting a job never silently removes a caller's existing escape.
+      //
+      // This is deliberately not "every façade job is skip_jobs-gated".
+      // `verification_coverage` never was — it gates on `verify_enforced` and
+      // the event being a pull_request — and adding skip_jobs to it in order
+      // to satisfy a uniform assertion would GROW the surface this workstream
+      // exists to retire. The invariant is "no escape was taken away", not
+      // "every job has one".
+      const notSkipGated = new Set(["verification_coverage"]);
       for (const { job } of CONVERTED) {
+        if (notSkipGated.has(job)) {
+          expect(workflow.jobs[job].if ?? "").not.toContain("inputs.skip_jobs");
+          continue;
+        }
         expect(workflow.jobs[job].if ?? "").toContain("inputs.skip_jobs");
       }
     });


### PR DESCRIPTION

The last two PR-legal gates a project could not govern through the `gates`
block. Both ran a hardcoded command, so a declared task or level was ignored.

They were deferred as "needs unconditional dependency installs — a cost
decision". That framing was mine and it was wrong. Resolution does need the
Lisa package, but the install does not need to be unconditional: both jobs have
a precondition that costs nothing and the install stays behind it.

  test_mutation         the existing `check_script` step already greps
                        package.json for `test:mutation`. A project without the
                        script installs nothing and resolves nothing, exactly as
                        before.

  verification_coverage had NO install at all — it runs plain `node` against a
                        shipped script. A naive facade would have added an
                        unconditional install to a job that had none, on every
                        pull request in the fleet. Instead a new step reads
                        `.lisa.config.json` for a non-empty `gates` block, which
                        answers the only question that decides it: a project
                        declaring no gates can never resolve one, so it goes
                        straight to the fallback and the job stays as cheap as
                        it has always been.

Residual, stated rather than hidden: a project that ships `test:mutation` AND
declares that gate `off` installs and then skips. Bounded and unavoidable — the
resolver lives inside the package the install provides.

Both resolve blocks are byte-identical to the eleven already in this file, with
only GATE_ID differing, so the facade stays one pattern rather than thirteen
variations.

One test invariant changed, deliberately. `quality-gate-facade.test.ts` asserted
that every converted job carries `inputs.skip_jobs` in its `if:`.
`verification_coverage` never did — it gates on `verify_enforced` and the event
being a pull_request — so satisfying that assertion would have meant ADDING a
skip_jobs escape to a job that never had one, growing the surface this
workstream exists to retire. The invariant is now "no job lost an escape it
had", not "every job has one", with `verification_coverage` pinned as explicitly
not skip-gated so a future edit cannot quietly hand it one.

Bite control: renaming the mutation gate-run step turns three assertions RED
('runs the project's task only when configured true', 'runs the project's task
when test-meaningfulness is configured', 'passes the resolved command through
env, never interpolated into the shell'); restoring it returns 350 passed.

Full suite: 12,953 passed across 715 files.

Work-Item: CodySwannGT/lisa#2636

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>
