### PR TITLE
fix(doctor): stop certifying a serialize opt-in nothing can make work

### DIFF
--- a/src/cli/doctor-serialize-legs-contract.ts
+++ b/src/cli/doctor-serialize-legs-contract.ts
@@ -9,6 +9,35 @@ import type { DoctorCheck } from "./doctor.js";
 
 const CHECK_NAME = "Maestro leg serialization wired?";
 
+/**
+ * Whether the REUSABLE workflow's own `permissions:` block grants `actions`.
+ *
+ * This is the part no caller can supply. A called workflow's `permissions:`
+ * block is a ceiling that zeroes everything unlisted, so a caller's grant is
+ * discarded at the reusable-workflow boundary no matter where it is placed.
+ * While this is false, `serialize_platform_legs` cannot order anything in ANY
+ * repository, and reporting a fully configured caller as `ok` would certify a
+ * configuration measured to fail.
+ *
+ * Measured 2026-08-17 against a caller granting `actions: read` at BOTH job and
+ * workflow level: the job's own token grant showed `Contents: read` and
+ * `Metadata: read` with no Actions scope, the jobs API answered 403, and the
+ * two platform legs started two seconds apart.
+ *
+ * A constant rather than a read of the workflow file, because consumers
+ * reference the reusable workflow at `@main` and do not have a copy of it to
+ * read. `serialize-legs-callee-grant.test.ts` pins this to the actual
+ * `permissions:` block in `.github/workflows/maestro-native-e2e.yml`, so it
+ * cannot drift from what Lisa ships — flipping it and forgetting the workflow,
+ * or the reverse, fails that test.
+ *
+ * Residual limit worth naming: a consumer's `lisa doctor` comes from its
+ * installed package while the workflow it runs comes from `@main`, so a stale
+ * install can disagree with what actually runs. That is a property of `@main`
+ * refs, not of this check.
+ */
+export const CALLEE_GRANTS_ACTIONS_READ = false;
+
 /** Which of the three required parts a caller declares. */
 export interface SerializeContract {
   /** `serialize_platform_legs: true` in the `with:` block. */
@@ -108,6 +137,22 @@ export async function checkSerializeLegsContract(
 
   const missing = missingParts(contract);
   if (missing.length === 0) {
+    if (!CALLEE_GRANTS_ACTIONS_READ) {
+      return {
+        name: CHECK_NAME,
+        status: "warn",
+        detail:
+          "serialize_platform_legs is enabled and this repository's side is " +
+          "complete, but the ordering CANNOT work in this version of Lisa and " +
+          "nothing here will change that. The reusable workflow's own " +
+          "`permissions:` block omits `actions`, and a called workflow's " +
+          "permissions are a ceiling that zeroes everything unlisted — so the " +
+          "grant is discarded at the boundary wherever it is declared. The " +
+          "jobs API answers 403, the ordering job logs a warning, concludes " +
+          "`success`, and both legs start together. Nothing to fix here; " +
+          "tracked upstream on CodySwannGT/lisa#2662",
+      };
+    }
     return {
       name: CHECK_NAME,
       status: "ok",
@@ -129,7 +174,10 @@ export async function checkSerializeLegsContract(
       "the suite behaves exactly as it did before the opt-in while reporting " +
       "green. `actions: read` must sit on the CALLING workflow's own " +
       "`permissions:`, not on the job: a called workflow requesting a scope " +
-      "its caller never held is a startup_failure for the entire run",
+      "its caller never held is a startup_failure for the entire run. " +
+      "Completing these parts is necessary but NOT sufficient today — see " +
+      "CodySwannGT/lisa#2662, which tracks the reusable workflow's own " +
+      "permissions ceiling discarding the grant",
   };
 }
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8753,6 +8753,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/cli/merge-learnings-cmd.test.ts": true,
     "tests/unit/cli/parse-refresh-templates.test.ts": true,
     "tests/unit/cli/prompts.test.ts": true,
+    "tests/unit/cli/serialize-legs-callee-grant.test.ts": true,
     "tests/unit/cli/setup-project.test.ts": true,
     "tests/unit/cli/setup-wiki.test.ts": true,
     "tests/unit/cli/shared-options.test.ts": true,

--- a/tests/unit/cli/serialize-legs-callee-grant.test.ts
+++ b/tests/unit/cli/serialize-legs-callee-grant.test.ts
@@ -1,0 +1,125 @@
+/**
+ * The callee-grant constant must never disagree with the workflow Lisa ships.
+ *
+ * `CALLEE_GRANTS_ACTIONS_READ` is what stops `lisa doctor` certifying a
+ * `serialize_platform_legs` opt-in that no caller configuration can make work.
+ * It is a constant rather than a file read because consumers reference the
+ * reusable workflow at `@main` and have no copy of it to read — which means
+ * nothing else can catch it drifting from reality.
+ *
+ * That drift is the whole risk. A constant left `false` after the workflow
+ * grants the scope makes doctor warn forever about a fixed problem; left `true`
+ * before it does, doctor certifies the exact configuration measured to answer
+ * HTTP 403 with both legs starting two seconds apart. The second is how this
+ * check came to vouch for the defect it exists to catch.
+ * @module tests/unit/cli/serialize-legs-callee-grant
+ */
+import fs from "node:fs";
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CALLEE_GRANTS_ACTIONS_READ,
+  checkSerializeLegsContract,
+} from "../../../src/cli/doctor-serialize-legs-contract.js";
+
+const WORKFLOW = path.join(
+  process.cwd(),
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/**
+ * Whether the reusable workflow's own top-level `permissions:` block grants
+ * `actions`.
+ *
+ * Read from the top-level block only. A job-level grant does not raise the
+ * workflow's ceiling, and treating one as equivalent would reintroduce exactly
+ * the mis-scoping this whole area exists to catch.
+ * @returns True when the workflow's own permissions include `actions`.
+ */
+const workflowGrantsActions = (): boolean => {
+  const source = readFileSync(WORKFLOW, "utf8");
+  const lines = source.split("\n");
+  const start = lines.findIndex(line => /^permissions:\s*$/u.test(line));
+  if (start === -1) {
+    // No block at all means the caller's grant is INHERITED rather than
+    // capped — a different world from today's, and one that hands a permissive
+    // consumer write scopes. It must not be read as "grants actions".
+    return false;
+  }
+  for (const line of lines.slice(start + 1)) {
+    // The block ends at the first line that is not an indented entry.
+    if (!/^\s+\S/u.test(line)) break;
+    if (/^\s+actions:\s*(read|write)\s*$/u.test(line)) return true;
+  }
+  return false;
+};
+
+describe("serialize-legs callee grant tracks the shipped workflow", () => {
+  it("matches the reusable workflow's own permissions block", () => {
+    expect(CALLEE_GRANTS_ACTIONS_READ).toBe(workflowGrantsActions());
+  });
+
+  it("refuses to certify a fully configured caller while the callee cannot receive the scope", async () => {
+    // The defect this replaces. TunnlAI/frontend declares every caller-side
+    // part — serialize on, token forwarded, `actions: read` at BOTH job and
+    // workflow level — and the check reported `ok`. That same configuration
+    // was measured at HTTP 403 with the two legs starting two seconds apart.
+    //
+    // A check that passes on a broken configuration is worse than no check: it
+    // converts "unverified" into "verified", and it is consulted instead of
+    // the runtime evidence.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-legs-"));
+    try {
+      fs.mkdirSync(path.join(root, ".github", "workflows"), {
+        recursive: true,
+      });
+      fs.writeFileSync(
+        path.join(root, ".github", "workflows", "maestro-e2e.yml"),
+        [
+          "name: Nightly",
+          "permissions:",
+          "  contents: read",
+          "  actions: read",
+          "jobs:",
+          "  native:",
+          "    permissions:",
+          "      contents: read",
+          "      actions: read",
+          "    uses: CodySwannGT/lisa/.github/workflows/maestro-native-e2e.yml@main",
+          "    with:",
+          "      serialize_platform_legs: true",
+          "    secrets:",
+          "      LEG_ORDER_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+          "",
+        ].join("\n")
+      );
+
+      const result = await checkSerializeLegsContract(root);
+      expect(CALLEE_GRANTS_ACTIONS_READ).toBe(false);
+      expect(result.status).toBe("warn");
+      expect(result.detail).toContain("CANNOT work");
+      // It must not send the operator to fix their own config: theirs is done.
+      expect(result.detail).toContain("Nothing to fix here");
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not read a job-level grant as the workflow's own", () => {
+    // The measured failure was `actions: read` on the job. If that ever counted
+    // here, the constant would flip on a change that grants nothing.
+    const source = readFileSync(WORKFLOW, "utf8");
+    const start = source
+      .split("\n")
+      .findIndex(line => line.startsWith("jobs:"));
+    expect(start).toBeGreaterThan(-1);
+    // Whatever jobs declare, the answer above comes from the top-level block.
+    expect(typeof workflowGrantsActions()).toBe("boolean");
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2661

`lisa doctor`'s serialize-legs check reported **ok** for a configuration measured to fail — and the check exists specifically to catch that failure.

Run against `a caller in the portfolio`'s caller, which grants `actions: read` at **both** job and workflow level and forwards the token:

```
contract:          {"optedIn":true,"forwardsToken":true,"grantsActionsRead":true}
missingParts:      []
isIncompleteOptIn: false        -> doctor says OK
```

The same configuration at runtime: jobs API **403**, ordering job logs a warning, concludes `success`, and the two platform legs start **two seconds apart**.

## Why no caller can fix it

The reusable workflow declares `permissions: contents: read`. A called workflow's `permissions:` block is a ceiling that **zeroes everything unlisted**, so the caller's grant is discarded at the reusable-workflow boundary wherever it is placed. `LEG_ORDER_TOKEN` was designed to route around that by forwarding a secret instead of declaring a scope; that route does not exist while the ceiling omits `actions`.

So the check's remediation — *"`actions: read` must sit on the CALLING workflow's own permissions block"* — sent operators to do the one thing that cannot help. It shipped from a diagnosis since retracted by the session that made it: **there is no placement that works.**

## The shape of the fix

`CALLEE_GRANTS_ACTIONS_READ` gates the `ok` branch. While false, a fully-configured caller gets a warning that says the ordering cannot work in this version and **"Nothing to fix here"** — because their side genuinely is complete.

A constant rather than a file read, because consumers reference the workflow at `@main` and hold no copy to read. A test pins it to the actual `permissions:` block in the shipped workflow, so it cannot drift **in either direction**: flipping the constant without the workflow fails, and changing the workflow without the constant fails. It reads the top-level block only — a job-level grant does not raise the ceiling, and counting one would reintroduce the exact mis-scoping this area exists to catch.

## Verification

`13,034 tests passed`. Two bite controls, each failing its own named test:

```
callee gate removed              -> × refuses to certify a fully configured caller …
constant flipped, workflow same  -> × matches the reusable workflow's own permissions block
                                    × refuses to certify a fully configured caller …
restored                         -> 3 passed
```

The second control is the one that matters longest: it proves the drift test bites, which is what stops this check going stale again once #2662 ships.

## Scope

Granting the scope in the reusable workflow is **#2662**, deliberately blocked. Consumers reference `@main`, so that change reaches every consumer on their next run with no staged rollout — and three of four portfolio repos have no caller-side `actions: read`, so it would `startup_failure` repos that never opted into serialization at all.

This PR has zero fleet impact and is the unblocked first step.

🤖 Generated with Claude Code