### PR TITLE
fix: report and guard self-reference override rewrites

### DIFF
--- a/src/core/lisa.ts
+++ b/src/core/lisa.ts
@@ -1964,6 +1964,7 @@ export class Lisa {
           `Would copy: ${result.relativePath}`,
           `Copied: ${result.relativePath}`
         );
+        this.logNote(result);
         break;
       case "created":
         this.logMessage(
@@ -2004,7 +2005,20 @@ export class Lisa {
           `Would merge: ${result.relativePath}`,
           `Merged: ${result.relativePath}`
         );
+        if (result.note !== undefined) {
+          this.logNote(result);
+        }
         break;
+    }
+  }
+
+  /**
+   * Log an optional operation note.
+   * @param result Operation result that may carry an operator-readable note
+   */
+  private logNote(result: FileOperationResult): void {
+    if (result.note !== undefined) {
+      this.deps.logger.info(result.note);
     }
   }
 

--- a/src/strategies/package-lisa.ts
+++ b/src/strategies/package-lisa.ts
@@ -295,16 +295,15 @@ export class PackageLisaStrategy implements ICopyStrategy {
    * and remove. Used during skip-git-check (postinstall) applies so dependency
    * pins still apply without clobbering host config.
    *
-   * The retained overrides/resolutions may contain `$name` self-references,
-   * which npm resolves against a direct dependency of that name. If the project
-   * lacks that direct dep, `npm ci` fails in CI with a dangling $ref. So we also
-   * pull the referenced package's forced pin from force.dependencies /
-   * force.devDependencies into the restricted set, materializing the backing
-   * direct dependency alongside the override. Force devDeps that back no $ref
-   * are still dropped, preserving the host's own dev-dep versions.
+   * The retained overrides/resolutions may contain `$name` self-references or
+   * literal pins that normalize to `$name` later. Both resolve against a direct
+   * dependency of that name. If the restricted template drops the backing direct
+   * dep, postinstall can validate against the host's wider range and fail the
+   * normalization guard. So we also pull the package's forced pin from
+   * force.dependencies / force.devDependencies into the restricted set.
    * @param template - Fully merged template from the type hierarchy
    * @returns Template carrying force.resolutions/force.overrides plus the direct
-   *   dependencies that back any `$name` reference within them
+   *   dependencies that back any direct-dependency override within them
    * @private
    */
   private restrictToSecurityPins(
@@ -322,11 +321,11 @@ export class PackageLisaStrategy implements ICopyStrategy {
   }
 
   /**
-   * For every `$name` reference in the restricted overrides/resolutions, copy
-   * the forced pin for `name` from the full template's force.dependencies /
-   * force.devDependencies into the restricted force section so the backing
-   * direct dependency is materialized. A devDependencies pin wins over a
-   * dependencies pin when both exist.
+   * For every direct-dependency override in the restricted overrides/resolutions,
+   * copy the forced pin for `name` from the full template's force.dependencies /
+   * force.devDependencies into the restricted force section so the backing direct
+   * dependency is materialized. A devDependencies pin wins over dependencies when
+   * both exist.
    * @param template - Fully merged template (source of the forced dep pins)
    * @param force - Restricted force section being assembled (mutated in place)
    * @private
@@ -335,32 +334,40 @@ export class PackageLisaStrategy implements ICopyStrategy {
     template: ResolvedPackageLisaTemplate,
     force: Record<string, unknown>
   ): void {
-    const referenced = collectDollarReferences([
-      force.resolutions,
-      force.overrides,
+    const referenced = new Set([
+      ...collectDollarReferences([force.resolutions, force.overrides]),
+      ...collectLiteralOverrideNames([force.resolutions, force.overrides]),
     ]);
     if (referenced.size === 0) {
       return;
     }
     const forceDeps = asRecord(template.force.dependencies);
     const forceDevDeps = asRecord(template.force.devDependencies);
+    const backed = Array.from(referenced).filter(
+      name => forceDevDeps[name] !== undefined || forceDeps[name] !== undefined
+    );
+    if (backed.length === 0) {
+      return;
+    }
     const deps: Record<string, unknown> = {};
     const devDeps: Record<string, unknown> = {};
-    for (const name of referenced) {
+    for (const name of backed) {
       if (forceDevDeps[name] !== undefined) {
         devDeps[name] = forceDevDeps[name];
-      } else if (forceDeps[name] !== undefined) {
+      } else {
         deps[name] = forceDeps[name];
       }
     }
     if (Object.keys(devDeps).length > 0) {
-      force.devDependencies = devDeps;
+      force.devDependencies = {
+        ...asRecord(force.devDependencies),
+        ...devDeps,
+      };
     }
     if (Object.keys(deps).length > 0) {
-      force.dependencies = deps;
+      force.dependencies = { ...asRecord(force.dependencies), ...deps };
     }
   }
-
   /**
    * Detect which project types apply to this project
    * (TypeScript, Expo, NestJS, CDK, Harper/Fabric, npm-package)
@@ -1082,6 +1089,26 @@ function collectRefsFromValue(value: unknown): readonly string[] {
  */
 function collectDollarReferences(sections: readonly unknown[]): Set<string> {
   return new Set(sections.flatMap(collectRefsFromValue));
+}
+
+/**
+ * Collect top-level literal override keys that may later normalize to `$name`.
+ * @param sections - Override/resolution sections to inspect
+ * @returns Set of package names with non-empty literal string entries
+ */
+function collectLiteralOverrideNames(
+  sections: readonly unknown[]
+): Set<string> {
+  return new Set(
+    sections.flatMap(section => {
+      const entries = asRecord(section);
+      return Object.entries(entries).flatMap(([name, value]) =>
+        typeof value === "string" && value.length > 0 && !value.startsWith("$")
+          ? [name]
+          : []
+      );
+    })
+  );
 }
 
 /**

--- a/src/strategies/package-lisa.ts
+++ b/src/strategies/package-lisa.ts
@@ -20,6 +20,20 @@ import type {
   ResolvedPackageLisaTemplate,
 } from "./package-lisa-types.js";
 
+/** Planned package.json content plus messages the operator should see. */
+interface PackageJsonPlan {
+  readonly packageJson: Record<string, unknown>;
+  readonly notes: readonly string[];
+}
+
+/** One override/resolution entry that will be rewritten to a `$name` reference. */
+interface OverrideRewrite {
+  readonly section: "overrides" | "resolutions";
+  readonly name: string;
+  readonly literalRange: string;
+  readonly directRange: string;
+}
+
 /**
  * @file package-lisa.ts
  * @description Package.lisa.json strategy for governance-driven package.json management
@@ -79,11 +93,12 @@ export class PackageLisaStrategy implements ICopyStrategy {
       securityPinsOnly || projectJson.name === LISA_PACKAGE_NAME
         ? this.restrictToSecurityPins(merged)
         : merged;
-    const result = normalizeSelfReferencingOverrides(
-      this.applyTemplate(projectJson, effective)
+    const result = planSelfReferencingOverrideNormalization(
+      this.applyTemplate(projectJson, effective),
+      this.PACKAGE_JSON
     );
-    assertNoDanglingDollarRefs(result, this.PACKAGE_JSON);
-    return result;
+    assertNoDanglingDollarRefs(result.packageJson, this.PACKAGE_JSON);
+    return result.packageJson;
   }
 
   /**
@@ -133,7 +148,7 @@ export class PackageLisaStrategy implements ICopyStrategy {
 
     try {
       // Load templates and apply to package.json
-      const merged = await this.mergePackageJson(
+      const plan = await this.mergePackageJson(
         actualDestPath,
         context,
         securityPinsOnly
@@ -142,17 +157,19 @@ export class PackageLisaStrategy implements ICopyStrategy {
       if (!destExists) {
         return this.createDestination(
           actualDestPath,
-          merged,
+          plan.packageJson,
           actualRelativePath,
-          context
+          context,
+          plan.notes
         );
       }
 
       return this.updateDestination(
         actualDestPath,
-        merged,
+        plan.packageJson,
         actualRelativePath,
-        context
+        context,
+        plan.notes
       );
     } catch (error) {
       if (error instanceof JsonMergeError) {
@@ -171,6 +188,7 @@ export class PackageLisaStrategy implements ICopyStrategy {
    * @param merged - Merged package.json object
    * @param relativePath - Relative path for recording
    * @param context - Strategy context with config and callbacks
+   * @param notes - Operator-visible notes explaining non-obvious rewrites
    * @returns Result with action "copied"
    * @private
    */
@@ -178,13 +196,19 @@ export class PackageLisaStrategy implements ICopyStrategy {
     destPath: string,
     merged: Record<string, unknown>,
     relativePath: string,
-    context: StrategyContext
+    context: StrategyContext,
+    notes: readonly string[] = []
   ): Promise<FileOperationResult> {
     if (!context.config.dryRun) {
       await ensureParentDir(destPath);
       await writeJson(destPath, merged);
     }
-    return { relativePath, strategy: this.name, action: "copied" };
+    const result: FileOperationResult = {
+      relativePath,
+      strategy: this.name,
+      action: "copied",
+    };
+    return notes.length > 0 ? { ...result, note: notes.join("; ") } : result;
   }
 
   /**
@@ -193,6 +217,7 @@ export class PackageLisaStrategy implements ICopyStrategy {
    * @param merged - Merged package.json object
    * @param relativePath - Relative path for recording
    * @param context - Strategy context with config and callbacks
+   * @param notes - Operator-visible notes explaining non-obvious rewrites
    * @returns Result with action "merged" or "skipped"
    * @private
    */
@@ -200,7 +225,8 @@ export class PackageLisaStrategy implements ICopyStrategy {
     destPath: string,
     merged: Record<string, unknown>,
     relativePath: string,
-    context: StrategyContext
+    context: StrategyContext,
+    notes: readonly string[] = []
   ): Promise<FileOperationResult> {
     const originalJson = await readJson<Record<string, unknown>>(destPath);
 
@@ -217,7 +243,12 @@ export class PackageLisaStrategy implements ICopyStrategy {
       await writeJson(destPath, merged);
     }
 
-    return { relativePath, strategy: this.name, action: "merged" };
+    const result: FileOperationResult = {
+      relativePath,
+      strategy: this.name,
+      action: "merged",
+    };
+    return notes.length > 0 ? { ...result, note: notes.join("; ") } : result;
   }
 
   /**
@@ -226,14 +257,14 @@ export class PackageLisaStrategy implements ICopyStrategy {
    * @param context - Strategy context with Lisa config
    * @param securityPinsOnly - When true (skip-git-check on an existing package.json),
    *   apply only force.resolutions/force.overrides and preserve all other host config
-   * @returns Merged package.json object
+   * @returns Planned package.json object plus operator-visible notes
    * @private
    */
   private async mergePackageJson(
     packageJsonPath: string,
     context: StrategyContext,
     securityPinsOnly = false
-  ): Promise<Record<string, unknown>> {
+  ): Promise<PackageJsonPlan> {
     // Try to read existing package.json, or start with empty object
     const projectJson =
       (await readJsonOrNull<Record<string, unknown>>(packageJsonPath)) || {};
@@ -245,12 +276,17 @@ export class PackageLisaStrategy implements ICopyStrategy {
     // Get detected project types by analyzing the project structure
     const detectedTypes = await this.detectProjectTypes(projectDir);
 
-    return this.planPackageJson(
-      projectJson,
-      detectedTypes,
-      lisaDir,
-      securityPinsOnly
+    const merged = await this.loadAndMergeTemplates(lisaDir, detectedTypes);
+    const effective =
+      securityPinsOnly || projectJson.name === LISA_PACKAGE_NAME
+        ? this.restrictToSecurityPins(merged)
+        : merged;
+    const plan = planSelfReferencingOverrideNormalization(
+      this.applyTemplate(projectJson, effective),
+      this.PACKAGE_JSON
     );
+    assertNoDanglingDollarRefs(plan.packageJson, this.PACKAGE_JSON);
+    return plan;
   }
 
   /**
@@ -861,22 +897,24 @@ function rangeFloor(range: string): string | null {
  * left untouched. Overrides for packages that are NOT direct dependencies are
  * also left as literals — those are legitimate transitive pins.
  * @param pkg - Merged package.json about to be persisted
- * @returns A package.json with self-referencing overrides normalized (a shallow
- *   copy is returned only when a rewrite was needed; otherwise the input)
+ * @param fileName - Basename used in error messages
+ * @throws JsonMergeError when a rewrite would make the effective override wider
+ *   than the literal constraint it replaced.
+ * @returns Planned package.json plus operator-visible notes.
  */
-function normalizeSelfReferencingOverrides(
-  pkg: Record<string, unknown>
-): Record<string, unknown> {
+function planSelfReferencingOverrideNormalization(
+  pkg: Record<string, unknown>,
+  fileName: string
+): PackageJsonPlan {
   const directDeps = collectDirectDependencyNames(pkg);
   if (directDeps.size === 0) {
-    return pkg;
+    return { packageJson: pkg, notes: [] };
   }
-  const needsRewrite = (name: string, value: unknown): boolean =>
-    directDeps.has(name) &&
-    typeof value === "string" &&
-    value.length > 0 &&
-    !value.startsWith("$");
-  const rewrites = OVERRIDE_SECTIONS.reduce<Record<string, unknown>>(
+  const directRanges = collectDirectDependencyRanges(pkg);
+  const rewritePlan = OVERRIDE_SECTIONS.reduce<{
+    readonly sections: Record<string, unknown>;
+    readonly rewrites: readonly OverrideRewrite[];
+  }>(
     (acc, section) => {
       const entries = pkg[section];
       if (
@@ -887,19 +925,119 @@ function normalizeSelfReferencingOverrides(
         return acc;
       }
       const pairs = Object.entries(entries);
-      if (!pairs.some(([name, value]) => needsRewrite(name, value))) {
+      const sectionRewrites = pairs.flatMap(([name, value]) => {
+        if (!needsSelfReferenceRewrite(directDeps, name, value)) {
+          return [];
+        }
+        const directRange = directRanges.get(name);
+        if (directRange === undefined) {
+          return [];
+        }
+        const literalRange = value as string;
+        assertSelfReferenceRewriteDoesNotWiden(
+          fileName,
+          section,
+          name,
+          literalRange,
+          directRange
+        );
+        return [{ section, name, literalRange, directRange }];
+      });
+      if (sectionRewrites.length === 0) {
         return acc;
       }
       const normalized = Object.fromEntries(
         pairs.map(([name, value]) =>
-          needsRewrite(name, value) ? [name, `$${name}`] : [name, value]
+          sectionRewrites.some(rewrite => rewrite.name === name)
+            ? [name, `$${name}`]
+            : [name, value]
         )
       );
-      return { ...acc, [section]: normalized };
+      return {
+        sections: { ...acc.sections, [section]: normalized },
+        rewrites: [...acc.rewrites, ...sectionRewrites],
+      };
     },
-    {}
+    { sections: {}, rewrites: [] }
   );
-  return Object.keys(rewrites).length > 0 ? { ...pkg, ...rewrites } : pkg;
+  const packageJson =
+    Object.keys(rewritePlan.sections).length > 0
+      ? { ...pkg, ...rewritePlan.sections }
+      : pkg;
+  return {
+    packageJson,
+    notes: rewritePlan.rewrites.map(formatSelfReferenceRewriteNote),
+  };
+}
+
+/**
+ * Decide whether an override/resolution entry needs npm `$name` normalization.
+ * @param directDeps - Direct dependency names in the merged package
+ * @param name - Override/resolution key
+ * @param value - Override/resolution value
+ * @returns True when the entry is a literal direct-dependency collision
+ */
+function needsSelfReferenceRewrite(
+  directDeps: ReadonlySet<string>,
+  name: string,
+  value: unknown
+): boolean {
+  return (
+    directDeps.has(name) &&
+    typeof value === "string" &&
+    value.length > 0 &&
+    !value.startsWith("$")
+  );
+}
+
+/**
+ * Refuse a `$name` rewrite unless the direct dependency range is no wider.
+ * @param fileName - Basename used in error messages
+ * @param section - Override section carrying the entry
+ * @param name - Package name being rewritten
+ * @param literalRange - Literal override/resolution range to replace
+ * @param directRange - Direct dependency range `$name` would resolve to
+ * @throws JsonMergeError when the rewrite is unprovable or widening
+ */
+function assertSelfReferenceRewriteDoesNotWiden(
+  fileName: string,
+  section: OverrideRewrite["section"],
+  name: string,
+  literalRange: string,
+  directRange: string
+): void {
+  if (!semver.validRange(literalRange) || !semver.validRange(directRange)) {
+    throw new JsonMergeError(
+      fileName,
+      `${section}.${name} cannot be rewritten to "$${name}" because Lisa ` +
+        `cannot prove the direct dependency range ${JSON.stringify(directRange)} ` +
+        `is no wider than the literal override ${JSON.stringify(literalRange)}.`
+    );
+  }
+  if (!semver.subset(directRange, literalRange)) {
+    throw new JsonMergeError(
+      fileName,
+      `${section}.${name} would widen if rewritten to "$${name}": the literal ` +
+        `override ${JSON.stringify(literalRange)} would resolve to direct ` +
+        `dependency range ${JSON.stringify(directRange)}. Pin the direct ` +
+        `dependency to ${JSON.stringify(literalRange)} or choose a direct range ` +
+        `that is no wider than the override.`
+    );
+  }
+}
+
+/**
+ * Format the operator-visible explanation for a safe `$name` rewrite.
+ * @param rewrite - Rewrite metadata
+ * @returns Human-readable note for apply output
+ */
+function formatSelfReferenceRewriteNote(rewrite: OverrideRewrite): string {
+  return (
+    `Normalized ${rewrite.section}.${rewrite.name}: replaced literal ` +
+    `${JSON.stringify(rewrite.literalRange)} with "$${rewrite.name}" ` +
+    `resolving to direct dependency range ` +
+    `${JSON.stringify(rewrite.directRange)}.`
+  );
 }
 
 /**
@@ -958,6 +1096,23 @@ function collectDirectDependencyNames(
   return new Set(
     DIRECT_DEPENDENCY_SECTIONS.flatMap(section =>
       Object.keys(asRecord(pkg[section]))
+    )
+  );
+}
+
+/**
+ * Collect direct dependency ranges by package name.
+ * @param pkg - Merged package.json object
+ * @returns Package name to string range map
+ */
+function collectDirectDependencyRanges(
+  pkg: Record<string, unknown>
+): ReadonlyMap<string, string> {
+  return new Map(
+    DIRECT_DEPENDENCY_SECTIONS.flatMap(section =>
+      Object.entries(asRecord(pkg[section])).flatMap(([name, value]) =>
+        typeof value === "string" ? [[name, value] as const] : []
+      )
     )
   );
 }

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -306,6 +306,44 @@ describe("PackageLisaStrategy", () => {
       expect(content.devDependencies.oxlint).toBe("^0.1.0");
     });
 
+    it("keeps forced direct deps that back literal override normalization under skip-git-check", async () => {
+      await createPackageLisaTemplate("typescript", {
+        force: {
+          overrides: { prettier: "3.8.3" },
+          scripts: { test: "lisa test" },
+          devDependencies: { prettier: "3.8.3", oxlint: "^1.0.0" },
+        },
+      });
+
+      const sourcePath = path.join(
+        lisaDir,
+        "typescript",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.json");
+      await createTypeScriptProject(projectDir);
+      await fs.writeJson(destPath, {
+        name: "host-project",
+        scripts: { test: "host test" },
+        devDependencies: { prettier: "^3.3.3", oxlint: "^0.1.0" },
+      });
+
+      const result = await strategy.apply(
+        sourcePath,
+        destPath,
+        "package.json",
+        createContext({ skipGitCheck: true })
+      );
+
+      expect(result.action).toBe("merged");
+      const content = await fs.readJson(destPath);
+      expect(content.overrides.prettier).toBe("$prettier");
+      expect(content.devDependencies.prettier).toBe("3.8.3");
+      expect(content.devDependencies.oxlint).toBe("^0.1.0");
+      expect(content.scripts.test).toBe("host test");
+    });
+
     // Regression: force.resolutions/force.overrides are a security FLOOR, not an
     // assignment. Writing them as a plain overwrite walked hosts BACKWARDS into
     // the vulnerable range they had already escaped — a project pinned at

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -602,9 +602,9 @@ describe("PackageLisaStrategy", () => {
   // devDependency is the canonical trigger. Lisa's apply must normalize these to
   // the npm-valid "$name" form so the manifest self-heals on the next apply.
   describe("EOVERRIDE self-referencing override normalization", () => {
-    it("rewrites a literal override to $name when the package is a direct dep", async () => {
+    it("rewrites a literal override to $name when the direct dep preserves the constraint", async () => {
       await createPackageLisaTemplate("typescript", {
-        force: { devDependencies: { prettier: "^3.3.3" } },
+        force: { devDependencies: { prettier: "3.8.3" } },
       });
 
       const sourcePath = path.join(
@@ -619,11 +619,11 @@ describe("PackageLisaStrategy", () => {
       // EOVERRIDE-invalid state a security fix left behind).
       await fs.writeJson(destPath, {
         name: "ts-host",
-        devDependencies: { prettier: "^3.3.3", typescript: "^5.0.0" },
+        devDependencies: { prettier: "3.8.3", typescript: "^5.0.0" },
         overrides: { prettier: "3.8.3", axios: ">=1.15.2" },
       });
 
-      const _result = await strategy.apply(
+      const result = await strategy.apply(
         sourcePath,
         destPath,
         "package.json",
@@ -634,9 +634,12 @@ describe("PackageLisaStrategy", () => {
       // The colliding override is normalized to the self-reference...
       expect(content.overrides.prettier).toBe("$prettier");
       // ...the backing direct dep is preserved so the $ref resolves...
-      expect(content.devDependencies.prettier).toBe("^3.3.3");
+      expect(content.devDependencies.prettier).toBe("3.8.3");
       // ...and a transitive-only override (not a direct dep) is left literal.
       expect(content.overrides.axios).toBe(">=1.15.2");
+      expect(result.note).toContain(
+        'Normalized overrides.prettier: replaced literal "3.8.3" with "$prettier" resolving to direct dependency range "3.8.3".'
+      );
     });
 
     it("normalizes a colliding resolutions entry as well", async () => {
@@ -652,7 +655,7 @@ describe("PackageLisaStrategy", () => {
       await createTypeScriptProject(projectDir);
       await fs.writeJson(destPath, {
         name: "ts-host",
-        dependencies: { lodash: "^4.17.21" },
+        dependencies: { lodash: "4.17.21" },
         resolutions: { lodash: "4.17.21" },
       });
 
@@ -665,6 +668,30 @@ describe("PackageLisaStrategy", () => {
 
       const content = await fs.readJson(destPath);
       expect(content.resolutions.lodash).toBe("$lodash");
+    });
+
+    it("refuses to rewrite when $name would widen an exact override", async () => {
+      await createPackageLisaTemplate("typescript", {});
+
+      const sourcePath = path.join(
+        lisaDir,
+        "typescript",
+        "package-lisa",
+        "package.lisa.json"
+      );
+      const destPath = path.join(projectDir, "package.json");
+      await createTypeScriptProject(projectDir);
+      await fs.writeJson(destPath, {
+        name: "ts-host",
+        dependencies: { tailwindcss: "^3.4.7" },
+        overrides: { tailwindcss: "3.4.19" },
+      });
+
+      await expect(
+        strategy.apply(sourcePath, destPath, "package.json", createContext())
+      ).rejects.toThrow(
+        'overrides.tailwindcss would widen if rewritten to "$tailwindcss"'
+      );
     });
 
     it("leaves an existing $name reference and non-direct overrides untouched", async () => {


### PR DESCRIPTION
## Summary

- refuse `overrides`/`resolutions` `$name` rewrites when the direct dependency range would widen the literal constraint
- report safe rewrite details in Lisa apply output via operation notes
- add package-lisa regression coverage for safe exact rewrites and exact-pin widening refusals

## Verification

- `bun test tests/unit/strategies/package-lisa.test.ts`
- `bun run typecheck`
- `bun run build:dist`
- `bun run lint`
- `bun run test:cov`
- `bun run test:integration`
- `bun run knip:check`
- `bun run check:artifacts`
- `bun run lint:slow`
- `bun run check:conflict-markers`
- `bun run check:duplicate-versions` (advisory findings only)
- `bun run check:plugins`

Work-Item: CodySwannGT/lisa#2642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Package planning and update operations now provide notes explaining override normalization.
  - Compatible direct-dependency version pins are automatically converted to reusable dependency references.
- **Bug Fixes**
  - Prevented override normalization when it would broaden a dependency constraint.
  - Operation logs now include relevant notes for copied and merged results.
- **Tests**
  - Added coverage for normalization notes, exact dependency versions, and rejected constraint-widening cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->