### PR TITLE
feat(doctor): report Lisa artifact copy provenance

### DIFF
--- a/src/cli/doctor-lisa-owned-artifact-copies.ts
+++ b/src/cli/doctor-lisa-owned-artifact-copies.ts
@@ -1,0 +1,63 @@
+/**
+ * Copy provenance helpers for Lisa-owned doctor artifacts.
+ * @module cli/doctor-lisa-owned-artifact-copies
+ */
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+
+/** A resolved Lisa-owned artifact copy. */
+interface ResolvedArtifactCopy {
+  readonly location: string;
+  readonly version: string;
+  readonly governs: boolean;
+}
+
+/** Provenance for an artifact that is reachable from more than one place. */
+export interface MultiCopyArtifact {
+  readonly destination: string;
+  readonly copies: readonly ResolvedArtifactCopy[];
+  readonly disagrees: boolean;
+}
+
+/**
+ * Short content identity for a resolved artifact copy.
+ * @param bytes - File contents
+ * @returns Human-sized content version
+ */
+function artifactVersion(bytes: Buffer): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex").slice(0, 12)}`;
+}
+
+/**
+ * Report all resolvable copies for one installed Lisa-owned artifact.
+ * @param lisaRoot - Installed Lisa package root
+ * @param destination - Project-relative artifact destination
+ * @param installed - Bytes currently installed in the project
+ * @param sources - Absolute paths of shipped package variants
+ * @returns Multi-copy provenance
+ */
+export async function describeResolvableCopies(
+  lisaRoot: string,
+  destination: string,
+  installed: Buffer,
+  sources: readonly string[]
+): Promise<MultiCopyArtifact> {
+  const shipped = await Promise.all(
+    sources.map(async source => [source, await readFile(source)] as const)
+  );
+  const copies: ResolvedArtifactCopy[] = [
+    {
+      location: `project:${destination}`,
+      version: artifactVersion(installed),
+      governs: true,
+    },
+    ...shipped.map(([source, bytes]) => ({
+      location: `package:${path.relative(lisaRoot, source).split(path.sep).join("/")}`,
+      version: artifactVersion(bytes),
+      governs: false,
+    })),
+  ];
+  const versions = new Set(copies.map(copy => copy.version));
+  return { destination, copies, disagrees: versions.size > 1 };
+}

