### PR TITLE
fix: preserve host ruleset checks

### DIFF
--- a/scripts/lisa-github-rulesets.sh
+++ b/scripts/lisa-github-rulesets.sh
@@ -427,6 +427,54 @@ add_config_required_checks() {
       end'
 }
 
+preserve_live_required_checks() {
+  local repo="$1"
+  local existing_id="$2"
+  local json="$3"
+  local ruleset_name="$4"
+
+  if [[ -z "$existing_id" ]]; then
+    echo "$json"
+    return 0
+  fi
+
+  local live
+  if ! live=$(gh api -X GET "repos/$repo/rulesets/$existing_id" 2>/dev/null); then
+    log_warning "Could not read existing ruleset '$ruleset_name' details — refusing to silently replace required checks" >&2
+    return 1
+  fi
+
+  echo "$json" | jq --argjson live "$live" '
+    def required_checks:
+      (.rules // [])
+      | map(select(.type == "required_status_checks"))
+      | .[0].parameters.required_status_checks // [];
+
+    ($live | required_checks) as $live_checks
+    | if ($live_checks | length) == 0 then .
+      elif ((.rules // []) | map(select(.type == "required_status_checks")) | length) > 0 then
+        .rules |= map(
+          if .type == "required_status_checks" then
+            .parameters.required_status_checks |= (
+              . as $expected
+              | . + ($live_checks | map(
+                  select(.context as $c | ($expected | map(.context) | index($c)) | not)
+                ))
+            )
+          else . end
+        )
+      else
+        .rules = ((.rules // []) + [{
+          type: "required_status_checks",
+          parameters: {
+            strict_required_status_checks_policy: false,
+            do_not_enforce_on_create: true,
+            required_status_checks: $live_checks
+          }
+        }])
+      end'
+}
+
 apply_ruleset() {
   local repo="$1"
   local template_file="$2"
@@ -453,6 +501,9 @@ apply_ruleset() {
 
   local existing_id
   existing_id=$(find_ruleset_by_name "$existing_rulesets" "$ruleset_name")
+  if [[ -n "$existing_id" ]]; then
+    clean_template=$(preserve_live_required_checks "$repo" "$existing_id" "$clean_template" "$ruleset_name")
+  fi
 
   if [[ "$DRY_RUN" == "true" ]]; then
     if [[ -n "$existing_id" ]]; then

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2193,7 +2193,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-github-repo-setup.sh":
       "dc2f1c9d718aa34ba57161120d9319b5f78fe6b0b496d8e3c77226a08795aa36",
     "scripts/lisa-github-rulesets.sh":
-      "8af5d059d29d5ad3723ef1d2d00e73cc873a6a04bd81b0ac92fbd15f272a211b",
+      "3e496f8d2d294d68c9f4d156684943dd2c7e35f2aaccf476ea4c7309c3a57b77",
     "scripts/lisa-remote-env/session-start.sh":
       "cb63d08b14ab7aa2d405e6770e0cf7db5d6588ae1dcb924ea6224b026fcff496",
     "scripts/lisa-remote-env/setup.sh":

--- a/src/health/ruleset-inspection.ts
+++ b/src/health/ruleset-inspection.ts
@@ -59,6 +59,12 @@ export interface RulesetDrift {
   readonly drifted: readonly string[];
 }
 
+/** Required-check drift grouped by the ruleset that should enforce it. */
+interface NamedRulesetContextDrift {
+  readonly ruleset: string;
+  readonly contexts: readonly string[];
+}
+
 /**
  * Run one fixed-argv bounded gh JSON read.
  * @param argv
@@ -451,6 +457,114 @@ function withoutGithubDefaults(value: unknown): unknown {
 }
 
 /**
+ * Extract required status checks by context from a material ruleset.
+ * @param rules
+ */
+function requiredStatusChecksByContext(
+  rules: unknown
+): ReadonlyMap<string, unknown> {
+  if (!Array.isArray(rules)) return new Map();
+  const entries = rules.flatMap(rule => {
+    if (
+      rule === null ||
+      typeof rule !== "object" ||
+      Reflect.get(rule, "type") !== "required_status_checks"
+    ) {
+      return [];
+    }
+    const parameters = Reflect.get(rule, "parameters");
+    if (parameters === null || typeof parameters !== "object") return [];
+    const checks = Reflect.get(parameters, "required_status_checks");
+    if (!Array.isArray(checks)) return [];
+    return checks.flatMap(check => {
+      if (check === null || typeof check !== "object") return [];
+      const context = Reflect.get(check, "context");
+      return typeof context === "string" ? [[context, check] as const] : [];
+    });
+  });
+  return new Map(entries);
+}
+
+/**
+ * Project actual rules onto expected required-check contexts.
+ *
+ * Host-added required contexts are enforcement, not drift. Comparing the whole
+ * live list would make doctor pressure operators to remove checks Lisa cannot
+ * preserve safely.
+ * @param actualRules
+ * @param expectedRules
+ */
+function comparableActualRules(
+  actualRules: unknown,
+  expectedRules: unknown
+): unknown {
+  const expectedContexts = new Set(
+    requiredStatusChecksByContext(expectedRules).keys()
+  );
+  if (!Array.isArray(actualRules) || expectedContexts.size === 0) {
+    return actualRules;
+  }
+  return actualRules.map(rule => {
+    if (
+      rule === null ||
+      typeof rule !== "object" ||
+      Reflect.get(rule, "type") !== "required_status_checks"
+    ) {
+      return rule;
+    }
+    const parameters = Reflect.get(rule, "parameters");
+    if (parameters === null || typeof parameters !== "object") return rule;
+    const checks = Reflect.get(parameters, "required_status_checks");
+    if (!Array.isArray(checks)) return rule;
+    return {
+      ...rule,
+      parameters: {
+        ...parameters,
+        required_status_checks: checks.filter(check => {
+          if (check === null || typeof check !== "object") return true;
+          const context = Reflect.get(check, "context");
+          return typeof context !== "string" || expectedContexts.has(context);
+        }),
+      },
+    };
+  });
+}
+
+/**
+ * List Lisa-required checks absent from a live ruleset.
+ * @param expected
+ * @param actual
+ */
+function missingRequiredContexts(
+  expected: HealthRuleset,
+  actual: HealthRuleset | undefined
+): readonly string[] {
+  const actualContexts = requiredStatusChecksByContext(actual?.rules);
+  return sortedCopy(
+    [...requiredStatusChecksByContext(expected.rules).keys()].filter(
+      context => !actualContexts.has(context)
+    ),
+    (left, right) => left.localeCompare(right)
+  );
+}
+
+/**
+ * Name missing required-check enforcement by ruleset.
+ * @param expected
+ * @param actual
+ */
+function requiredContextDrift(
+  expected: readonly HealthRuleset[],
+  actual: readonly HealthRuleset[]
+): readonly NamedRulesetContextDrift[] {
+  const observed = new Map(actual.map(item => [item.name, item]));
+  return expected.flatMap(item => {
+    const contexts = missingRequiredContexts(item, observed.get(item.name));
+    return contexts.length === 0 ? [] : [{ ruleset: item.name, contexts }];
+  });
+}
+
+/**
  * Compare expected and observed material ruleset documents.
  * @param expected
  * @param actual
@@ -479,7 +593,7 @@ export function compareRulesets(
         target: present.target,
         enforcement: present.enforcement,
         conditions: present.conditions,
-        rules: present.rules,
+        rules: comparableActualRules(present.rules, item.rules),
       })
     );
     if (JSON.stringify(expectedMaterial) !== JSON.stringify(actualMaterial)) {
@@ -558,9 +672,23 @@ export async function rulesetFinding(
   }
   const expected = await expectedRulesets(lisaRoot, projectRoot, types, config);
   const drift = compareRulesets(expected, actual);
+  const contextDrift = requiredContextDrift(expected, actual);
+  const missingContextsByRuleset = new Map(
+    contextDrift.map(item => [item.ruleset, item.contexts])
+  );
   const names = [
-    ...drift.missing.map(name => `${name} missing`),
-    ...drift.drifted.map(name => `${name} drifted`),
+    ...drift.missing.map(name => {
+      const contexts = missingContextsByRuleset.get(name) ?? [];
+      return contexts.length === 0
+        ? `${name} missing`
+        : `${name} missing; runs without blocking: ${contexts.join(", ")}`;
+    }),
+    ...drift.drifted.map(name => {
+      const contexts = missingContextsByRuleset.get(name) ?? [];
+      return contexts.length === 0
+        ? `${name} drifted`
+        : `${name} drifted; runs without blocking: ${contexts.join(", ")}`;
+    }),
   ];
   return names.length === 0
     ? deterministicFinding(

--- a/tests/unit/health/deterministic-regressions.test.ts
+++ b/tests/unit/health/deterministic-regressions.test.ts
@@ -25,6 +25,7 @@ import { readProjectFile } from "../../../src/health/read-only-fs.js";
 import {
   compareRulesets,
   expectedRulesets,
+  rulesetFinding,
   type HealthRuleset,
 } from "../../../src/health/ruleset-inspection.js";
 import {
@@ -482,6 +483,128 @@ describe("deterministic health governance regressions", () => {
     expect(unrelated?.rules?.[0]?.parameters?.required_status_checks).toEqual([
       { context: "CI", integration_id: 15_368 },
     ]);
+  });
+
+  it("names unenforced required checks and tolerates host-added checks", async () => {
+    const expected: HealthRuleset = {
+      name: "quality checks",
+      target: "branch",
+      enforcement: "active",
+      conditions: { ref_name: { include: ["~DEFAULT_BRANCH"], exclude: [] } },
+      rules: [
+        {
+          type: "required_status_checks",
+          parameters: {
+            required_status_checks: [
+              {
+                context: "🔍 Quality Checks / 🧹 Lint",
+                integration_id: 15_368,
+              },
+              {
+                context: "🔍 Quality Checks / 🔗 Work-Item Traceability",
+                integration_id: 15_368,
+              },
+            ],
+          },
+        },
+      ],
+    };
+    const actualWithHostAddition: HealthRuleset = {
+      ...expected,
+      rules: [
+        {
+          type: "required_status_checks",
+          parameters: {
+            required_status_checks: [
+              {
+                context: "🔍 Quality Checks / 🧹 Lint",
+                integration_id: 15_368,
+              },
+              {
+                context: "🧭 E2E Route Coverage",
+                integration_id: 15_368,
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    expect(compareRulesets([expected], [actualWithHostAddition])).toEqual({
+      missing: [],
+      drifted: ["quality checks"],
+    });
+
+    const lisaRoot = await temporaryRoot("lisa-health-ruleset-names-source-");
+    const projectRoot = await temporaryRoot("lisa-health-ruleset-names-host-");
+    await write(
+      lisaRoot,
+      "typescript/github-rulesets/quality-checks.json",
+      `${JSON.stringify(expected)}\n`
+    );
+    await write(projectRoot, ".github/workflows/ci.yml", "on: push\n");
+
+    const finding = await rulesetFinding(
+      lisaRoot,
+      projectRoot,
+      ["typescript"],
+      { github: { org: "acme", repo: "app" } },
+      async () => [actualWithHostAddition],
+      1_000,
+      new AbortController().signal
+    );
+    expect(finding.status).toBe("fail");
+    expect(finding.reason).toContain("quality checks drifted");
+    expect(finding.reason).toContain("runs without blocking");
+    expect(finding.reason).toContain(
+      "🔍 Quality Checks / 🔗 Work-Item Traceability"
+    );
+    expect(finding.reason).not.toContain("🧭 E2E Route Coverage");
+  });
+
+  it("reports missing rulesets with their unenforced required checks", async () => {
+    const lisaRoot = await temporaryRoot("lisa-health-ruleset-missing-source-");
+    const projectRoot = await temporaryRoot(
+      "lisa-health-ruleset-missing-host-"
+    );
+    await write(
+      lisaRoot,
+      "expo/github-rulesets/nightly-e2e-health.json",
+      `${JSON.stringify({
+        name: "nightly e2e health",
+        target: "branch",
+        enforcement: "active",
+        rules: [
+          {
+            type: "required_status_checks",
+            parameters: {
+              required_status_checks: [
+                {
+                  context: "🌙 Nightly E2E Health / 🌙 Gate",
+                  integration_id: 15_368,
+                },
+              ],
+            },
+          },
+        ],
+      })}\n`
+    );
+    await write(projectRoot, ".github/workflows/ci.yml", "on: push\n");
+
+    const finding = await rulesetFinding(
+      lisaRoot,
+      projectRoot,
+      ["expo"],
+      { github: { org: "acme", repo: "app" } },
+      async () => [],
+      1_000,
+      new AbortController().signal
+    );
+
+    expect(finding.status).toBe("fail");
+    expect(finding.reason).toContain("nightly e2e health missing");
+    expect(finding.reason).toContain("🌙 Nightly E2E Health / 🌙 Gate");
+    expect(finding.reason).toContain("runs without blocking");
   });
 });
 /* eslint-enable jsdoc/require-jsdoc, sonarjs/no-duplicate-string, max-lines -- restore repository test defaults */

--- a/tests/unit/scripts/lisa-github-rulesets.test.ts
+++ b/tests/unit/scripts/lisa-github-rulesets.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string, max-lines -- shell mock fixtures intentionally repeat gh argv fragments */
 import { execFileSync, spawnSync } from "node:child_process";
 import {
   copyFileSync,
@@ -161,6 +162,58 @@ function createCapturingGhBin(captureDir: string): string {
       'if [[ "$1" == "api" && "$2" == "-X" ]]; then',
       '  input="${!#}"',
       `  cp "$input" "${captureDir}/$(date +%s%N).json"`,
+      '  echo "{}"',
+      "  exit 0",
+      "fi",
+      'echo "unexpected gh invocation: $*" >&2',
+      "exit 1",
+      "",
+    ].join("\n"),
+    { mode: 0o755 }
+  );
+  return binDir;
+}
+
+/**
+ * Creates a mock gh for an update path with one live ruleset detail.
+ *
+ * @param captureDir Directory the mock writes the update payload into.
+ * @param liveRuleset Existing detailed ruleset payload returned by GitHub.
+ * @returns Temporary bin directory containing the mock gh executable.
+ */
+function createUpdatingGhBin(
+  captureDir: string,
+  liveRuleset: RulesetPayload
+): string {
+  const binDir = mkdtempSync(path.join(tmpdir(), "lisa-gh-update-"));
+  const ghPath = path.join(binDir, "gh");
+  writeFileSync(
+    ghPath,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      'if [[ "$1 $2" == "auth status" ]]; then',
+      "  exit 0",
+      "fi",
+      'if [[ "$1 $2" == "repo view" ]]; then',
+      `  echo "${REPO_NAME}"`,
+      "  exit 0",
+      "fi",
+      `if [[ "$1" == "api" && "$2" == "repos/${REPO_NAME}/rulesets" ]]; then`,
+      '  echo "[{\\"id\\":7,\\"name\\":\\"base\\"}]"',
+      "  exit 0",
+      "fi",
+      `if [[ "$1 $2 $3" == "api -X GET" && "$4" == "repos/${REPO_NAME}/rulesets/7" ]]; then`,
+      `  cat <<'JSON'\n${JSON.stringify(liveRuleset)}\nJSON`,
+      "  exit 0",
+      "fi",
+      `if [[ "$1 $2 $3" == "api -X PUT" && "$4" == "repos/${REPO_NAME}/rulesets/7" ]]; then`,
+      '  input="${!#}"',
+      `  cp "$input" "${captureDir}/updated.json"`,
+      '  echo "{}"',
+      "  exit 0",
+      "fi",
+      'if [[ "$1 $2 $3" == "api -X POST" ]]; then',
       '  echo "{}"',
       "  exit 0",
       "fi",
@@ -339,5 +392,73 @@ describe("lisa-github-rulesets.sh", () => {
         expect(contextsOf(payload)).toEqual([]);
       }
     });
+
+    it("preserves live-only required checks when updating a ruleset", () => {
+      const projectDir = createProject();
+      const captureDir = mkdtempSync(
+        path.join(tmpdir(), "lisa-gh-update-payloads-")
+      );
+      const lisaInstall = createLisaInstall();
+      const shippedContext = "🔗 Work-Item Traceability";
+      const hostContext = "🧭 E2E Route Coverage";
+      const ghBin = createUpdatingGhBin(captureDir, {
+        name: "base",
+        rules: [
+          {
+            type: "required_status_checks",
+            parameters: {
+              required_status_checks: [
+                { context: hostContext, integration_id: 15_368 },
+              ],
+            },
+          },
+        ],
+      });
+
+      mkdirSync(path.join(projectDir, ".github", "workflows"), {
+        recursive: true,
+      });
+      writeFileSync(
+        path.join(
+          lisaInstall.root,
+          "typescript",
+          "github-rulesets",
+          "base.json"
+        ),
+        JSON.stringify({
+          name: "base",
+          enforcement: ACTIVE_ENFORCEMENT,
+          rules: [
+            {
+              type: "required_status_checks",
+              parameters: {
+                required_status_checks: [
+                  { context: shippedContext, integration_id: 15_368 },
+                ],
+              },
+            },
+          ],
+        })
+      );
+
+      try {
+        const result = runRulesetScript(
+          lisaInstall.scriptPath,
+          ["--yes", projectDir],
+          ghBin
+        );
+        expect(result.status).toBe(0);
+        const updated = JSON.parse(
+          readFileSync(path.join(captureDir, "updated.json"), "utf8")
+        ) as RulesetPayload;
+        expect(contextsOf(updated)).toEqual([shippedContext, hostContext]);
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+        rmSync(captureDir, { recursive: true, force: true });
+        rmSync(ghBin, { recursive: true, force: true });
+        rmSync(lisaInstall.root, { recursive: true, force: true });
+      }
+    });
   });
 });
+/* eslint-enable sonarjs/no-duplicate-string, max-lines -- restore repository defaults */


### PR DESCRIPTION
## Summary

- preserve live-only required status checks when updating an existing GitHub ruleset
- make health/doctor ruleset drift name unenforced required contexts and missing rulesets
- add regressions for host-added context preservation and missing required-check reporting

## Verification

- bun test tests/unit/scripts/lisa-github-rulesets.test.ts
- bunx vitest run tests/unit/health/deterministic-regressions.test.ts
- bun run typecheck
- bun run lint
- bun run build:dist
- bun run check:artifacts
- bun run check:conflict-markers
- bun run check:duplicate-versions (advisory findings only)
- bun run test:cov
- bun run test:integration
- bun run lint:slow
- bun run knip:check
- bun run check:plugins
- git push pre-push gate: passed

Work-Item: CodySwannGT/lisa#2641