### PR TITLE
feat(maestro): declare actions: read so leg serialization can work

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -432,8 +432,32 @@ on:
           Android leg start — it never fails the run over it.
         required: false
 
+# `actions: read` is what makes `serialize_platform_legs` capable of ordering
+# anything at all. A called workflow's `permissions:` block is a CEILING that
+# zeroes everything unlisted, so a caller granting the scope had it discarded at
+# this boundary wherever it was declared — which is why the ordering job read
+# the jobs API, got HTTP 403, and released the Android leg on every run in every
+# repository since the feature shipped. `LEG_ORDER_TOKEN` was designed to route
+# around #2046 by forwarding a secret rather than declaring a scope; that route
+# does not exist while this block omits `actions`.
+#
+# Declared explicitly rather than by OMITTING the block, which was measured as
+# the other way to make it work: a callee with no `permissions:` inherits the
+# caller's grant, but a consumer whose repo default is `write` then hands this
+# workflow nineteen write scopes including `contents`, `packages` and
+# `securityEvents` — on a workflow that runs Maestro flows and third-party
+# actions, with nothing in the diff to say so. Naming the two keeps the ceiling
+# a ceiling.
+#
+# The cost of declaring it: a caller that has NOT granted `actions: read` now
+# gets a `startup_failure` for its entire run, decided before any `if:` is
+# evaluated, whether or not it opted into serialization. Every `@main` caller in
+# the portfolio was confirmed to grant it before this landed — there is no
+# version to pin away from, so the check had to be exhaustive rather than
+# hopeful.
 permissions:
   contents: read
+  actions: read
 
 # Cross-run serialization is opt-in via the `concurrency_group` input, and the
 # default is deadlock-safe by construction: an unset input yields a group unique

--- a/src/cli/doctor-serialize-legs-contract.ts
+++ b/src/cli/doctor-serialize-legs-contract.ts
@@ -184,6 +184,13 @@ export async function checkSerializeLegsContract(
   };
 }
 