--- a/src/cli/doctor-lisa-owned-artifacts.ts
+++ b/src/cli/doctor-lisa-owned-artifacts.ts
@@ -16,6 +16,7 @@
  * @module cli/doctor-lisa-owned-artifacts
  */
 import { readFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as fse from "fs-extra";
@@ -54,6 +55,26 @@ interface ArtifactCheck {
 
 /** One shipped Lisa-owned artifact and the destination it installs to. */
 type ShippedArtifact = readonly [destination: string, source: string];
+
+/** A resolved Lisa-owned artifact copy. */
+interface ResolvedArtifactCopy {
+  readonly location: string;
+  readonly version: string;
+  readonly governs: boolean;
+}
+
+/** Provenance for an artifact that is reachable from more than one place. */
+interface MultiCopyArtifact {
+  readonly destination: string;
+  readonly copies: readonly ResolvedArtifactCopy[];
+  readonly disagrees: boolean;
+}
+
+/** Per-destination assessment before it is folded into one doctor line. */
+interface ArtifactAssessment {
+  readonly finding?: readonly [string, Finding];
+  readonly multiCopy?: MultiCopyArtifact;
+}
 
 /**
  * Resolve the installed Lisa package root, mirroring how apply resolves it.
@@ -135,6 +156,59 @@ async function matchesAnyShipped(
 }
 
 /**
+ * Short content identity for a resolved artifact copy.
+ * @param bytes - File contents
+ * @returns Human-sized content version
+ */
+function artifactVersion(bytes: Buffer): string {
+  return `sha256:${createHash("sha256").update(bytes).digest("hex").slice(0, 12)}`;
+}
+
+/**
+ * Report all resolvable copies for one installed Lisa-owned artifact.
+ *
+ * The project copy is listed as governing first because Lisa's documented hook
+ * and script invocations run the installed project path. Package templates are
+ * still listed because they are also reachable and are the source apply uses.
+ * @param targetPath - Project path being inspected
+ * @param lisaRoot - Installed Lisa package root
+ * @param destination - Project-relative artifact destination
+ * @param installed - Bytes currently installed in the project
+ * @param sources - Absolute paths of shipped package variants
+ * @returns Multi-copy provenance, or undefined for a single-copy artifact
+ */
+async function describeResolvableCopies(
+  targetPath: string,
+  lisaRoot: string,
+  destination: string,
+  installed: Buffer,
+  sources: readonly string[]
+): Promise<MultiCopyArtifact | undefined> {
+  if (sources.length === 0) return undefined;
+  const shipped = await Promise.all(
+    sources.map(async source => [source, await readFile(source)] as const)
+  );
+  const copies: ResolvedArtifactCopy[] = [
+    {
+      location: `project:${destination}`,
+      version: artifactVersion(installed),
+      governs: true,
+    },
+    ...shipped.map(([source, bytes]) => ({
+      location: `package:${path.relative(lisaRoot, source).split(path.sep).join("/")}`,
+      version: artifactVersion(bytes),
+      governs: false,
+    })),
+  ];
+  const versions = new Set(copies.map(copy => copy.version));
+  return {
+    destination,
+    copies,
+    disagrees: versions.size > 1,
+  };
+}
+
+/**
  * Whether the installed file is a trampoline that re-exports the shipped
  * template instead of copying it.
  *
@@ -206,36 +280,58 @@ export async function checkLisaOwnedArtifacts(
   // swap a guard for a thin re-export and have doctor call it current.
   const selfHost = await isLisaSourceRepo(targetPath);
 
-  const results = await Promise.all(
-    [...shipped].map(async ([destination, sources]) => {
-      // Ignored is UNASSESSED, not clean. Reported as such below, because a
-      // `.lisaignore` entry on a Lisa-owned guard suppresses the divergence
-      // warning while changing nothing about the divergence — and the ok line
-      // then states conformance that was never established.
-      if (matchesAnyPattern(destination, ignorePatterns))
-        return [destination, "ignored"] as const;
-      const installedPath = path.join(targetPath, destination);
-      const installed = await readFile(installedPath).catch(() => undefined);
-      if (installed === undefined) return undefined;
-      if (await matchesAnyShipped(installed, sources)) return undefined;
-      if (
-        selfHost &&
-        reExportsShippedTemplate(installed, installedPath, sources)
-      )
-        return undefined;
-      const outdated = await isProvablyStale(
-        installed,
-        destination,
-        sources,
-        ledger
-      );
-      return [destination, outdated ? "stale" : "modified"] as const;
-    })
+  const results: readonly (ArtifactAssessment | undefined)[] =
+    await Promise.all(
+      [...shipped].map(async ([destination, sources]) => {
+        // Ignored is UNASSESSED, not clean. Reported as such below, because a
+        // `.lisaignore` entry on a Lisa-owned guard suppresses the divergence
+        // warning while changing nothing about the divergence — and the ok line
+        // then states conformance that was never established.
+        if (matchesAnyPattern(destination, ignorePatterns))
+          return {
+            finding: [destination, "ignored"] as const,
+          } satisfies ArtifactAssessment;
+        const installedPath = path.join(targetPath, destination);
+        const installed = await readFile(installedPath).catch(() => undefined);
+        if (installed === undefined) return undefined;
+        const multiCopy = await describeResolvableCopies(
+          targetPath,
+          lisaRoot,
+          destination,
+          installed,
+          sources
+        );
+        if (await matchesAnyShipped(installed, sources))
+          return multiCopy === undefined
+            ? undefined
+            : ({ multiCopy } satisfies ArtifactAssessment);
+        if (
+          selfHost &&
+          reExportsShippedTemplate(installed, installedPath, sources)
+        )
+          return undefined;
+        const outdated = await isProvablyStale(
+          installed,
+          destination,
+          sources,
+          ledger
+        );
+        const finding = [destination, outdated ? "stale" : "modified"] as const;
+        return multiCopy === undefined
+          ? ({ finding } satisfies ArtifactAssessment)
+          : ({ finding, multiCopy } satisfies ArtifactAssessment);
+      })
+    );
+  const assessments = results.filter(
+    (item): item is ArtifactAssessment => item !== undefined
   );
   return summarise(
-    results.filter(
-      (item): item is readonly [string, Finding] => item !== undefined
-    )
+    assessments
+      .map(item => item.finding)
+      .filter((item): item is readonly [string, Finding] => item !== undefined),
+    assessments
+      .map(item => item.multiCopy)
+      .filter((item): item is MultiCopyArtifact => item !== undefined)
   );
 }
 
@@ -245,10 +341,12 @@ type Finding = "stale" | "modified" | "ignored";
 /**
  * Turn the per-artifact findings into one doctor line.
  * @param findings - Destination paths paired with what was found
+ * @param multiCopies - Provenance for artifacts reachable from multiple paths
  * @returns Doctor check result
  */
 function summarise(
-  findings: readonly (readonly [string, Finding])[]
+  findings: readonly (readonly [string, Finding])[],
+  multiCopies: readonly MultiCopyArtifact[]
 ): ArtifactCheck {
   const pick = (wanted: Finding): string[] =>
     findings
@@ -259,7 +357,9 @@ function summarise(
   const stale = pick("stale");
   const modified = pick("modified");
   const ignored = pick("ignored");
-  if (stale.length === 0 && modified.length === 0) {
+  const copyDisagreements = multiCopies.filter(copy => copy.disagrees);
+  const copyReports = renderCopyReports(multiCopies);
+  if (hasNoWarnings(stale, modified, copyDisagreements)) {
     // Named rather than folded into the pass. A guard excluded by
     // `.lisaignore` was never compared, so claiming it matches asserts
     // something no comparison established — and the file it most often hides
@@ -267,10 +367,7 @@ function summarise(
     return {
       name: CHECK_NAME,
       status: "ok",
-      detail:
-        ignored.length > 0
-          ? `Enforcement guards match the installed Lisa version; ${ignored.length} not assessed (.lisaignore): ${ignored.join(", ")}`
-          : "Enforcement guards match the installed Lisa version",
+      detail: renderOkDetail(ignored, copyReports),
     };
   }
 
@@ -281,8 +378,74 @@ function summarise(
     modified.length > 0
       ? `Lisa-owned guards edited in this project, so apply will keep yours rather than overwrite them: ${modified.join(", ")}`
       : "",
+    copyDisagreements.length > 0
+      ? `Resolvable Lisa-owned artifact copies disagree: ${renderCopyReports(copyDisagreements, false)}`
+      : "",
   ].filter(part => part.length > 0);
   return { name: CHECK_NAME, status: "warn", detail: parts.join(". ") };
+}
+
+/**
+ * Whether the accumulated artifact state is warning-free.
+ * @param stale - Outdated artifacts
+ * @param modified - Host-modified artifacts
+ * @param copyDisagreements - Multi-copy artifacts with differing content
+ * @returns True when the doctor line can remain OK
+ */
+function hasNoWarnings(
+  stale: readonly string[],
+  modified: readonly string[],
+  copyDisagreements: readonly MultiCopyArtifact[]
+): boolean {
+  return (
+    stale.length === 0 &&
+    modified.length === 0 &&
+    copyDisagreements.length === 0
+  );
+}
+
+/**
+ * Render the OK detail while preserving the ignored-is-unassessed wording.
+ * @param ignored - Paths skipped by .lisaignore
+ * @param copyReports - Rendered multi-copy provenance
+ * @returns Doctor detail text
+ */
+function renderOkDetail(
+  ignored: readonly string[],
+  copyReports: string
+): string {
+  const suffix = copyReports.length > 0 ? `; ${copyReports}` : "";
+  if (ignored.length > 0) {
+    return `Enforcement guards match the installed Lisa version; ${ignored.length} not assessed (.lisaignore): ${ignored.join(", ")}${suffix}`;
+  }
+  return `Enforcement guards match the installed Lisa version${suffix}`;
+}
+
+/**
+ * Render copy provenance in one operator-readable fragment.
+ * @param multiCopies - Multi-copy artifact reports
+ * @param includeHeading - Include the generic provenance heading
+ * @returns Detail text for multi-copy provenance
+ */
+function renderCopyReports(
+  multiCopies: readonly MultiCopyArtifact[],
+  includeHeading = true
+): string {
+  if (multiCopies.length === 0) return "";
+  const reports = multiCopies
+    .map(
+      artifact =>
+        `${artifact.destination} governed by ${artifact.copies.find(copy => copy.governs)?.location ?? "unknown"} first (${artifact.copies
+          .map(
+            copy =>
+              `${copy.location}@${copy.version}${copy.governs ? " governs" : ""}`
+          )
+          .join(", ")})`
+    )
+    .join("; ");
+  return includeHeading
+    ? `Resolvable Lisa-owned artifact copies: ${reports}`
+    : reports;
 }
 
 /**

--- a/src/cli/doctor-lisa-owned-artifacts.ts
+++ b/src/cli/doctor-lisa-owned-artifacts.ts
@@ -16,7 +16,6 @@
  * @module cli/doctor-lisa-owned-artifacts
  */
 import { readFile } from "node:fs/promises";
-import { createHash } from "node:crypto";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import * as fse from "fs-extra";
@@ -34,6 +33,10 @@ import {
   matchesAnyPattern,
   parseIgnorePatterns,
 } from "../utils/ignore-patterns.js";
+import {
+  describeResolvableCopies,
+  type MultiCopyArtifact,
+} from "./doctor-lisa-owned-artifact-copies.js";
 
 const CHECK_NAME = "Lisa enforcement artifacts current?";
 const COPY_OVERWRITE = "copy-overwrite";
@@ -55,20 +58,6 @@ interface ArtifactCheck {
 
 /** One shipped Lisa-owned artifact and the destination it installs to. */
 type ShippedArtifact = readonly [destination: string, source: string];
-
-/** A resolved Lisa-owned artifact copy. */
-interface ResolvedArtifactCopy {
-  readonly location: string;
-  readonly version: string;
-  readonly governs: boolean;
-}
-
-/** Provenance for an artifact that is reachable from more than one place. */
-interface MultiCopyArtifact {
-  readonly destination: string;
-  readonly copies: readonly ResolvedArtifactCopy[];
-  readonly disagrees: boolean;
-}
 
 /** Per-destination assessment before it is folded into one doctor line. */
 interface ArtifactAssessment {
@@ -156,59 +145,6 @@ async function matchesAnyShipped(
 }
 
 /**
- * Short content identity for a resolved artifact copy.
- * @param bytes - File contents
- * @returns Human-sized content version
- */
-function artifactVersion(bytes: Buffer): string {
-  return `sha256:${createHash("sha256").update(bytes).digest("hex").slice(0, 12)}`;
-}
-
-/**
- * Report all resolvable copies for one installed Lisa-owned artifact.
- *
- * The project copy is listed as governing first because Lisa's documented hook
- * and script invocations run the installed project path. Package templates are
- * still listed because they are also reachable and are the source apply uses.
- * @param targetPath - Project path being inspected
- * @param lisaRoot - Installed Lisa package root
- * @param destination - Project-relative artifact destination
- * @param installed - Bytes currently installed in the project
- * @param sources - Absolute paths of shipped package variants
- * @returns Multi-copy provenance, or undefined for a single-copy artifact
- */
-async function describeResolvableCopies(
-  targetPath: string,
-  lisaRoot: string,
-  destination: string,
-  installed: Buffer,
-  sources: readonly string[]
-): Promise<MultiCopyArtifact | undefined> {
-  if (sources.length === 0) return undefined;
-  const shipped = await Promise.all(
-    sources.map(async source => [source, await readFile(source)] as const)
-  );
-  const copies: ResolvedArtifactCopy[] = [
-    {
-      location: `project:${destination}`,
-      version: artifactVersion(installed),
-      governs: true,
-    },
-    ...shipped.map(([source, bytes]) => ({
-      location: `package:${path.relative(lisaRoot, source).split(path.sep).join("/")}`,
-      version: artifactVersion(bytes),
-      governs: false,
-    })),
-  ];
-  const versions = new Set(copies.map(copy => copy.version));
-  return {
-    destination,
-    copies,
-    disagrees: versions.size > 1,
-  };
-}
-
-/**
  * Whether the installed file is a trampoline that re-exports the shipped
  * template instead of copying it.
  *
@@ -282,45 +218,17 @@ export async function checkLisaOwnedArtifacts(
 
   const results: readonly (ArtifactAssessment | undefined)[] =
     await Promise.all(
-      [...shipped].map(async ([destination, sources]) => {
-        // Ignored is UNASSESSED, not clean. Reported as such below, because a
-        // `.lisaignore` entry on a Lisa-owned guard suppresses the divergence
-        // warning while changing nothing about the divergence — and the ok line
-        // then states conformance that was never established.
-        if (matchesAnyPattern(destination, ignorePatterns))
-          return {
-            finding: [destination, "ignored"] as const,
-          } satisfies ArtifactAssessment;
-        const installedPath = path.join(targetPath, destination);
-        const installed = await readFile(installedPath).catch(() => undefined);
-        if (installed === undefined) return undefined;
-        const multiCopy = await describeResolvableCopies(
+      [...shipped].map(async ([destination, sources]) =>
+        assessArtifact(
           targetPath,
           lisaRoot,
           destination,
-          installed,
-          sources
-        );
-        if (await matchesAnyShipped(installed, sources))
-          return multiCopy === undefined
-            ? undefined
-            : ({ multiCopy } satisfies ArtifactAssessment);
-        if (
-          selfHost &&
-          reExportsShippedTemplate(installed, installedPath, sources)
-        )
-          return undefined;
-        const outdated = await isProvablyStale(
-          installed,
-          destination,
           sources,
+          ignorePatterns,
+          selfHost,
           ledger
-        );
-        const finding = [destination, outdated ? "stale" : "modified"] as const;
-        return multiCopy === undefined
-          ? ({ finding } satisfies ArtifactAssessment)
-          : ({ finding, multiCopy } satisfies ArtifactAssessment);
-      })
+        )
+      )
     );
   const assessments = results.filter(
     (item): item is ArtifactAssessment => item !== undefined
@@ -333,6 +241,74 @@ export async function checkLisaOwnedArtifacts(
       .map(item => item.multiCopy)
       .filter((item): item is MultiCopyArtifact => item !== undefined)
   );
+}
+
+/**
+ * Assess one installed Lisa-owned artifact destination.
+ * @param targetPath - Project path to inspect
+ * @param lisaRoot - Installed Lisa package root
+ * @param destination - Project-relative artifact destination
+ * @param sources - Absolute shipped package variants
+ * @param ignorePatterns - Parsed .lisaignore patterns
+ * @param selfHost - Whether the target is Lisa's own source repository
+ * @param ledger - Known-good hashes, defaulting to Lisa's shipping history
+ * @returns Per-artifact assessment, or undefined when no installed copy exists
+ */
+async function assessArtifact(
+  targetPath: string,
+  lisaRoot: string,
+  destination: string,
+  sources: readonly string[],
+  ignorePatterns: readonly string[],
+  selfHost: boolean,
+  ledger?: HashLedger
+): Promise<ArtifactAssessment | undefined> {
+  const installedPath = path.join(targetPath, destination);
+  const installed = await readFile(installedPath).catch(() => undefined);
+  const ignored = matchesAnyPattern(destination, ignorePatterns);
+  if (installed === undefined) {
+    return ignored
+      ? ({
+          finding: [destination, "ignored"] as const,
+        } satisfies ArtifactAssessment)
+      : undefined;
+  }
+  const multiCopy = await describeResolvableCopies(
+    lisaRoot,
+    destination,
+    installed,
+    sources
+  );
+  if (ignored) return withMultiCopy([destination, "ignored"], multiCopy);
+  if (await matchesAnyShipped(installed, sources)) {
+    return multiCopy === undefined ? undefined : { multiCopy };
+  }
+  if (selfHost && reExportsShippedTemplate(installed, installedPath, sources)) {
+    return undefined;
+  }
+  const outdated = await isProvablyStale(
+    installed,
+    destination,
+    sources,
+    ledger
+  );
+  return withMultiCopy(
+    [destination, outdated ? "stale" : "modified"],
+    multiCopy
+  );
+}
+
+/**
+ * Attach optional multi-copy provenance without materialising undefined fields.
+ * @param finding - Artifact finding tuple
+ * @param multiCopy - Optional multi-copy provenance
+ * @returns Artifact assessment
+ */
+function withMultiCopy(
+  finding: readonly [string, Finding],
+  multiCopy: MultiCopyArtifact | undefined
+): ArtifactAssessment {
+  return multiCopy === undefined ? { finding } : { finding, multiCopy };
 }
 
 /** Which finding an artifact produced. */
@@ -359,7 +335,11 @@ function summarise(
   const ignored = pick("ignored");
   const copyDisagreements = multiCopies.filter(copy => copy.disagrees);
   const copyReports = renderCopyReports(multiCopies);
-  if (hasNoWarnings(stale, modified, copyDisagreements)) {
+  const warningFree =
+    stale.length === 0 &&
+    modified.length === 0 &&
+    copyDisagreements.length === 0;
+  if (warningFree) {
     // Named rather than folded into the pass. A guard excluded by
     // `.lisaignore` was never compared, so claiming it matches asserts
     // something no comparison established — and the file it most often hides
@@ -372,6 +352,9 @@ function summarise(
   }
 
   const parts = [
+    ignored.length > 0
+      ? `${ignored.length} not assessed (.lisaignore): ${ignored.join(", ")}`
+      : "",
     stale.length > 0
       ? `Outdated Lisa-owned guards (run \`npx lisa apply .\` to refresh): ${stale.join(", ")}`
       : "",
@@ -383,25 +366,6 @@ function summarise(
       : "",
   ].filter(part => part.length > 0);
   return { name: CHECK_NAME, status: "warn", detail: parts.join(". ") };
-}
-
-/**
- * Whether the accumulated artifact state is warning-free.
- * @param stale - Outdated artifacts
- * @param modified - Host-modified artifacts
- * @param copyDisagreements - Multi-copy artifacts with differing content
- * @returns True when the doctor line can remain OK
- */
-function hasNoWarnings(
-  stale: readonly string[],
-  modified: readonly string[],
-  copyDisagreements: readonly MultiCopyArtifact[]
-): boolean {
-  return (
-    stale.length === 0 &&
-    modified.length === 0 &&
-    copyDisagreements.length === 0
-  );
 }
 
 /**

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8215,6 +8215,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/doctor-learnings-ledger.ts": true,
     "src/cli/doctor-learnings-merge-driver.ts": true,
     "src/cli/doctor-legacy-overlay.ts": true,
+    "src/cli/doctor-lisa-owned-artifact-copies.ts": true,
     "src/cli/doctor-lisa-owned-artifacts.ts": true,
     "src/cli/doctor-monitor-thresholds.ts": true,
     "src/cli/doctor-readiness-action-pins.ts": true,

--- a/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
+++ b/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
@@ -17,8 +17,10 @@ import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
 
 const GUARD = "scripts/lisa-hooks/block-no-verify.sh";
 const HOST_CONFIG = "tsconfig.json";
+const GENERATED_ARTIFACT = "scripts/lisa-new-artifact.mjs";
 const SHIPPED_GUARD = "#!/usr/bin/env bash\n# closed\n";
 const OLD_GUARD = "#!/usr/bin/env bash\n# fails open\n";
+const SHIPPED_GENERATED = "export const governed = true;\n";
 const ENTRYPOINT = "scripts/lisa-work-item.mjs";
 const LISA_PACKAGE = '{"name":"@codyswann/lisa"}';
 const HOST_PACKAGE = '{"name":"some-host-app"}';
@@ -149,6 +151,13 @@ describe("checkLisaOwnedArtifacts", () => {
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
     expect(check.status).toBe(OK);
+    expect(check.detail).toContain("Resolvable Lisa-owned artifact copies");
+    expect(check.detail).toContain(`project:${GUARD}@sha256:`);
+    expect(check.detail).toContain(
+      `package:all/copy-overwrite/${GUARD}@sha256:`
+    );
+    expect(check.detail).toContain(`project:${GUARD}@sha256:`);
+    expect(check.detail).toContain("governs");
   });
 
   it("passes when the project never installed the guard", async () => {
@@ -156,6 +165,46 @@ describe("checkLisaOwnedArtifacts", () => {
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
     expect(check.status).toBe(OK);
+    expect(check.detail).not.toContain("Resolvable Lisa-owned artifact copies");
+  });
+
+  it("warns when resolvable Lisa-owned artifact copies disagree", async () => {
+    await fs.outputFile(path.join(projectDir, GUARD), OLD_GUARD);
+
+    const check = await checkLisaOwnedArtifacts(
+      projectDir,
+      lisaRoot,
+      shippedLedger()
+    );
+
+    expect(check.status).toBe(WARN);
+    expect(check.detail).toContain(
+      "Resolvable Lisa-owned artifact copies disagree"
+    );
+    expect(check.detail).toContain(`project:${GUARD}@sha256:`);
+    expect(check.detail).toContain(
+      `package:all/copy-overwrite/${GUARD}@sha256:`
+    );
+    expect(check.detail).toContain("governed by project:");
+  });
+
+  it("discovers newly shipped Lisa-owned artifacts from copy-overwrite sources", async () => {
+    await fs.outputFile(
+      path.join(lisaRoot, "typescript", "copy-overwrite", GENERATED_ARTIFACT),
+      SHIPPED_GENERATED
+    );
+    await fs.outputFile(
+      path.join(projectDir, GENERATED_ARTIFACT),
+      SHIPPED_GENERATED
+    );
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe(OK);
+    expect(check.detail).toContain(GENERATED_ARTIFACT);
+    expect(check.detail).toContain(
+      `package:typescript/copy-overwrite/${GENERATED_ARTIFACT}@sha256:`
+    );
   });
 
   it("ignores drift in host-owned managed config", async () => {

--- a/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
+++ b/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
@@ -21,6 +21,9 @@ const GENERATED_ARTIFACT = "scripts/lisa-new-artifact.mjs";
 const SHIPPED_GUARD = "#!/usr/bin/env bash\n# closed\n";
 const OLD_GUARD = "#!/usr/bin/env bash\n# fails open\n";
 const SHIPPED_GENERATED = "export const governed = true;\n";
+const SHIPPED_GUARD_VERSION = "sha256:1f8d79a5e303";
+const OLD_GUARD_VERSION = "sha256:5708bbd8b37f";
+const SHIPPED_GENERATED_VERSION = "sha256:c534dbb9ff9e";
 const ENTRYPOINT = "scripts/lisa-work-item.mjs";
 const LISA_PACKAGE = '{"name":"@codyswann/lisa"}';
 const HOST_PACKAGE = '{"name":"some-host-app"}';
@@ -152,12 +155,13 @@ describe("checkLisaOwnedArtifacts", () => {
 
     expect(check.status).toBe(OK);
     expect(check.detail).toContain("Resolvable Lisa-owned artifact copies");
-    expect(check.detail).toContain(`project:${GUARD}@sha256:`);
+    expect(check.detail).toContain(`governed by project:${GUARD} first`);
     expect(check.detail).toContain(
-      `package:all/copy-overwrite/${GUARD}@sha256:`
+      `project:${GUARD}@${SHIPPED_GUARD_VERSION} governs`
     );
-    expect(check.detail).toContain(`project:${GUARD}@sha256:`);
-    expect(check.detail).toContain("governs");
+    expect(check.detail).toContain(
+      `package:all/copy-overwrite/${GUARD}@${SHIPPED_GUARD_VERSION}`
+    );
   });
 
   it("passes when the project never installed the guard", async () => {
@@ -181,11 +185,13 @@ describe("checkLisaOwnedArtifacts", () => {
     expect(check.detail).toContain(
       "Resolvable Lisa-owned artifact copies disagree"
     );
-    expect(check.detail).toContain(`project:${GUARD}@sha256:`);
+    expect(check.detail).toContain(`governed by project:${GUARD} first`);
     expect(check.detail).toContain(
-      `package:all/copy-overwrite/${GUARD}@sha256:`
+      `project:${GUARD}@${OLD_GUARD_VERSION} governs`
     );
-    expect(check.detail).toContain("governed by project:");
+    expect(check.detail).toContain(
+      `package:all/copy-overwrite/${GUARD}@${SHIPPED_GUARD_VERSION}`
+    );
   });
 
   it("discovers newly shipped Lisa-owned artifacts from copy-overwrite sources", async () => {
@@ -203,7 +209,10 @@ describe("checkLisaOwnedArtifacts", () => {
     expect(check.status).toBe(OK);
     expect(check.detail).toContain(GENERATED_ARTIFACT);
     expect(check.detail).toContain(
-      `package:typescript/copy-overwrite/${GENERATED_ARTIFACT}@sha256:`
+      `project:${GENERATED_ARTIFACT}@${SHIPPED_GENERATED_VERSION} governs`
+    );
+    expect(check.detail).toContain(
+      `package:typescript/copy-overwrite/${GENERATED_ARTIFACT}@${SHIPPED_GENERATED_VERSION}`
     );
   });
 
@@ -218,8 +227,10 @@ describe("checkLisaOwnedArtifacts", () => {
     expect(check.status).toBe(OK);
   });
 
-  it("respects .lisaignore", async () => {
-    // A project that deliberately holds its own copy said so already.
+  it("keeps .lisaignore unassessed while still reporting copy disagreement", async () => {
+    // A project that deliberately holds its own copy said so already, but the
+    // operator still needs to know there are multiple resolvable copies and
+    // which one the documented invocation path reaches.
     await fs.outputFile(path.join(projectDir, GUARD), OLD_GUARD);
     await fs.outputFile(
       path.join(projectDir, ".lisaignore"),
@@ -228,7 +239,14 @@ describe("checkLisaOwnedArtifacts", () => {
 
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
-    expect(check.status).toBe(OK);
+    expect(check.status).toBe(WARN);
+    expect(check.detail).toContain("not assessed (.lisaignore)");
+    expect(check.detail).toContain(
+      "Resolvable Lisa-owned artifact copies disagree"
+    );
+    expect(check.detail).toContain(
+      `project:${GUARD}@${OLD_GUARD_VERSION} governs`
+    );
   });
 
   describe("when the project is Lisa's own repository", () => {


### PR DESCRIPTION
## Summary
- Extend `lisa doctor` Lisa-owned artifact checks to report every resolvable project/package copy with short content hashes.
- Name the project-installed copy as the governing invocation path and warn when copies disagree, including ignored artifacts.
- Add regression coverage for matching copies, disagreeing copies, ignored disagreements, and newly shipped artifacts discovered from copy-overwrite sources.

## Verification
- `bun test tests/unit/cli/doctor-lisa-owned-artifacts.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run build:dist`
- `bun run check:artifacts`
- `node dist/index.js doctor . --json --offline | jq '.checks[] | select(.name == "Lisa enforcement artifacts current?")'`
- push gates: `test:cov`, `test:integration`, `lint:slow`, `knip:check`, `typecheck`, artifact freshness, plugin parity/routing

Work-Item: CodySwannGT/lisa#2639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced artifact diagnostics to track installed and available copies, including locations, versions, and the governing copy.
  * Added warnings when artifact copies disagree, preventing an otherwise successful diagnostic result.
  * Improved discovery of nested overwrite copies and handling of ignored artifacts.

* **Bug Fixes**
  * Preserved accurate reporting for stale, modified, current, missing, and trampoline artifacts.
  * Missing artifacts remain unresolved without unnecessary diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->