### PR TITLE
docs(mutation-testing): scope the mutant annotation to mutation runs

### DIFF
--- a/.agents/skills/mutation-testing/SKILL.md
+++ b/.agents/skills/mutation-testing/SKILL.md
@@ -213,6 +213,20 @@ For each validated test:
    ```
 2. Commit the test improvement to the experimental branch
 
+**This annotation belongs to tests hardened during a mutation run, and to no
+others.** "Validated test" means a test validated against a mutant *this run*
+generated and assigned an id to. It is not a general requirement on new or
+changed tests.
+
+The annotation's only function is to point at the mutant it killed. A test
+written from a code review, a bug report, or ordinary TDD has no mutant to
+reference, and inventing one — `M001` for a run that never happened, a risk
+factor nobody assessed — is worse than omitting the comment: a later reader
+reasonably concludes the file carries mutation coverage it does not have.
+
+If such a test needs a note about why its assertion is strong, write that in
+plain language. Do not borrow this format, because the format is a citation.
+
 ## Step 5: Cleanup and Report
 
 ### 5a. Revert All Mutants

--- a/.claude/skills/mutation-testing/SKILL.md
+++ b/.claude/skills/mutation-testing/SKILL.md
@@ -213,6 +213,20 @@ For each validated test:
    ```
 2. Commit the test improvement to the experimental branch
 
+**This annotation belongs to tests hardened during a mutation run, and to no
+others.** "Validated test" means a test validated against a mutant *this run*
+generated and assigned an id to. It is not a general requirement on new or
+changed tests.
+
+The annotation's only function is to point at the mutant it killed. A test
+written from a code review, a bug report, or ordinary TDD has no mutant to
+reference, and inventing one — `M001` for a run that never happened, a risk
+factor nobody assessed — is worse than omitting the comment: a later reader
+reasonably concludes the file carries mutation coverage it does not have.
+
+If such a test needs a note about why its assertion is strong, write that in
+plain language. Do not borrow this format, because the format is a citation.
+
 ## Step 5: Cleanup and Report
 
 ### 5a. Revert All Mutants


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2675

The mutation-testing skill's step 4e says:

> For each validated test:
> 1. Add an inline comment above the test referencing the mutant:
>    `// Test hardened to kill mutant M001 (Risk Factor: …)`

In context, "validated test" means a test validated against a mutant **that run generated and assigned an id to**. Read out of context — which is how a reviewer reads it — it scans as a universal rule about tests.

## Observed

CodeRabbit applied it to tests authored from a code review on PR #2671, citing *"As per coding guidelines, validated tests require an inline mutant ID and risk-factor annotation."* Those tests came from its own review findings, not from a mutation run. There is no mutant to reference.

Complying would have meant writing `M001` for a run that never happened and a risk factor nobody assessed.

## Why that is worse than an absent comment

The annotation's only function is **to point at the mutant it killed**. It is a citation. An invented id does not merely fail to help — it asserts that the file carries mutation coverage it does not have, to every later reader and to the next reviewer. 18 files carry this annotation truthfully today; a fabricated one is indistinguishable from those.

This is the same defect class the repository has been closing all week: an artifact that looks like evidence of verification that never occurred.

## Fix

State the scope where the instruction is, in both tracked copies of the skill (`.claude/` and `.agents/`, which had already diverged elsewhere):

- the annotation belongs to tests hardened **during a mutation run**, and to no others
- it is not a general requirement on new or changed tests
- a test needing a note about why its assertion is strong should say so in plain language rather than borrowing the format, **because the format is a citation**

## Acceptance criteria

```gherkin
Scenario: the rule states its scope where it is read
  Given a reader encounters step 4e out of context
  Then the text says the annotation applies only to mutation-run outputs

Scenario: an ordinary new test is not asked for a mutant id
  Given a test authored from a code review or bug report
  Then no mutant annotation is required

Scenario: both skill copies agree
  Then .claude/ and .agents/ carry the same scoping
```

## Out of scope

The annotation format itself, and the 18 files already using it correctly.