+/** The slice of a calling job this check reads. */
+interface CallingJob {
+  readonly uses?: string;
+  readonly with?: Record<string, unknown>;
+  readonly secrets?: Record<string, unknown>;
+}
+
 /**
  * Read which parts of the contract a caller workflow declares.
  *
@@ -200,15 +207,61 @@ export function readContract(source: string): SerializeContract {
     .split("\n")
     .filter(line => !line.trim().startsWith("#"))
     .join("\n");
+  const call = callingJob(source);
   return {
-    optedIn: /serialize_platform_legs:\s*true/u.test(uncommented),
-    forwardsToken: /LEG_ORDER_TOKEN:/u.test(uncommented),
+    // Read from the CALLING JOB when the file parses, because the three parts
+    // only mean anything together. Whole-file matching reported `ok` for a
+    // workflow with `serialize_platform_legs` in one job and `LEG_ORDER_TOKEN`
+    // in another — the actual call then omits the token and releases Android
+    // regardless, which is the check saying yes without binding its evidence.
+    optedIn: call
+      ? call.with?.serialize_platform_legs === true
+      : /serialize_platform_legs:\s*true/u.test(uncommented),
+    forwardsToken: call
+      ? Object.hasOwn(call.secrets ?? {}, "LEG_ORDER_TOKEN")
+      : /LEG_ORDER_TOKEN:/u.test(uncommented),
     grantsActionsRead: hasWorkflowActionsRead(source, uncommented),
   };
 }
 
 /**
+ * The job that calls Lisa's reusable Maestro workflow, when the file parses.
+ *
+ * `null` when the YAML will not parse or no job calls it — the caller then
+ * falls back to whole-file matching, which is weaker but still answers on a
+ * workflow this cannot read. A file with a syntax error elsewhere still
+ * deserves the check.
+ * @param source - Raw workflow YAML.
+ * @returns The calling job, or `null`.
+ */
+function callingJob(source: string): CallingJob | null {
+  try {
+    const doc = loadYaml(source) as {
+      readonly jobs?: Record<string, CallingJob>;
+    } | null;
+    const jobs = Object.values(doc?.jobs ?? {});
+    return (
+      jobs.find(job =>
+        typeof job?.uses === "string"
+          ? job.uses.includes("maestro-native-e2e.yml")
+          : false
+      ) ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Whether `actions: read` sits on the WORKFLOW's own permissions, not a job's.
+ *
+ * A job-level grant on the calling job is deliberately NOT accepted here, and
+ * the reason is a measurement: on 2026-08-17 a caller declaring `actions: read`
+ * at job level produced HTTP 403 from the jobs API, the ordering job released
+ * Android anyway, and both platform legs started within the same second. The
+ * top-level block is what reached the token. Counting a job-level grant would
+ * make this check pass for the exact configuration that was measured to fail —
+ * which is the defect this file was rewritten to stop doing.
  *
  * Placement is the whole point, and a text match cannot tell the two apart. The
  * measured failure on 2026-08-17 was `actions: read` declared at JOB level: the

--- a/src/cli/doctor-serialize-legs-contract.ts
+++ b/src/cli/doctor-serialize-legs-contract.ts
@@ -17,7 +17,9 @@ const CHECK_NAME = "Maestro leg serialization wired?";
  * discarded at the reusable-workflow boundary no matter where it is placed.
  * While this is false, `serialize_platform_legs` cannot order anything in ANY
  * repository, and reporting a fully configured caller as `ok` would certify a
- * configuration measured to fail.
+ * configuration measured to fail. It is now TRUE: the reusable workflow
+ * declares `actions: read` for itself, so a fully configured caller can
+ * genuinely order its legs and `ok` is an honest verdict again.
  *
  * Measured 2026-08-17 against a caller granting `actions: read` at BOTH job and
  * workflow level: the job's own token grant showed `Contents: read` and
@@ -36,7 +38,7 @@ const CHECK_NAME = "Maestro leg serialization wired?";
  * install can disagree with what actually runs. That is a property of `@main`
  * refs, not of this check.
  */
-export const CALLEE_GRANTS_ACTIONS_READ = false;
+export const CALLEE_GRANTS_ACTIONS_READ = true;
 
 /** Which of the three required parts a caller declares. */
 export interface SerializeContract {
@@ -175,9 +177,10 @@ export async function checkSerializeLegsContract(
       "green. `actions: read` must sit on the CALLING workflow's own " +
       "`permissions:`, not on the job: a called workflow requesting a scope " +
       "its caller never held is a startup_failure for the entire run. " +
-      "Completing these parts is necessary but NOT sufficient today — see " +
-      "CodySwannGT/lisa#2662, which tracks the reusable workflow's own " +
-      "permissions ceiling discarding the grant",
+      "The reusable workflow now declares `actions: read` for itself " +
+      "(CodySwannGT/lisa#2662), so completing these parts is what makes " +
+      "ordering work — and a caller that has NOT granted the scope gets a " +
+      "startup_failure for its whole run, opted in or not",
   };
 }
 

--- a/tests/integration/maestro-leg-order.test.ts
+++ b/tests/integration/maestro-leg-order.test.ts
@@ -166,11 +166,26 @@ describe("maestro-native-e2e leg ordering — job graph", () => {
       expect(declaring).toEqual([]);
     });
 
-    it("keeps the workflow-level grant at contents: read", () => {
-      // The negative control for the assertion above. Moving the escalation up
-      // to the workflow level would satisfy a per-job check while causing the
+    it("keeps the workflow-level grant to exactly contents+actions read", () => {
+      // The negative control for the assertion above: a scope added at the
+      // workflow level would satisfy a per-job check while causing the
       // identical startup_failure, so the ceiling is pinned too.
-      expect(raw.permissions).toEqual({ contents: "read" });
+      //
+      // `actions: read` is now part of that ceiling, and it is the ONE scope
+      // this workflow may hold beyond contents. It reads this run's own job
+      // list, which is what lets `serialize_platform_legs` order the legs at
+      // all; without it the poll answered HTTP 403 on every run in every
+      // repository since the feature shipped. It was added only after all four
+      // consumers were confirmed to grant it on their default branches —
+      // see the header of reusable-workflow-caller-scopes.test.ts for why that
+      // order is not optional.
+      //
+      // Pinned as equality so the next scope still has to come through that
+      // same door.
+      expect(raw.permissions).toEqual({
+        contents: "read",
+        actions: "read",
+      });
     });
   });
 

--- a/tests/integration/reusable-workflow-caller-scopes.test.ts
+++ b/tests/integration/reusable-workflow-caller-scopes.test.ts
@@ -89,7 +89,13 @@ const BASELINE: Readonly<Record<string, ScopeMap>> = {
   // `contents: read` only. The leg-ordering job reads the jobs API through the
   // forwarded LEG_ORDER_TOKEN secret precisely so this line does not have to
   // gain `actions: read` — see #2566.
-  "maestro-native-e2e.yml": { contents: "read" },
+  // Gained `actions: read` deliberately, under rule 3 of this file's header:
+  // the caller migration shipped FIRST and was confirmed on every consumer's
+  // default branch before this line changed. The job that needs it polls this
+  // run's own job list to order the platform legs; forwarding a token instead
+  // (rule 1, the default answer) was implemented as LEG_ORDER_TOKEN and
+  // MEASURED to fail with HTTP 403, so rule 1 is exhausted rather than untried.
+  "maestro-native-e2e.yml": { contents: "read", actions: "read" },
   "nightly-e2e-health.yml": {
     actions: "read",
     contents: "read",
@@ -149,15 +155,23 @@ describe("reusable workflows never gain a declared permission scope", () => {
     // exactly like a clean fleet. This reproduces #2566 exactly: a JOB-level
     // `actions: read` under a workflow-level `contents: read`, which a check
     // reading only the workflow-level block would have waved through.
+    // The scope is deliberately NOT `actions: read` any more — that is now in
+    // the baseline, so reusing it would compare a value to itself and the
+    // control would pass while proving nothing. `packages: write` stands in for
+    // "the next scope somebody adds".
     const regressed = declaredScopes({
-      permissions: { contents: "read" },
-      jobs: { leg_order: { permissions: { actions: "read" } } },
+      permissions: { contents: "read", actions: "read" },
+      jobs: { leg_order: { permissions: { packages: "write" } } },
     });
-    expect(regressed).toEqual({ contents: "read", actions: "read" });
+    expect(regressed).toEqual({
+      contents: "read",
+      actions: "read",
+      packages: "write",
+    });
     expect(regressed).not.toEqual(BASELINE["maestro-native-e2e.yml"]);
     expect(
       missingScopes(BASELINE["maestro-native-e2e.yml"], regressed)
-    ).toEqual(["actions:read"]);
+    ).toEqual(["packages:write"]);
   });
 
   it("counts a raised level as a gain, not only a brand-new scope", () => {

--- a/tests/unit/cli/serialize-legs-callee-grant.test.ts
+++ b/tests/unit/cli/serialize-legs-callee-grant.test.ts
@@ -24,6 +24,7 @@ import { describe, expect, it } from "vitest";
 import {
   CALLEE_GRANTS_ACTIONS_READ,
   checkSerializeLegsContract,
+  readContract,
 } from "../../../src/cli/doctor-serialize-legs-contract.js";
 
 const WORKFLOW = path.join(
@@ -60,6 +61,23 @@ const workflowGrantsActions = (): boolean => {
   return false;
 };
 
+/** The workflow-level grant a conforming caller declares. */
+const GRANT = ["permissions:", "  contents: read", "  actions: read"] as const;
+
+/** Header shared by the caller fixtures below. */
+const HEADER = ["name: Nightly", ...GRANT, "jobs:"] as const;
+
+/** The line that makes a job the one calling Lisa's reusable workflow. */
+const CALLS_LISA =
+  "    uses: CodySwannGT/lisa/.github/workflows/maestro-native-e2e.yml@main";
+
+/** The two parts a caller must declare on that same job. */
+const OPTS_IN = ["    with:", "      serialize_platform_legs: true"] as const;
+const FORWARDS = [
+  "    secrets:",
+  "      LEG_ORDER_TOKEN: ${{ secrets.GITHUB_TOKEN }}",
+] as const;
+
 describe("serialize-legs callee grant tracks the shipped workflow", () => {
   it("matches the reusable workflow's own permissions block", () => {
     expect(CALLEE_GRANTS_ACTIONS_READ).toBe(workflowGrantsActions());
@@ -77,9 +95,7 @@ describe("serialize-legs callee grant tracks the shipped workflow", () => {
         path.join(root, ".github", "workflows", "maestro-e2e.yml"),
         [
           "name: Nightly",
-          "permissions:",
-          "  contents: read",
-          "  actions: read",
+          ...GRANT,
           "jobs:",
           "  native:",
           "    permissions:",
@@ -105,6 +121,50 @@ describe("serialize-legs callee grant tracks the shipped workflow", () => {
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }
+  });
+
+  it("does not accept the parts spread across different jobs", () => {
+    // Whole-file matching reported `ok` here: `serialize_platform_legs` in one
+    // job, `LEG_ORDER_TOKEN` in another, and neither in the job that actually
+    // calls the reusable workflow. The real call then omits the token and
+    // releases Android regardless — the check saying yes without binding its
+    // evidence together.
+    const split = readContract(
+      [
+        ...HEADER,
+        "  unrelated:",
+        "    uses: ./.github/workflows/other.yml",
+        ...OPTS_IN,
+        ...FORWARDS,
+        "  native:",
+        CALLS_LISA,
+        "",
+      ].join("\n")
+    );
+    expect(split.optedIn).toBe(false);
+    expect(split.forwardsToken).toBe(false);
+  });
+
+  it("reads the parts from the job that calls the reusable workflow", () => {
+    const bound = readContract(
+      [...HEADER, "  native:", CALLS_LISA, ...OPTS_IN, ...FORWARDS, ""].join(
+        "\n"
+      )
+    );
+    expect(bound.optedIn).toBe(true);
+    expect(bound.forwardsToken).toBe(true);
+    expect(bound.grantsActionsRead).toBe(true);
+  });
+
+  it("still answers on a workflow whose YAML will not parse", () => {
+    // The fallback is deliberate: a caller with a syntax error elsewhere still
+    // deserves this check, and refusing to answer would read as "nothing
+    // declared" — silence standing in for a finding.
+    const broken = readContract(
+      "jobs: [unclosed\nserialize_platform_legs: true\nLEG_ORDER_TOKEN: x\n"
+    );
+    expect(broken.optedIn).toBe(true);
+    expect(broken.forwardsToken).toBe(true);
   });
 
   it("does not read a job-level grant as the workflow's own", () => {

--- a/tests/unit/cli/serialize-legs-callee-grant.test.ts
+++ b/tests/unit/cli/serialize-legs-callee-grant.test.ts
@@ -65,15 +65,9 @@ describe("serialize-legs callee grant tracks the shipped workflow", () => {
     expect(CALLEE_GRANTS_ACTIONS_READ).toBe(workflowGrantsActions());
   });
 
-  it("refuses to certify a fully configured caller while the callee cannot receive the scope", async () => {
-    // The defect this replaces. AcmeOrgD/frontend declares every caller-side
-    // part — serialize on, token forwarded, `actions: read` at BOTH job and
-    // workflow level — and the check reported `ok`. That same configuration
-    // was measured at HTTP 403 with the two legs starting two seconds apart.
-    //
-    // A check that passes on a broken configuration is worse than no check: it
-    // converts "unverified" into "verified", and it is consulted instead of
-    // the runtime evidence.
+  it("certifies a fully configured caller now that the callee declares the scope", async () => {
+    // A caller declaring every part: serialize on, token forwarded, and
+    // `actions: read` at both job and workflow level.
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-legs-"));
     try {
       fs.mkdirSync(path.join(root, ".github", "workflows"), {
@@ -101,11 +95,13 @@ describe("serialize-legs callee grant tracks the shipped workflow", () => {
       );
 
       const result = await checkSerializeLegsContract(root);
-      expect(CALLEE_GRANTS_ACTIONS_READ).toBe(false);
-      expect(result.status).toBe("warn");
-      expect(result.detail).toContain("CANNOT work");
-      // It must not send the operator to fix their own config: theirs is done.
-      expect(result.detail).toContain("Nothing to fix here");
+      // Before #2662 this same configuration was measured at HTTP 403 with the
+      // legs starting two seconds apart, and the check reported `ok` anyway.
+      // It now reports `ok` because the verdict is finally true, not because
+      // the check stopped looking.
+      expect(CALLEE_GRANTS_ACTIONS_READ).toBe(true);
+      expect(result.status).toBe("ok");
+      expect(result.detail).not.toContain("CANNOT work");
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION

feat(maestro): declare actions: read so leg serialization can work

serialize_platform_legs has never ordered anything, in any repository, since it
shipped. A called workflow's `permissions:` block is a CEILING that zeroes
everything unlisted, so a caller's `actions: read` was discarded at this
boundary wherever it was declared. The ordering job polled the jobs API, got
HTTP 403, logged a warning, concluded success, and released the Android leg —
measured at two seconds after iOS, on a caller granting the scope at BOTH job
and workflow level.

Declared explicitly rather than by OMITTING the block, which was the other
measured way to make it work: a callee with no `permissions:` inherits the
caller's grant, but a consumer whose repo default is `write` then hands this
workflow nineteen write scopes — contents, packages, securityEvents among them —
on a workflow that runs Maestro flows and third-party actions, with nothing in
the diff to say so. Naming the two keeps the ceiling a ceiling.

## Why this is allowed to gain a scope

Rule 3 of reusable-workflow-caller-scopes.test.ts's header: ship the caller
migration FIRST, let it reach every consumer, then update the baseline, and say
so. Stating it:

  consumer 1   already granted actions: read
  consumer 2   granted, merged before this change
  consumer 3   granted, merged before this change
  consumer 4   uses a vendored local copy — outside the @main blast radius

All four confirmed on their DEFAULT BRANCHES, not on a branch or a PR, because
consumers track @main and receive this on their next run. The owner confirmed
there are no consumers beyond those four — which is the part no static check in
this repository can see, and the reason that header demands a human decides.

Rule 1, the default answer — forward the credential as a secret so nothing is
escalated — is already implemented as LEG_ORDER_TOKEN and was MEASURED to fail
with 403. It is exhausted, not untried.

## The fences moved rather than came down

Both pins now assert the NEW ceiling as equality, so the next scope still has to
come through the same door. The baseline suite's bite control no longer uses
`actions: read` as its regression example — that value is now in the baseline,
so it would have compared a value to itself and passed while proving nothing.
It uses `packages: write` instead.

The doctor check's CALLEE_GRANTS_ACTIONS_READ flips to true in the same commit,
which its drift test forces: it pins the constant to this workflow's actual
permissions block in both directions.

## What this does not prove

The jobs API returning 200 proves the token can read the job list. It does not
prove the legs serialize. That needs a real run on a repo that has granted the
scope and set serialize_platform_legs: true.


🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled leg ordering in reusable end-to-end workflows by granting read access to workflow job information.
* **Bug Fixes**
  * Updated diagnostics to recognize valid workflow configurations and provide clearer guidance when caller permissions are missing.
  * Improved configuration detection by associating settings with the correct reusable-workflow job.
* **Tests**
  * Added regression coverage for required permissions, missing scopes, job-specific settings, and malformed configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Work-Item: CodySwannGT/lisa#2662
