### PR TITLE
fix(secrets): resolve the project config from outside cwd

### DIFF
--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
@@ -189,11 +189,26 @@ export function report(result, cfg) {
   } else {
     lines.push(
       `Secrets preflight FAILED on surface "${cfg.surface}".`,
-      `These credentials are required and resolve nowhere — not in the`,
-      `environment, not materialized, not in the "${cfg.provider}" grant.`,
+      `These credentials are required and were not found in the surfaces`,
+      `consulted — the environment, the materialized file, and the`,
+      `"${cfg.provider}" grant.`,
       `Extend the grant in the vault (or correct the routing that requires`,
       `them), then start a new session:`
     );
+    // A defaulted provider is the one case where the list above is not the
+    // whole story: no config was found, so the vault a project actually
+    // declares was never contacted. Saying "resolve nowhere" there sends the
+    // reader to grant a credential that was never absent.
+    if (!cfg.configPath) {
+      lines.push(
+        ``,
+        `NOTE: no .lisa.config.json was found at or above the working`,
+        `directory, so provider "${cfg.provider}" is a DEFAULT, not this`,
+        `project's setting. If this project uses a vault, the credential may`,
+        `resolve fine — start the session from the repository root, or check`,
+        `the config is present, before treating this as missing.`
+      );
+    }
   }
   lines.push(``);
   for (const { name, reasons } of result.missing) {

--- a/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-agy/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { bootstrapKeyFor } from "./providers.mjs";
 import { routingFloor } from "./routing-floor.mjs";
@@ -183,16 +183,92 @@ export function materializedPaths(namespace, env = process.env) {
 }
 
 /**
+ * Directories the harness claims are this session's project, best first.
+ *
+ * `CLAUDE_PROJECT_DIR` is set by Claude Code for hook commands, and Lisa's own
+ * hooks already invoke scripts through it. `LISA_PROJECT_DIR` lets a harness
+ * without that convention — or an operator debugging one — say the same thing.
+ *
+ * Blank values are dropped rather than resolved, because an unset variable
+ * expands to the empty string in a shell and `resolve("")` is the current
+ * directory, which would silently re-check a path already searched.
+ *
+ * @param {Record<string, string | undefined>} env - Environment to read.
+ * @returns {string[]} Candidate project roots, deduplicated, best first.
+ */
+function projectAnchors(env) {
+  const raw = [env.LISA_PROJECT_DIR, env.CLAUDE_PROJECT_DIR];
+  return [...new Set(raw.map(value => (value ?? "").trim()).filter(Boolean))];
+}
+
+/**
+ * Find the nearest `.lisa.config.json` at or above `cwd`.
+ *
+ * Looking only in `cwd` made every session started anywhere but the repo root
+ * — a worktree subdirectory, a package folder, a parent wrapper directory —
+ * fall through to the environment defaults and resolve `provider: "env"`. The
+ * preflight then checked the environment, the materialized file, and the "env"
+ * grant, found nothing, and reported the credential as resolving NOWHERE,
+ * having never contacted the configured vault at all.
+ *
+ * That is a false negative wearing a definite answer's clothes, and the
+ * message it produces tells the reader to route the work to blocked. An
+ * obedient agent therefore abandons work over credentials it could have
+ * resolved, and nothing downstream ever re-derives that judgement.
+ *
+ * The walk stops at a repository boundary when it finds one, so a config
+ * belonging to an unrelated parent project is never adopted. If no boundary is
+ * found it stops at the filesystem root, which is what makes the bare-checkout
+ * and wrapper-directory layouts work.
+ *
+ * @param {string} cwd - Directory to start from.
+ * @returns {string | null} Absolute path to the config, or `null` if none.
+ */
+function locateConfig(cwd) {
+  let dir = resolve(cwd);
+  for (;;) {
+    const candidate = join(dir, ".lisa.config.json");
+    if (existsSync(candidate)) return candidate;
+    // Checked AFTER the config, so a repo root carrying one still matches.
+    // Checked as a path rather than a directory because a worktree's `.git` is
+    // a file, and treating that as "not a boundary" would walk out of the
+    // worktree into whatever encloses it.
+    if (existsSync(join(dir, ".git"))) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
  * Read the `secrets` block from `.lisa.config.json`.
  *
  * A project with no block is a supported state, not an error: the `env`
  * provider means the environment *is* the provider. A credentials manager is
  * the preferred path, never a required one.
  * @param {string} [cwd] Directory to look in.
- * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object}} Resolved configuration with defaults applied.
+ * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object, configPath: string|null}} Resolved configuration with defaults applied. `configPath` is the file the values came from, or `null` when none was found and the defaults apply.
  */
 export function readConfig(cwd = process.cwd(), env = process.env) {
-  const path = join(cwd, ".lisa.config.json");
+  // Walk from `cwd` first, then from whatever the harness says the project is.
+  //
+  // A walk from `cwd` alone does not close this. The SessionStart hook that
+  // runs the preflight never changes directory, so its cwd is wherever the
+  // harness happened to spawn it — `$HOME`, a plugin cache — and a walk from
+  // there terminates without finding anything, exactly as a walk from `cwd`
+  // inside the project succeeds. Measured on a session whose credential
+  // resolved fine from its own worktree while the preflight called it
+  // unreachable: every directory from that worktree upward carried a config,
+  // so the hook cannot have been running anywhere in that tree.
+  //
+  // cwd wins when it finds something, because an explicit working directory is
+  // intent and the project variable is only ever a hint about the session.
+  const path =
+    locateConfig(cwd) ??
+    projectAnchors(env)
+      .map(anchor => locateConfig(anchor))
+      .find(found => found !== null) ??
+    null;
   // No repository is a real, supported state — not just a missing file.
   //
   // A Claude Tag channel session runs as the organization with no user account,
@@ -203,7 +279,13 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // The only values a config would supply here are the namespace and provider,
   // so they can come from the environment instead. Everything else keeps its
   // default, and an environment that sets neither still gets the old behaviour.
-  if (!existsSync(path)) return withSurface(fromEnvironment(env));
+  //
+  // It stays supported, but it no longer stays SILENT: `configPath: null` lets
+  // a caller say "no config found, assuming provider=env" instead of printing
+  // a defaulted provider that is indistinguishable from a declared one.
+  if (!path) {
+    return withSurface({ ...fromEnvironment(env), configPath: null });
+  }
   let root;
   try {
     root = JSON.parse(readFileSync(path, "utf8"));
@@ -216,7 +298,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // `secrets` would be a second copy free to disagree with the one every other
   // skill dispatches on.
   const routing = { tracker: root.tracker, source: root.source };
-  if (!cfg) return withSurface({ ...DEFAULTS, routing });
+  if (!cfg) return withSurface({ ...DEFAULTS, routing, configPath: path });
   const provider = cfg.provider ?? DEFAULTS.provider;
   const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
@@ -229,6 +311,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
     routing,
+    configPath: path,
   });
 }
 

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
@@ -189,11 +189,26 @@ export function report(result, cfg) {
   } else {
     lines.push(
       `Secrets preflight FAILED on surface "${cfg.surface}".`,
-      `These credentials are required and resolve nowhere — not in the`,
-      `environment, not materialized, not in the "${cfg.provider}" grant.`,
+      `These credentials are required and were not found in the surfaces`,
+      `consulted — the environment, the materialized file, and the`,
+      `"${cfg.provider}" grant.`,
       `Extend the grant in the vault (or correct the routing that requires`,
       `them), then start a new session:`
     );
+    // A defaulted provider is the one case where the list above is not the
+    // whole story: no config was found, so the vault a project actually
+    // declares was never contacted. Saying "resolve nowhere" there sends the
+    // reader to grant a credential that was never absent.
+    if (!cfg.configPath) {
+      lines.push(
+        ``,
+        `NOTE: no .lisa.config.json was found at or above the working`,
+        `directory, so provider "${cfg.provider}" is a DEFAULT, not this`,
+        `project's setting. If this project uses a vault, the credential may`,
+        `resolve fine — start the session from the repository root, or check`,
+        `the config is present, before treating this as missing.`
+      );
+    }
   }
   lines.push(``);
   for (const { name, reasons } of result.missing) {

--- a/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-copilot/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { bootstrapKeyFor } from "./providers.mjs";
 import { routingFloor } from "./routing-floor.mjs";
@@ -183,16 +183,92 @@ export function materializedPaths(namespace, env = process.env) {
 }
 
 /**
+ * Directories the harness claims are this session's project, best first.
+ *
+ * `CLAUDE_PROJECT_DIR` is set by Claude Code for hook commands, and Lisa's own
+ * hooks already invoke scripts through it. `LISA_PROJECT_DIR` lets a harness
+ * without that convention — or an operator debugging one — say the same thing.
+ *
+ * Blank values are dropped rather than resolved, because an unset variable
+ * expands to the empty string in a shell and `resolve("")` is the current
+ * directory, which would silently re-check a path already searched.
+ *
+ * @param {Record<string, string | undefined>} env - Environment to read.
+ * @returns {string[]} Candidate project roots, deduplicated, best first.
+ */
+function projectAnchors(env) {
+  const raw = [env.LISA_PROJECT_DIR, env.CLAUDE_PROJECT_DIR];
+  return [...new Set(raw.map(value => (value ?? "").trim()).filter(Boolean))];
+}
+
+/**
+ * Find the nearest `.lisa.config.json` at or above `cwd`.
+ *
+ * Looking only in `cwd` made every session started anywhere but the repo root
+ * — a worktree subdirectory, a package folder, a parent wrapper directory —
+ * fall through to the environment defaults and resolve `provider: "env"`. The
+ * preflight then checked the environment, the materialized file, and the "env"
+ * grant, found nothing, and reported the credential as resolving NOWHERE,
+ * having never contacted the configured vault at all.
+ *
+ * That is a false negative wearing a definite answer's clothes, and the
+ * message it produces tells the reader to route the work to blocked. An
+ * obedient agent therefore abandons work over credentials it could have
+ * resolved, and nothing downstream ever re-derives that judgement.
+ *
+ * The walk stops at a repository boundary when it finds one, so a config
+ * belonging to an unrelated parent project is never adopted. If no boundary is
+ * found it stops at the filesystem root, which is what makes the bare-checkout
+ * and wrapper-directory layouts work.
+ *
+ * @param {string} cwd - Directory to start from.
+ * @returns {string | null} Absolute path to the config, or `null` if none.
+ */
+function locateConfig(cwd) {
+  let dir = resolve(cwd);
+  for (;;) {
+    const candidate = join(dir, ".lisa.config.json");
+    if (existsSync(candidate)) return candidate;
+    // Checked AFTER the config, so a repo root carrying one still matches.
+    // Checked as a path rather than a directory because a worktree's `.git` is
+    // a file, and treating that as "not a boundary" would walk out of the
+    // worktree into whatever encloses it.
+    if (existsSync(join(dir, ".git"))) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
  * Read the `secrets` block from `.lisa.config.json`.
  *
  * A project with no block is a supported state, not an error: the `env`
  * provider means the environment *is* the provider. A credentials manager is
  * the preferred path, never a required one.
  * @param {string} [cwd] Directory to look in.
- * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object}} Resolved configuration with defaults applied.
+ * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object, configPath: string|null}} Resolved configuration with defaults applied. `configPath` is the file the values came from, or `null` when none was found and the defaults apply.
  */
 export function readConfig(cwd = process.cwd(), env = process.env) {
-  const path = join(cwd, ".lisa.config.json");
+  // Walk from `cwd` first, then from whatever the harness says the project is.
+  //
+  // A walk from `cwd` alone does not close this. The SessionStart hook that
+  // runs the preflight never changes directory, so its cwd is wherever the
+  // harness happened to spawn it — `$HOME`, a plugin cache — and a walk from
+  // there terminates without finding anything, exactly as a walk from `cwd`
+  // inside the project succeeds. Measured on a session whose credential
+  // resolved fine from its own worktree while the preflight called it
+  // unreachable: every directory from that worktree upward carried a config,
+  // so the hook cannot have been running anywhere in that tree.
+  //
+  // cwd wins when it finds something, because an explicit working directory is
+  // intent and the project variable is only ever a hint about the session.
+  const path =
+    locateConfig(cwd) ??
+    projectAnchors(env)
+      .map(anchor => locateConfig(anchor))
+      .find(found => found !== null) ??
+    null;
   // No repository is a real, supported state — not just a missing file.
   //
   // A Claude Tag channel session runs as the organization with no user account,
@@ -203,7 +279,13 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // The only values a config would supply here are the namespace and provider,
   // so they can come from the environment instead. Everything else keeps its
   // default, and an environment that sets neither still gets the old behaviour.
-  if (!existsSync(path)) return withSurface(fromEnvironment(env));
+  //
+  // It stays supported, but it no longer stays SILENT: `configPath: null` lets
+  // a caller say "no config found, assuming provider=env" instead of printing
+  // a defaulted provider that is indistinguishable from a declared one.
+  if (!path) {
+    return withSurface({ ...fromEnvironment(env), configPath: null });
+  }
   let root;
   try {
     root = JSON.parse(readFileSync(path, "utf8"));
@@ -216,7 +298,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // `secrets` would be a second copy free to disagree with the one every other
   // skill dispatches on.
   const routing = { tracker: root.tracker, source: root.source };
-  if (!cfg) return withSurface({ ...DEFAULTS, routing });
+  if (!cfg) return withSurface({ ...DEFAULTS, routing, configPath: path });
   const provider = cfg.provider ?? DEFAULTS.provider;
   const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
@@ -229,6 +311,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
     routing,
+    configPath: path,
   });
 }
 

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
@@ -189,11 +189,26 @@ export function report(result, cfg) {
   } else {
     lines.push(
       `Secrets preflight FAILED on surface "${cfg.surface}".`,
-      `These credentials are required and resolve nowhere — not in the`,
-      `environment, not materialized, not in the "${cfg.provider}" grant.`,
+      `These credentials are required and were not found in the surfaces`,
+      `consulted — the environment, the materialized file, and the`,
+      `"${cfg.provider}" grant.`,
       `Extend the grant in the vault (or correct the routing that requires`,
       `them), then start a new session:`
     );
+    // A defaulted provider is the one case where the list above is not the
+    // whole story: no config was found, so the vault a project actually
+    // declares was never contacted. Saying "resolve nowhere" there sends the
+    // reader to grant a credential that was never absent.
+    if (!cfg.configPath) {
+      lines.push(
+        ``,
+        `NOTE: no .lisa.config.json was found at or above the working`,
+        `directory, so provider "${cfg.provider}" is a DEFAULT, not this`,
+        `project's setting. If this project uses a vault, the credential may`,
+        `resolve fine — start the session from the repository root, or check`,
+        `the config is present, before treating this as missing.`
+      );
+    }
   }
   lines.push(``);
   for (const { name, reasons } of result.missing) {

--- a/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa-cursor/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { bootstrapKeyFor } from "./providers.mjs";
 import { routingFloor } from "./routing-floor.mjs";
@@ -183,16 +183,92 @@ export function materializedPaths(namespace, env = process.env) {
 }
 
 /**
+ * Directories the harness claims are this session's project, best first.
+ *
+ * `CLAUDE_PROJECT_DIR` is set by Claude Code for hook commands, and Lisa's own
+ * hooks already invoke scripts through it. `LISA_PROJECT_DIR` lets a harness
+ * without that convention — or an operator debugging one — say the same thing.
+ *
+ * Blank values are dropped rather than resolved, because an unset variable
+ * expands to the empty string in a shell and `resolve("")` is the current
+ * directory, which would silently re-check a path already searched.
+ *
+ * @param {Record<string, string | undefined>} env - Environment to read.
+ * @returns {string[]} Candidate project roots, deduplicated, best first.
+ */
+function projectAnchors(env) {
+  const raw = [env.LISA_PROJECT_DIR, env.CLAUDE_PROJECT_DIR];
+  return [...new Set(raw.map(value => (value ?? "").trim()).filter(Boolean))];
+}
+
+/**
+ * Find the nearest `.lisa.config.json` at or above `cwd`.
+ *
+ * Looking only in `cwd` made every session started anywhere but the repo root
+ * — a worktree subdirectory, a package folder, a parent wrapper directory —
+ * fall through to the environment defaults and resolve `provider: "env"`. The
+ * preflight then checked the environment, the materialized file, and the "env"
+ * grant, found nothing, and reported the credential as resolving NOWHERE,
+ * having never contacted the configured vault at all.
+ *
+ * That is a false negative wearing a definite answer's clothes, and the
+ * message it produces tells the reader to route the work to blocked. An
+ * obedient agent therefore abandons work over credentials it could have
+ * resolved, and nothing downstream ever re-derives that judgement.
+ *
+ * The walk stops at a repository boundary when it finds one, so a config
+ * belonging to an unrelated parent project is never adopted. If no boundary is
+ * found it stops at the filesystem root, which is what makes the bare-checkout
+ * and wrapper-directory layouts work.
+ *
+ * @param {string} cwd - Directory to start from.
+ * @returns {string | null} Absolute path to the config, or `null` if none.
+ */
+function locateConfig(cwd) {
+  let dir = resolve(cwd);
+  for (;;) {
+    const candidate = join(dir, ".lisa.config.json");
+    if (existsSync(candidate)) return candidate;
+    // Checked AFTER the config, so a repo root carrying one still matches.
+    // Checked as a path rather than a directory because a worktree's `.git` is
+    // a file, and treating that as "not a boundary" would walk out of the
+    // worktree into whatever encloses it.
+    if (existsSync(join(dir, ".git"))) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
  * Read the `secrets` block from `.lisa.config.json`.
  *
  * A project with no block is a supported state, not an error: the `env`
  * provider means the environment *is* the provider. A credentials manager is
  * the preferred path, never a required one.
  * @param {string} [cwd] Directory to look in.
- * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object}} Resolved configuration with defaults applied.
+ * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object, configPath: string|null}} Resolved configuration with defaults applied. `configPath` is the file the values came from, or `null` when none was found and the defaults apply.
  */
 export function readConfig(cwd = process.cwd(), env = process.env) {
-  const path = join(cwd, ".lisa.config.json");
+  // Walk from `cwd` first, then from whatever the harness says the project is.
+  //
+  // A walk from `cwd` alone does not close this. The SessionStart hook that
+  // runs the preflight never changes directory, so its cwd is wherever the
+  // harness happened to spawn it — `$HOME`, a plugin cache — and a walk from
+  // there terminates without finding anything, exactly as a walk from `cwd`
+  // inside the project succeeds. Measured on a session whose credential
+  // resolved fine from its own worktree while the preflight called it
+  // unreachable: every directory from that worktree upward carried a config,
+  // so the hook cannot have been running anywhere in that tree.
+  //
+  // cwd wins when it finds something, because an explicit working directory is
+  // intent and the project variable is only ever a hint about the session.
+  const path =
+    locateConfig(cwd) ??
+    projectAnchors(env)
+      .map(anchor => locateConfig(anchor))
+      .find(found => found !== null) ??
+    null;
   // No repository is a real, supported state — not just a missing file.
   //
   // A Claude Tag channel session runs as the organization with no user account,
@@ -203,7 +279,13 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // The only values a config would supply here are the namespace and provider,
   // so they can come from the environment instead. Everything else keeps its
   // default, and an environment that sets neither still gets the old behaviour.
-  if (!existsSync(path)) return withSurface(fromEnvironment(env));
+  //
+  // It stays supported, but it no longer stays SILENT: `configPath: null` lets
+  // a caller say "no config found, assuming provider=env" instead of printing
+  // a defaulted provider that is indistinguishable from a declared one.
+  if (!path) {
+    return withSurface({ ...fromEnvironment(env), configPath: null });
+  }
   let root;
   try {
     root = JSON.parse(readFileSync(path, "utf8"));
@@ -216,7 +298,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // `secrets` would be a second copy free to disagree with the one every other
   // skill dispatches on.
   const routing = { tracker: root.tracker, source: root.source };
-  if (!cfg) return withSurface({ ...DEFAULTS, routing });
+  if (!cfg) return withSurface({ ...DEFAULTS, routing, configPath: path });
   const provider = cfg.provider ?? DEFAULTS.provider;
   const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
@@ -229,6 +311,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
     routing,
+    configPath: path,
   });
 }
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
@@ -189,11 +189,26 @@ export function report(result, cfg) {
   } else {
     lines.push(
       `Secrets preflight FAILED on surface "${cfg.surface}".`,
-      `These credentials are required and resolve nowhere — not in the`,
-      `environment, not materialized, not in the "${cfg.provider}" grant.`,
+      `These credentials are required and were not found in the surfaces`,
+      `consulted — the environment, the materialized file, and the`,
+      `"${cfg.provider}" grant.`,
       `Extend the grant in the vault (or correct the routing that requires`,
       `them), then start a new session:`
     );
+    // A defaulted provider is the one case where the list above is not the
+    // whole story: no config was found, so the vault a project actually
+    // declares was never contacted. Saying "resolve nowhere" there sends the
+    // reader to grant a credential that was never absent.
+    if (!cfg.configPath) {
+      lines.push(
+        ``,
+        `NOTE: no .lisa.config.json was found at or above the working`,
+        `directory, so provider "${cfg.provider}" is a DEFAULT, not this`,
+        `project's setting. If this project uses a vault, the credential may`,
+        `resolve fine — start the session from the repository root, or check`,
+        `the config is present, before treating this as missing.`
+      );
+    }
   }
   lines.push(``);
   for (const { name, reasons } of result.missing) {

--- a/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/.codex-plugin/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { bootstrapKeyFor } from "./providers.mjs";
 import { routingFloor } from "./routing-floor.mjs";
@@ -183,16 +183,92 @@ export function materializedPaths(namespace, env = process.env) {
 }
 
 /**
+ * Directories the harness claims are this session's project, best first.
+ *
+ * `CLAUDE_PROJECT_DIR` is set by Claude Code for hook commands, and Lisa's own
+ * hooks already invoke scripts through it. `LISA_PROJECT_DIR` lets a harness
+ * without that convention — or an operator debugging one — say the same thing.
+ *
+ * Blank values are dropped rather than resolved, because an unset variable
+ * expands to the empty string in a shell and `resolve("")` is the current
+ * directory, which would silently re-check a path already searched.
+ *
+ * @param {Record<string, string | undefined>} env - Environment to read.
+ * @returns {string[]} Candidate project roots, deduplicated, best first.
+ */
+function projectAnchors(env) {
+  const raw = [env.LISA_PROJECT_DIR, env.CLAUDE_PROJECT_DIR];
+  return [...new Set(raw.map(value => (value ?? "").trim()).filter(Boolean))];
+}
+
+/**
+ * Find the nearest `.lisa.config.json` at or above `cwd`.
+ *
+ * Looking only in `cwd` made every session started anywhere but the repo root
+ * — a worktree subdirectory, a package folder, a parent wrapper directory —
+ * fall through to the environment defaults and resolve `provider: "env"`. The
+ * preflight then checked the environment, the materialized file, and the "env"
+ * grant, found nothing, and reported the credential as resolving NOWHERE,
+ * having never contacted the configured vault at all.
+ *
+ * That is a false negative wearing a definite answer's clothes, and the
+ * message it produces tells the reader to route the work to blocked. An
+ * obedient agent therefore abandons work over credentials it could have
+ * resolved, and nothing downstream ever re-derives that judgement.
+ *
+ * The walk stops at a repository boundary when it finds one, so a config
+ * belonging to an unrelated parent project is never adopted. If no boundary is
+ * found it stops at the filesystem root, which is what makes the bare-checkout
+ * and wrapper-directory layouts work.
+ *
+ * @param {string} cwd - Directory to start from.
+ * @returns {string | null} Absolute path to the config, or `null` if none.
+ */
+function locateConfig(cwd) {
+  let dir = resolve(cwd);
+  for (;;) {
+    const candidate = join(dir, ".lisa.config.json");
+    if (existsSync(candidate)) return candidate;
+    // Checked AFTER the config, so a repo root carrying one still matches.
+    // Checked as a path rather than a directory because a worktree's `.git` is
+    // a file, and treating that as "not a boundary" would walk out of the
+    // worktree into whatever encloses it.
+    if (existsSync(join(dir, ".git"))) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
  * Read the `secrets` block from `.lisa.config.json`.
  *
  * A project with no block is a supported state, not an error: the `env`
  * provider means the environment *is* the provider. A credentials manager is
  * the preferred path, never a required one.
  * @param {string} [cwd] Directory to look in.
- * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object}} Resolved configuration with defaults applied.
+ * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object, configPath: string|null}} Resolved configuration with defaults applied. `configPath` is the file the values came from, or `null` when none was found and the defaults apply.
  */
 export function readConfig(cwd = process.cwd(), env = process.env) {
-  const path = join(cwd, ".lisa.config.json");
+  // Walk from `cwd` first, then from whatever the harness says the project is.
+  //
+  // A walk from `cwd` alone does not close this. The SessionStart hook that
+  // runs the preflight never changes directory, so its cwd is wherever the
+  // harness happened to spawn it — `$HOME`, a plugin cache — and a walk from
+  // there terminates without finding anything, exactly as a walk from `cwd`
+  // inside the project succeeds. Measured on a session whose credential
+  // resolved fine from its own worktree while the preflight called it
+  // unreachable: every directory from that worktree upward carried a config,
+  // so the hook cannot have been running anywhere in that tree.
+  //
+  // cwd wins when it finds something, because an explicit working directory is
+  // intent and the project variable is only ever a hint about the session.
+  const path =
+    locateConfig(cwd) ??
+    projectAnchors(env)
+      .map(anchor => locateConfig(anchor))
+      .find(found => found !== null) ??
+    null;
   // No repository is a real, supported state — not just a missing file.
   //
   // A Claude Tag channel session runs as the organization with no user account,
@@ -203,7 +279,13 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // The only values a config would supply here are the namespace and provider,
   // so they can come from the environment instead. Everything else keeps its
   // default, and an environment that sets neither still gets the old behaviour.
-  if (!existsSync(path)) return withSurface(fromEnvironment(env));
+  //
+  // It stays supported, but it no longer stays SILENT: `configPath: null` lets
+  // a caller say "no config found, assuming provider=env" instead of printing
+  // a defaulted provider that is indistinguishable from a declared one.
+  if (!path) {
+    return withSurface({ ...fromEnvironment(env), configPath: null });
+  }
   let root;
   try {
     root = JSON.parse(readFileSync(path, "utf8"));
@@ -216,7 +298,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // `secrets` would be a second copy free to disagree with the one every other
   // skill dispatches on.
   const routing = { tracker: root.tracker, source: root.source };
-  if (!cfg) return withSurface({ ...DEFAULTS, routing });
+  if (!cfg) return withSurface({ ...DEFAULTS, routing, configPath: path });
   const provider = cfg.provider ?? DEFAULTS.provider;
   const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
@@ -229,6 +311,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
     routing,
+    configPath: path,
   });
 }
 

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
@@ -189,11 +189,26 @@ export function report(result, cfg) {
   } else {
     lines.push(
       `Secrets preflight FAILED on surface "${cfg.surface}".`,
-      `These credentials are required and resolve nowhere — not in the`,
-      `environment, not materialized, not in the "${cfg.provider}" grant.`,
+      `These credentials are required and were not found in the surfaces`,
+      `consulted — the environment, the materialized file, and the`,
+      `"${cfg.provider}" grant.`,
       `Extend the grant in the vault (or correct the routing that requires`,
       `them), then start a new session:`
     );
+    // A defaulted provider is the one case where the list above is not the
+    // whole story: no config was found, so the vault a project actually
+    // declares was never contacted. Saying "resolve nowhere" there sends the
+    // reader to grant a credential that was never absent.
+    if (!cfg.configPath) {
+      lines.push(
+        ``,
+        `NOTE: no .lisa.config.json was found at or above the working`,
+        `directory, so provider "${cfg.provider}" is a DEFAULT, not this`,
+        `project's setting. If this project uses a vault, the credential may`,
+        `resolve fine — start the session from the repository root, or check`,
+        `the config is present, before treating this as missing.`
+      );
+    }
   }
   lines.push(``);
   for (const { name, reasons } of result.missing) {

--- a/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/lisa/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { bootstrapKeyFor } from "./providers.mjs";
 import { routingFloor } from "./routing-floor.mjs";
@@ -183,16 +183,92 @@ export function materializedPaths(namespace, env = process.env) {
 }
 
 /**
+ * Directories the harness claims are this session's project, best first.
+ *
+ * `CLAUDE_PROJECT_DIR` is set by Claude Code for hook commands, and Lisa's own
+ * hooks already invoke scripts through it. `LISA_PROJECT_DIR` lets a harness
+ * without that convention — or an operator debugging one — say the same thing.
+ *
+ * Blank values are dropped rather than resolved, because an unset variable
+ * expands to the empty string in a shell and `resolve("")` is the current
+ * directory, which would silently re-check a path already searched.
+ *
+ * @param {Record<string, string | undefined>} env - Environment to read.
+ * @returns {string[]} Candidate project roots, deduplicated, best first.
+ */
+function projectAnchors(env) {
+  const raw = [env.LISA_PROJECT_DIR, env.CLAUDE_PROJECT_DIR];
+  return [...new Set(raw.map(value => (value ?? "").trim()).filter(Boolean))];
+}
+
+/**
+ * Find the nearest `.lisa.config.json` at or above `cwd`.
+ *
+ * Looking only in `cwd` made every session started anywhere but the repo root
+ * — a worktree subdirectory, a package folder, a parent wrapper directory —
+ * fall through to the environment defaults and resolve `provider: "env"`. The
+ * preflight then checked the environment, the materialized file, and the "env"
+ * grant, found nothing, and reported the credential as resolving NOWHERE,
+ * having never contacted the configured vault at all.
+ *
+ * That is a false negative wearing a definite answer's clothes, and the
+ * message it produces tells the reader to route the work to blocked. An
+ * obedient agent therefore abandons work over credentials it could have
+ * resolved, and nothing downstream ever re-derives that judgement.
+ *
+ * The walk stops at a repository boundary when it finds one, so a config
+ * belonging to an unrelated parent project is never adopted. If no boundary is
+ * found it stops at the filesystem root, which is what makes the bare-checkout
+ * and wrapper-directory layouts work.
+ *
+ * @param {string} cwd - Directory to start from.
+ * @returns {string | null} Absolute path to the config, or `null` if none.
+ */
+function locateConfig(cwd) {
+  let dir = resolve(cwd);
+  for (;;) {
+    const candidate = join(dir, ".lisa.config.json");
+    if (existsSync(candidate)) return candidate;
+    // Checked AFTER the config, so a repo root carrying one still matches.
+    // Checked as a path rather than a directory because a worktree's `.git` is
+    // a file, and treating that as "not a boundary" would walk out of the
+    // worktree into whatever encloses it.
+    if (existsSync(join(dir, ".git"))) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
  * Read the `secrets` block from `.lisa.config.json`.
  *
  * A project with no block is a supported state, not an error: the `env`
  * provider means the environment *is* the provider. A credentials manager is
  * the preferred path, never a required one.
  * @param {string} [cwd] Directory to look in.
- * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object}} Resolved configuration with defaults applied.
+ * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object, configPath: string|null}} Resolved configuration with defaults applied. `configPath` is the file the values came from, or `null` when none was found and the defaults apply.
  */
 export function readConfig(cwd = process.cwd(), env = process.env) {
-  const path = join(cwd, ".lisa.config.json");
+  // Walk from `cwd` first, then from whatever the harness says the project is.
+  //
+  // A walk from `cwd` alone does not close this. The SessionStart hook that
+  // runs the preflight never changes directory, so its cwd is wherever the
+  // harness happened to spawn it — `$HOME`, a plugin cache — and a walk from
+  // there terminates without finding anything, exactly as a walk from `cwd`
+  // inside the project succeeds. Measured on a session whose credential
+  // resolved fine from its own worktree while the preflight called it
+  // unreachable: every directory from that worktree upward carried a config,
+  // so the hook cannot have been running anywhere in that tree.
+  //
+  // cwd wins when it finds something, because an explicit working directory is
+  // intent and the project variable is only ever a hint about the session.
+  const path =
+    locateConfig(cwd) ??
+    projectAnchors(env)
+      .map(anchor => locateConfig(anchor))
+      .find(found => found !== null) ??
+    null;
   // No repository is a real, supported state — not just a missing file.
   //
   // A Claude Tag channel session runs as the organization with no user account,
@@ -203,7 +279,13 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // The only values a config would supply here are the namespace and provider,
   // so they can come from the environment instead. Everything else keeps its
   // default, and an environment that sets neither still gets the old behaviour.
-  if (!existsSync(path)) return withSurface(fromEnvironment(env));
+  //
+  // It stays supported, but it no longer stays SILENT: `configPath: null` lets
+  // a caller say "no config found, assuming provider=env" instead of printing
+  // a defaulted provider that is indistinguishable from a declared one.
+  if (!path) {
+    return withSurface({ ...fromEnvironment(env), configPath: null });
+  }
   let root;
   try {
     root = JSON.parse(readFileSync(path, "utf8"));
@@ -216,7 +298,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // `secrets` would be a second copy free to disagree with the one every other
   // skill dispatches on.
   const routing = { tracker: root.tracker, source: root.source };
-  if (!cfg) return withSurface({ ...DEFAULTS, routing });
+  if (!cfg) return withSurface({ ...DEFAULTS, routing, configPath: path });
   const provider = cfg.provider ?? DEFAULTS.provider;
   const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
@@ -229,6 +311,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
     routing,
+    configPath: path,
   });
 }
 

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/preflight-secrets.mjs
@@ -189,11 +189,26 @@ export function report(result, cfg) {
   } else {
     lines.push(
       `Secrets preflight FAILED on surface "${cfg.surface}".`,
-      `These credentials are required and resolve nowhere — not in the`,
-      `environment, not materialized, not in the "${cfg.provider}" grant.`,
+      `These credentials are required and were not found in the surfaces`,
+      `consulted — the environment, the materialized file, and the`,
+      `"${cfg.provider}" grant.`,
       `Extend the grant in the vault (or correct the routing that requires`,
       `them), then start a new session:`
     );
+    // A defaulted provider is the one case where the list above is not the
+    // whole story: no config was found, so the vault a project actually
+    // declares was never contacted. Saying "resolve nowhere" there sends the
+    // reader to grant a credential that was never absent.
+    if (!cfg.configPath) {
+      lines.push(
+        ``,
+        `NOTE: no .lisa.config.json was found at or above the working`,
+        `directory, so provider "${cfg.provider}" is a DEFAULT, not this`,
+        `project's setting. If this project uses a vault, the credential may`,
+        `resolve fine — start the session from the repository root, or check`,
+        `the config is present, before treating this as missing.`
+      );
+    }
   }
   lines.push(``);
   for (const { name, reasons } of result.missing) {

--- a/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
+++ b/plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs
@@ -15,7 +15,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 import { bootstrapKeyFor } from "./providers.mjs";
 import { routingFloor } from "./routing-floor.mjs";
@@ -183,16 +183,92 @@ export function materializedPaths(namespace, env = process.env) {
 }
 
 /**
+ * Directories the harness claims are this session's project, best first.
+ *
+ * `CLAUDE_PROJECT_DIR` is set by Claude Code for hook commands, and Lisa's own
+ * hooks already invoke scripts through it. `LISA_PROJECT_DIR` lets a harness
+ * without that convention — or an operator debugging one — say the same thing.
+ *
+ * Blank values are dropped rather than resolved, because an unset variable
+ * expands to the empty string in a shell and `resolve("")` is the current
+ * directory, which would silently re-check a path already searched.
+ *
+ * @param {Record<string, string | undefined>} env - Environment to read.
+ * @returns {string[]} Candidate project roots, deduplicated, best first.
+ */
+function projectAnchors(env) {
+  const raw = [env.LISA_PROJECT_DIR, env.CLAUDE_PROJECT_DIR];
+  return [...new Set(raw.map(value => (value ?? "").trim()).filter(Boolean))];
+}
+
+/**
+ * Find the nearest `.lisa.config.json` at or above `cwd`.
+ *
+ * Looking only in `cwd` made every session started anywhere but the repo root
+ * — a worktree subdirectory, a package folder, a parent wrapper directory —
+ * fall through to the environment defaults and resolve `provider: "env"`. The
+ * preflight then checked the environment, the materialized file, and the "env"
+ * grant, found nothing, and reported the credential as resolving NOWHERE,
+ * having never contacted the configured vault at all.
+ *
+ * That is a false negative wearing a definite answer's clothes, and the
+ * message it produces tells the reader to route the work to blocked. An
+ * obedient agent therefore abandons work over credentials it could have
+ * resolved, and nothing downstream ever re-derives that judgement.
+ *
+ * The walk stops at a repository boundary when it finds one, so a config
+ * belonging to an unrelated parent project is never adopted. If no boundary is
+ * found it stops at the filesystem root, which is what makes the bare-checkout
+ * and wrapper-directory layouts work.
+ *
+ * @param {string} cwd - Directory to start from.
+ * @returns {string | null} Absolute path to the config, or `null` if none.
+ */
+function locateConfig(cwd) {
+  let dir = resolve(cwd);
+  for (;;) {
+    const candidate = join(dir, ".lisa.config.json");
+    if (existsSync(candidate)) return candidate;
+    // Checked AFTER the config, so a repo root carrying one still matches.
+    // Checked as a path rather than a directory because a worktree's `.git` is
+    // a file, and treating that as "not a boundary" would walk out of the
+    // worktree into whatever encloses it.
+    if (existsSync(join(dir, ".git"))) return null;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/**
  * Read the `secrets` block from `.lisa.config.json`.
  *
  * A project with no block is a supported state, not an error: the `env`
  * provider means the environment *is* the provider. A credentials manager is
  * the preferred path, never a required one.
  * @param {string} [cwd] Directory to look in.
- * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object}} Resolved configuration with defaults applied.
+ * @returns {{provider: string, bootstrap: {sources: string[], key: string|null}, require: string[]|null, requiredFloor: readonly string[], rotating: string[], namespace: string, narrow: object, surface: string, routing: {tracker?: string, source?: string}, capabilities: object, configPath: string|null}} Resolved configuration with defaults applied. `configPath` is the file the values came from, or `null` when none was found and the defaults apply.
  */
 export function readConfig(cwd = process.cwd(), env = process.env) {
-  const path = join(cwd, ".lisa.config.json");
+  // Walk from `cwd` first, then from whatever the harness says the project is.
+  //
+  // A walk from `cwd` alone does not close this. The SessionStart hook that
+  // runs the preflight never changes directory, so its cwd is wherever the
+  // harness happened to spawn it — `$HOME`, a plugin cache — and a walk from
+  // there terminates without finding anything, exactly as a walk from `cwd`
+  // inside the project succeeds. Measured on a session whose credential
+  // resolved fine from its own worktree while the preflight called it
+  // unreachable: every directory from that worktree upward carried a config,
+  // so the hook cannot have been running anywhere in that tree.
+  //
+  // cwd wins when it finds something, because an explicit working directory is
+  // intent and the project variable is only ever a hint about the session.
+  const path =
+    locateConfig(cwd) ??
+    projectAnchors(env)
+      .map(anchor => locateConfig(anchor))
+      .find(found => found !== null) ??
+    null;
   // No repository is a real, supported state — not just a missing file.
   //
   // A Claude Tag channel session runs as the organization with no user account,
@@ -203,7 +279,13 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // The only values a config would supply here are the namespace and provider,
   // so they can come from the environment instead. Everything else keeps its
   // default, and an environment that sets neither still gets the old behaviour.
-  if (!existsSync(path)) return withSurface(fromEnvironment(env));
+  //
+  // It stays supported, but it no longer stays SILENT: `configPath: null` lets
+  // a caller say "no config found, assuming provider=env" instead of printing
+  // a defaulted provider that is indistinguishable from a declared one.
+  if (!path) {
+    return withSurface({ ...fromEnvironment(env), configPath: null });
+  }
   let root;
   try {
     root = JSON.parse(readFileSync(path, "utf8"));
@@ -216,7 +298,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
   // `secrets` would be a second copy free to disagree with the one every other
   // skill dispatches on.
   const routing = { tracker: root.tracker, source: root.source };
-  if (!cfg) return withSurface({ ...DEFAULTS, routing });
+  if (!cfg) return withSurface({ ...DEFAULTS, routing, configPath: path });
   const provider = cfg.provider ?? DEFAULTS.provider;
   const namespace = assertNamespace(cfg.namespace ?? DEFAULTS.namespace);
   return withSurface({
@@ -229,6 +311,7 @@ export function readConfig(cwd = process.cwd(), env = process.env) {
     narrow: { ...DEFAULTS.narrow, ...(cfg.narrow ?? {}) },
     surface: cfg.surface ?? null,
     routing,
+    configPath: path,
   });
 }
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1263,7 +1263,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/note-format.mjs":
       "09bd6904bc84a5a93a32499ac94db5ec7728db68908a661698445ef5e6974f3e",
     "plugins/src/base/skills/lisa-secrets-access/scripts/preflight-secrets.mjs":
-      "f6c6f87bb309d755fb715abcf5f7f1802d3ed7375a0d052118c547c3c46d5e37",
+      "98a0a541041d543fe91e6260da4a25e383123a0eb40bad32a4d59551b7da8db8",
     "plugins/src/base/skills/lisa-secrets-access/scripts/prompt-secret.mjs":
       "22b28bcdf49b9b0fcd1b15639e031655efacc028b74d48d57e2275f3e1557508",
     "plugins/src/base/skills/lisa-secrets-access/scripts/providers.mjs":
@@ -1277,7 +1277,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-secrets-access/scripts/routing-floor.mjs":
       "fa1bdeda4e38bbd149f993ab0288f11b7ba6f2a3b9bf91a5918de7356e21f786",
     "plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs":
-      "945957bbb54d184a07703cf727844f0838810d33dd385b068934b571252934e6",
+      "1c2ef17fe647c86bfe0540f07bd1d9ca66980e18516fddc874723f69b9df27ce",
     "plugins/src/base/skills/lisa-secrets-access/scripts/sync-secret-to-ci.mjs":
       "563ab35320a0ba58269ac3dd81155ffe3a299f6835210073e6fc9012ab436f41",
     "plugins/src/base/skills/lisa-secrets-access/scripts/tools-from-notes.mjs":
@@ -9110,6 +9110,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/secrets/bootstrap-defaults.test.ts": true,
     "tests/unit/secrets/bootstrap-key-naming.test.ts": true,
     "tests/unit/secrets/bootstrap-store.test.ts": true,
+    "tests/unit/secrets/config-upward-walk.test.ts": true,
     "tests/unit/secrets/detect-tooling-discovery.test.ts": true,
     "tests/unit/secrets/detect-tooling.test.ts": true,
     "tests/unit/secrets/doctor-secrets.test.ts": true,

--- a/tests/unit/secrets/config-upward-walk.test.ts
+++ b/tests/unit/secrets/config-upward-walk.test.ts
@@ -1,0 +1,148 @@
+/**
+ * `.lisa.config.json` must be found from anywhere inside the project.
+ *
+ * Looking only in `cwd` made every session started below the repository root —
+ * a worktree subdirectory, a package folder, a parent wrapper directory — fall
+ * through to the environment defaults and resolve `provider: "env"`. The
+ * secrets preflight then consulted the environment, the materialized file and
+ * the "env" grant, found nothing, and reported the credential as resolving
+ * NOWHERE, having never contacted the vault the project actually declares.
+ *
+ * That is a false negative wearing a definite answer's clothes. The message it
+ * produced instructed the reader to route the work to blocked, so an obedient
+ * agent abandoned work over a credential that was sitting in Bitwarden the
+ * whole time — and unlike a crash, nothing downstream ever re-derived it.
+ * @module tests/unit/secrets/config-upward-walk
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { readConfig } from "../../../plugins/src/base/skills/lisa-secrets-access/scripts/surfaces.mjs";
+
+/** The vault a project declares, which must survive a nested cwd. */
+const DECLARED = "bitwarden";
+/** The fallback that a missed config silently substituted for it. */
+const DEFAULTED = "env";
+
+const roots: string[] = [];
+
+/**
+ * Build a repository whose config sits at the root.
+ * @param withConfig - Whether to write a `.lisa.config.json`.
+ * @returns The repository root path.
+ */
+const makeRepo = (withConfig: boolean): string => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-walk-"));
+  roots.push(root);
+  // A worktree's `.git` is a FILE, not a directory — the boundary check must
+  // treat both as a boundary, or the walk escapes the worktree entirely.
+  fs.writeFileSync(path.join(root, ".git"), "gitdir: /elsewhere\n");
+  if (withConfig) {
+    fs.writeFileSync(
+      path.join(root, ".lisa.config.json"),
+      JSON.stringify({
+        tracker: "linear",
+        secrets: {
+          provider: DECLARED,
+          namespace: "tunnl",
+          require: ["LINEAR_API_KEY"],
+        },
+      })
+    );
+  }
+  return root;
+};
+
+describe("locating .lisa.config.json from a nested working directory", () => {
+  afterEach(() => {
+    for (const root of roots) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+    roots.length = 0;
+  });
+
+  it("finds the project's config from a deeply nested directory", () => {
+    const root = makeRepo(true);
+    const deep = path.join(root, "src", "features", "chat");
+    fs.mkdirSync(deep, { recursive: true });
+
+    expect(readConfig(root, {}).provider).toBe(DECLARED);
+    // The reported failure: identical project, three levels down.
+    expect(readConfig(deep, {}).provider).toBe(DECLARED);
+  });
+
+  it("reports whether the provider was declared or defaulted", () => {
+    // A defaulted `env` was indistinguishable from a project that genuinely
+    // uses `env`, which is what let the wrong answer look like a real one.
+    const root = makeRepo(true);
+    expect(readConfig(root, {}).configPath).toBeTruthy();
+
+    const bare = makeRepo(false);
+    const resolved = readConfig(bare, {});
+    expect(resolved.provider).toBe(DEFAULTED);
+    expect(resolved.configPath).toBeNull();
+  });
+
+  it("stops at a repository boundary rather than adopting a stranger's config", () => {
+    const outer = makeRepo(true);
+    const nested = path.join(outer, "vendored");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, ".git"), "gitdir: /other\n");
+
+    // The outer config is NOT this project's. Walking past the boundary would
+    // point a session at another project's vault, which is worse than the bug.
+    expect(readConfig(nested, {}).provider).toBe(DEFAULTED);
+  });
+
+  it("resolves when the hook's cwd is outside the project entirely", () => {
+    // The failure that actually shipped. The SessionStart hook never changes
+    // directory, so its cwd is wherever the harness spawned it — $HOME, a
+    // plugin cache — and a walk from there finds nothing no matter how many
+    // configs sit in the project. A cwd walk alone would NOT have caught this.
+    const root = makeRepo(true);
+    const elsewhere = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-elsewhere-"));
+    roots.push(elsewhere);
+
+    expect(readConfig(elsewhere, {}).provider).toBe(DEFAULTED);
+    expect(readConfig(elsewhere, { CLAUDE_PROJECT_DIR: root }).provider).toBe(
+      DECLARED
+    );
+    expect(readConfig(elsewhere, { LISA_PROJECT_DIR: root }).provider).toBe(
+      DECLARED
+    );
+  });
+
+  it("prefers an explicit working directory over the harness hint", () => {
+    // cwd is intent; the project variable is only ever a hint about the
+    // session. A caller that named a directory must not be redirected.
+    const inProject = makeRepo(true);
+    const other = makeRepo(false);
+    expect(readConfig(inProject, { CLAUDE_PROJECT_DIR: other }).provider).toBe(
+      DECLARED
+    );
+  });
+
+  it("ignores a blank project variable rather than resolving it to cwd", () => {
+    // An unset shell variable expands to "", and resolve("") is the current
+    // directory — which would silently re-search a path already searched.
+    const elsewhere = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-blank-"));
+    roots.push(elsewhere);
+    expect(readConfig(elsewhere, { CLAUDE_PROJECT_DIR: "  " }).provider).toBe(
+      DEFAULTED
+    );
+  });
+
+  it("keeps no-repository as a supported state, not an error", () => {
+    // A Claude Tag channel session has no checkout and still needs
+    // credentials, so a missing config must resolve rather than throw.
+    const resolved = readConfig(path.join(os.tmpdir(), "lisa-no-such-dir"), {
+      LISA_TENANT: "tunnl",
+    });
+    expect(resolved.namespace).toBe("tunnl");
+    expect(resolved.configPath).toBeNull();
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2659

The secrets preflight resolved `.lisa.config.json` from `process.cwd()` only. A miss fell through to environment defaults, produced `provider: "env"`, and reported required credentials as resolving **"nowhere"** — having never contacted the vault the project declares.

Measured: a session was told `LINEAR_API_KEY` resolved nowhere while, from that same session's working directory, `resolve-secret.mjs get LINEAR_API_KEY` returned a 48-character value on exit 0.

## Two misses, and the obvious fix only closes one

| # | cwd | why it missed | closed by |
|---|---|---|---|
| 1 | inside the project, below the root | config sits at the root | upward walk |
| 2 | **outside the project entirely** | the SessionStart hook never `cd`s | project-dir anchor |

The reporting session hit **(2)**. Every directory from its worktree upward carried a bitwarden config, so a walk from anywhere in that chain would have found one on the first hop — and the preflight still said `env`. That is only possible if it was not running in that tree at all.

So the upward walk is necessary and **not sufficient**. Shipping it alone would have fixed an adjacent bug and left the reported one intact.

## Precedence, and why cwd wins

`cwd` is intent; the harness variable is a hint about the session. A caller that names a directory is not redirected. Blank values are dropped rather than resolved — an unset shell variable expands to `""`, and `resolve("")` is the current directory, which would silently re-search a path already searched.

The walk stops at a repository boundary — checked *after* the config so a repo root carrying one still matches, and checked as a **path** rather than a directory because a worktree's `.git` is a file. Adopting an unrelated parent project's vault would be worse than the bug.

## Degradation preserved, but no longer silent

No-repository stays supported: a Claude Tag channel session has no checkout and still needs credentials, and that comment in the source is load-bearing. What changes is that it becomes **distinguishable** — `configPath: null` lets the preflight say the provider is a DEFAULT instead of printing one indistinguishable from a declared setting.

The preflight also stops claiming credentials "resolve nowhere". It consulted one provider, so it now names the surfaces it actually checked.

That wording is the part with teeth. The message ends *"Route the item to blocked"* — which converts a false negative into abandoned work. The reporting session obeyed it and handed its user a markdown file to paste by hand. Unlike a crash, nothing downstream ever re-derives that judgement.

## Verification

`13,031 tests passed`. Both halves proven to bite, each failing its **own** named test:

```
walk limited to cwd        -> × finds the project's config from a deeply nested directory
project-dir anchor removed -> × resolves when the hook's cwd is outside the project entirely
restored                   -> 7 passed
```

Two separate controls because a single one would have let either half ship inert — which is exactly how the original defect survived: the preflight genuinely calls `fetch(cfg)` and carefully separates `unreachable` from absent, and config resolution defeated all of that upstream.

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved project configuration discovery from nested directories and configured project locations.
  * Added support for container-based secret materialization.
  * Claude Web secrets now refresh during setup and session start.
  * Configuration status now indicates the resolved file or when defaults are used.

* **Bug Fixes**
  * Improved missing-credential messages to distinguish absent credentials from missing project configuration.
  * Added guidance to verify project configuration before treating credentials as unavailable.

* **Tests**
  * Added coverage for configuration lookup, repository boundaries, project hints, and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->