### PR TITLE
fix(ci): make the traceability job honor its gate level

### DIFF
--- a/.github/workflows/quality-rails.yml
+++ b/.github/workflows/quality-rails.yml
@@ -178,6 +178,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: ${{ github.event_name == 'pull_request' && !contains(format(',{0},', inputs.skip_jobs), ',work_item_traceability,') }}
+    # KNOWN GAP (#2680): this condition keys on `skip_jobs` and on nothing
+    # else, so `gates.traceability` in .lisa.config.json does NOT govern this
+    # job. Declaring it `off` still reddens the pull request; declaring it
+    # `required` changes nothing, because the job already ran. The quality.yml
+    # counterpart resolves the gate through the shared façade; this workflow
+    # carries no façade at all — it has neither the `moment` nor the
+    # `package_manager` input the byte-identical resolve block reads, so
+    # closing the gap here means bringing the whole façade to this workflow,
+    # not bolting a second on/off mechanism onto one job. `skip_jobs` remains
+    # the only control for a Rails consumer until then.
+    #
     # DELIBERATELY no `permissions:` block — see the quality.yml counterpart.
     # Requesting a scope the caller never held is a startup_failure for the
     # ENTIRE run, and these workflows are consumed @main by repos whose ci.yml

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -458,19 +458,20 @@ jobs:
       # from the required-context list, which is derived from the same
       # declaration by `contextsFor`, so the two can never disagree.
       #
-      # WHY THE RESOLVE STEP IS REPEATED IN NINE JOBS. GitHub Actions has no
-      # YAML anchors and no step-level reuse without a separate composite
-      # action, so the only single-copy option is a resolver JOB whose outputs
-      # the nine read through `needs:` — and that is refused, because a
-      # `needs:` parent that fails or is cancelled leaves its dependents
-      # SKIPPED, and a skipped required check counts as SATISFIED. Nine
-      # independent resolutions is what keeps each context unable to be
-      # satisfied by something other than its own gate. The repeated text is
-      # therefore an INVOCATION, not a reimplementation: the resolver is
-      # scripts/lisa-gates.mjs and the only thing that differs between copies
-      # is GATE_ID. tests/integration/quality-gate-facade.test.ts asserts all
-      # nine blocks are byte-identical once GATE_ID is normalised, so they
-      # cannot drift apart the way two hand-maintained copies would.
+      # WHY THE RESOLVE STEP IS REPEATED IN EVERY GATED JOB. GitHub Actions
+      # has no YAML anchors and no step-level reuse without a separate
+      # composite action, so the only single-copy option is a resolver JOB
+      # whose outputs the gated jobs read through `needs:` — and that is
+      # refused, because a `needs:` parent that fails or is cancelled leaves
+      # its dependents SKIPPED, and a skipped required check counts as
+      # SATISFIED. One independent resolution per job is what keeps each
+      # context unable to be satisfied by something other than its own gate.
+      # The repeated text is therefore an INVOCATION, not a reimplementation:
+      # the resolver is scripts/lisa-gates.mjs and the only thing that differs
+      # between copies is GATE_ID.
+      # tests/integration/quality-gate-facade.test.ts asserts every block is
+      # byte-identical once GATE_ID is normalised, so they cannot drift apart
+      # the way two hand-maintained copies would.
       #
       # Two properties of the resolve step below are load-bearing:
       #   * Nothing discards stderr, and `pipefail` is on. A malformed
@@ -2655,6 +2656,81 @@ jobs:
           package-manager-cache: false
           node-version: ${{ inputs.node_version }}
 
+      - name: 🍞 Setup Bun
+        if: inputs.package_manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.8'
+
+      - name: 📦 Install dependencies
+        # Lisa's BUILT-IN validator needs no dependencies — it is plain node,
+        # which is why this job never installed before. The install is here for
+        # the other two paths. A project that names its own traceability task
+        # runs that task's own tooling, and the RESOLVER itself ships inside
+        # node_modules for a repository that carries no copied
+        # scripts/lisa-gates.mjs (Lisa's own is exactly that shape), so a
+        # declaration would be unreadable without it and `off` would silently
+        # keep failing. Every other façade job installs first for the same
+        # reason.
+        run: |
+          if [ "${{ inputs.package_manager }}" = "npm" ]; then
+            npm ci
+          elif [ "${{ inputs.package_manager }}" = "yarn" ]; then
+            yarn install --frozen-lockfile
+          elif [ "${{ inputs.package_manager }}" = "bun" ]; then
+            bun install --frozen-lockfile
+          fi
+        working-directory: ${{ inputs.working_directory || '.' }}
+
+      # Gate façade — contract and fallback rationale documented in full on the
+      # 🧹 Lint job above.
+      #
+      # WHY THIS JOB WAS CONVERTED (#2680). Its `if:` keyed on `skip_jobs` and
+      # nothing else, so `gates.traceability` governed the LOCAL runner
+      # (lisa-run-gates, `moments: PR_ONLY`) and governed nothing here.
+      # Declaring the gate `off` still produced a red check; declaring it
+      # `required` changed nothing, because the job already ran on every pull
+      # request. One key meant two different things on two surfaces, and
+      # nothing anywhere said so — a declaration that reads as a decision taken
+      # and governs nothing.
+      #
+      # The JOB'S OWN condition is deliberately left keyed on `skip_jobs`.
+      # A required status context that runs zero steps reports SATISFIED on
+      # GitHub, so `off` has to empty the job rather than skip it; dropping the
+      # context is `contextsFor`'s job, from the same declaration.
+      #
+      # `optional` needs no branch here, and that is the whole point of the
+      # level: it resolves exactly like `required` and the job still fails on a
+      # missing trailer, but `contextsFor` emits a required context only for
+      # `required`, so the red check blocks nothing. Making the step swallow
+      # its own exit code instead would be a continue-on-error green, which is
+      # the defect this façade exists to prevent.
+      - name: 🎛️ Resolve the traceability gate
+        id: gate
+        env:
+          GATE_ID: traceability
+          FALLBACK_RUNNER: ${{ inputs.package_manager }} run
+          GATE_MOMENT: ${{ inputs.moment }}
+        run: |
+          set -euo pipefail
+          RESOLVER=""
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+            if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
+          done
+          if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
+          node "$RESOLVER" list --moment="$GATE_MOMENT" --json --include-off | node -e '
+          let raw = ""; process.stdin.on("data", d => { raw += d }).on("end", () => {
+          const id = process.env.GATE_ID, hit = JSON.parse(raw || "[]").find(g => g.id === id);
+          if (hit && hit.level === "off") return process.stdout.write("configured=off\n");
+          const task = hit && hit.mode === "run" && hit.task ? hit.task : "";
+          if (!task) return process.stdout.write("configured=false\n");
+          const runner = (require("./.lisa.config.json").gates || {}).runner || process.env.FALLBACK_RUNNER;
+          const plain = value => /^[A-Za-z0-9:._@\/= -]+$/.test(value);
+          if (!plain(task) || !plain(runner)) { console.error(`::error::gates.${id} resolves to "${runner} ${task}", which is not a plain command.`); process.exit(1); }
+          process.stdout.write(`configured=true\nrunner=${runner}\ntask=${task}\n`); });
+          ' >> "$GITHUB_OUTPUT"
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       - name: 🔗 Resolve the branch-authored commit range
         id: range
         env:
@@ -2682,7 +2758,37 @@ jobs:
           echo "base=$base" >> "$GITHUB_OUTPUT"
           echo "Validating ${base}..${PR_HEAD_SHA}"
 
+      - name: 🔗 Run the traceability gate
+        # The project named its own prover. It gets the same event-derived
+        # inputs the built-in gets — a traceability check of any shape needs
+        # the commit range, the PR number and a token — but none of the
+        # readiness plumbing below, which is specific to Lisa's validator.
+        # It stays fail-CLOSED regardless: `validate-pr` refuses a PR it
+        # cannot read rather than reporting a success it did not earn, and a
+        # declared task that is absent exits non-zero.
+        if: steps.gate.outputs.configured == 'true'
+        env:
+          GATE_RUNNER: ${{ steps.gate.outputs.runner }}
+          GATE_TASK: ${{ steps.gate.outputs.task }}
+          GH_TOKEN: ${{ github.token }}
+          LISA_PR_BASE_SHA: ${{ steps.range.outputs.base }}
+          LISA_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          LISA_PR_NUMBER: ${{ github.event.pull_request.number }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          JIRA_LOGIN: ${{ secrets.JIRA_LOGIN }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+        # Deliberate word split, as on every other façade job.
+        run: $GATE_RUNNER $GATE_TASK
+        working-directory: ${{ inputs.working_directory || '.' }}
+
       - name: 🔗 Validate Work-Item traceability
+        # FALLBACK. Runs when nothing resolves — no resolver, no `gates` block,
+        # the gate not declared at this moment, or declared `await`-proved. It
+        # is byte-for-byte what this job did before #2680, so an unmigrated
+        # project is unchanged. `== 'false'` and not `!= 'true'`, because
+        # `off` satisfies the negative form and would keep running the very
+        # tooling the declaration turned off.
+        if: steps.gate.outputs.configured == 'false'
         # Env-var form (equivalent to --base/--head/--pr-number) keeps event
         # payload values out of the shell command entirely.
         env:

--- a/docs/design/gates-and-policy.md
+++ b/docs/design/gates-and-policy.md
@@ -229,6 +229,22 @@ skipped-but-required hole is unrepresentable rather than merely discouraged.
 `optional` must never be `continue-on-error: true` — that makes a failing job
 report green, which is the defect itself in a new costume.
 
+**A level only means this once the job resolves it.** The table describes what a
+declaration *is*; a CI job delivers it only if it reads the declaration. The
+`🔗 Work-Item Traceability` job did not: its condition keyed on the `skip_jobs`
+workflow input alone, so `gates.traceability` governed the local runner and
+governed nothing in CI — `off` still reddened every pull request and `required`
+changed nothing, because the job already ran (#2680). It now resolves the gate
+through the same façade as every other job in `quality.yml`.
+
+**What an undeclared gate does, everywhere in that workflow:** the resolution
+reports `configured=false` and the job runs Lisa's built-in tooling, byte for
+byte as it did before the façade existed. `configured=false` covers all of: no
+resolver present, no `gates` block, the gate not declared at the moment being
+resolved, and the gate declared `await`-proved rather than run. A gate declared
+`off` is a *different* answer (`configured=off`) and reaches neither branch, so
+the job runs no gate work and reports green having correctly done nothing.
+
 ## Renames, and why they are dangerous
 
 Job names are branch-protection contexts matched by exact string. A renamed job
@@ -243,10 +259,11 @@ Reconciliation may **add** a missing context under `repair`. Removing an EXTRA
 one requires explicit `--prune`, because an extra required context may be an
 external app Lisa does not manage, and removing it silently strips protection.
 
-That rule earned itself before shipping: three contexts currently required on
-`main` — Security Scan, Work-Item Traceability, Plugin artifacts match source —
-produce no derived context, so a ruleset regenerated from config alone would
-have dropped them.
+That rule earned itself before shipping: three contexts required on `main` —
+Security Scan, Work-Item Traceability, Plugin artifacts match source — produced
+no derived context, so a ruleset regenerated from config alone would have
+dropped them. Work-Item Traceability has since been declared and now derives;
+the other two still do not, and the rule stands for them.
 
 ## A template change lands on a schedule nobody chose
 
@@ -505,3 +522,8 @@ guess.
   `required` without naming a context that does not exist.
 - `plugins-sync`'s "generated plugin tree matches source" has no registry gate;
   adjacent to `artifact-freshness`, different artifact.
+- `quality-rails.yml` carries the same `work_item_traceability` job and **no
+  gate façade at all** — no `moment` input, no `package_manager` input, and so
+  no resolve block. `gates.traceability` is therefore still inert for a Rails
+  consumer, exactly as #2680 describes. Converting that workflow means bringing
+  the façade to it, not bolting a second on/off mechanism onto one job.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8854,6 +8854,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/vitest-cdk.test.ts": true,
     "tests/unit/config/vitest-nestjs.test.ts": true,
     "tests/unit/config/vitest-typescript.test.ts": true,
+    "tests/unit/config/work-item-traceability-gate-level.test.ts": true,
     "tests/unit/config/work-item-traceability-scope-gate.test.ts": true,
     "tests/unit/config/worktree-exclusion-anchoring.test.ts": true,
     "tests/unit/configs/lintstaged-matcher-ordering.test.ts": true,

--- a/tests/integration/quality-gate-facade-fixture.ts
+++ b/tests/integration/quality-gate-facade-fixture.ts
@@ -60,7 +60,10 @@ export const NOT_CONFIGURED = "steps.gate.outputs.configured == 'false'";
 export const DECLARED_OFF = "steps.gate.outputs.configured == 'off'";
 
 /**
- * The thirteen jobs converted to the gate façade.
+ * Every job converted to the gate façade.
+ *
+ * Deliberately not counted in prose: the count has been wrong twice already
+ * ("thirteen" survived two additions). The list is the count.
  *
  * Kept exhaustive by `quality-gate-moment-input.test.ts`, which fails if the
  * workflow contains a resolve step this list omits. `test_node_suites` shipped
@@ -212,13 +215,26 @@ export const CONVERTED: ConvertedJob[] = [
     gateStep: "✅ Run the coverage-adequacy gate",
     fallbackSteps: ["✅ Require a verification (e2e) spec delta on feat/fix"],
   },
+  {
+    job: "work_item_traceability",
+    jobName: "🔗 Work-Item Traceability",
+    gate: "traceability",
+    gateStep: "🔗 Run the traceability gate",
+    // Only the validator itself. `🔗 Resolve the branch-authored commit range`
+    // is deliberately NOT here: it computes the event-derived base SHA that
+    // BOTH paths are handed, so gating it on the fallback would leave a
+    // project's own task without the range `validate-pr` refuses to run
+    // without. It proves nothing and can fail nothing, which is what keeps an
+    // `off` declaration a no-op job rather than a skipped one.
+    fallbackSteps: ["🔗 Validate Work-Item traceability"],
+  },
 ];
 
 /**
  * Steps that carried `continue-on-error` BEFORE this conversion.
  *
  * A failing job that reports green is the exact defect the façade exists to
- * prevent, so the set is pinned rather than checked only on the thirteen jobs:
+ * prevent, so the set is pinned rather than checked only on the converted jobs:
  * growing it anywhere in this workflow has to fail here.
  */
 export const PREEXISTING_CONTINUE_ON_ERROR = ["📊 SonarCloud Scan"];

--- a/tests/integration/quality-gate-facade.test.ts
+++ b/tests/integration/quality-gate-facade.test.ts
@@ -124,7 +124,7 @@ describe("quality.yml gate façade", () => {
     );
 
     it("resolves every gate with one byte-identical block, differing only in GATE_ID", () => {
-      // Thirteen copies exist because the single-copy alternative — a resolver job
+      // One copy per converted job exists because the single-copy alternative — a resolver job
       // read through `needs:` — leaves dependents SKIPPED when it fails, and a
       // skipped required check counts as satisfied. Copies that cannot be
       // deduplicated must instead be prevented from drifting, so this compares

--- a/tests/unit/config/work-item-traceability-gate-level.test.ts
+++ b/tests/unit/config/work-item-traceability-gate-level.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests that `gates.traceability` governs the CI job that bears its name.
+ *
+ * It did not (#2680). The `🔗 Work-Item Traceability` job's condition keyed on
+ * `skip_jobs` and on nothing else, so the declaration reached the LOCAL runner
+ * (`lisa-run-gates`, `moments: PR_ONLY`) and reached nothing in CI. Declaring
+ * the gate `off` still produced a red check on every pull request; declaring it
+ * `required` changed nothing, because the job already ran. One key meant two
+ * different things on two surfaces, silently — a declaration that reads as a
+ * decision taken and governs nothing.
+ *
+ * The resolution runs as inline bash inside the reusable `quality.yml`, so the
+ * step's `run:` body is the actual unit under test: it is extracted from the
+ * workflow and executed against fixture projects, the same way the token-scope
+ * readiness gate is covered. Asserting only on the parsed YAML would not tell a
+ * working resolver from a deleted one.
+ * @module tests/unit/config/work-item-traceability-gate-level
+ */
+
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+import { load } from "js-yaml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { resolveMoment } from "../../../all/copy-overwrite/scripts/lisa-gates.mjs";
+
+const REPO_ROOT = path.join(__dirname, "..", "..", "..");
+
+/** The reusable workflow whose job the declaration must govern. */
+const QUALITY_YML = path.join(REPO_ROOT, ".github", "workflows", "quality.yml");
+
+/** The registry the workflow resolves declarations through. */
+const GATES_SCRIPT = path.join(
+  REPO_ROOT,
+  "all",
+  "copy-overwrite",
+  "scripts",
+  "lisa-gates.mjs"
+);
+
+/** The one helper the registry imports; copied alongside it. */
+const INVOKED_AS_SCRIPT = path.join(
+  REPO_ROOT,
+  "all",
+  "copy-overwrite",
+  "scripts",
+  "lib",
+  "invoked-as-script.mjs"
+);
+
+/** The job under test. */
+const JOB = "work_item_traceability";
+
+/** The gate id that job must resolve. */
+const GATE = "traceability";
+
+/** The moment the gate is declared at. */
+const PULL_REQUEST = "pull-request";
+
+/**
+ * Absolute interpreter path — resolving `bash` through PATH could pick up a
+ * fixture directory.
+ */
+const BASH = "/bin/bash";
+
+/** Shape of the parsed workflow, narrowed to what these tests read. */
+interface Workflow {
+  readonly jobs: Record<
+    string,
+    {
+      readonly if?: string;
+      readonly steps?: readonly {
+        name?: string;
+        id?: string;
+        if?: string;
+        run?: string;
+        env?: Record<string, string>;
+      }[];
+    }
+  >;
+}
+
+const workflow = load(readFileSync(QUALITY_YML, "utf8")) as Workflow;
+
+/** The steps of the traceability job. */
+const steps = workflow.jobs[JOB]?.steps ?? [];
+
+/**
+ * One named step of the traceability job.
+ * @param name - Exact step name
+ * @returns The step, or undefined
+ */
+const stepNamed = (name: string) => steps.find(step => step.name === name);
+
+/**
+ * The gate-resolution step's shell body.
+ * @returns The step's `run:` script
+ */
+function resolveScript(): string {
+  const step = steps.find(candidate => candidate.id === "gate");
+  if (!step?.run) throw new Error(`no gate resolution step in ${JOB}`);
+  return step.run;
+}
+
+/** Per-test scratch state. */
+interface Resources {
+  dir: string;
+}
+
+const resources: Resources = { dir: "" };
+
+beforeEach(async () => {
+  resources.dir = await mkdtemp(path.join(tmpdir(), "lisa-wit-level-"));
+});
+
+afterEach(async () => {
+  await rm(resources.dir, { recursive: true, force: true });
+});
+
+/**
+ * Refuse a resolve step that did not complete.
+ *
+ * The step is `set -euo pipefail`, so a non-zero status means the resolution
+ * itself broke. Reading `GITHUB_OUTPUT` anyway would report an empty file as
+ * "the gate resolved to nothing" — a failed command read as a measured zero.
+ * @param result - The spawn result
+ */
+function assertResolved(result: SpawnSyncReturns<string>): void {
+  if (result.status !== 0) {
+    throw new Error(
+      `resolve step exited ${String(result.status)}: ${result.stderr ?? ""}`
+    );
+  }
+}
+
+/**
+ * Run the extracted resolve step against a fixture project.
+ * @param gates - The `gates` block written to `.lisa.config.json`, or null to
+ *   write a config carrying no gates block at all
+ * @returns The key/value lines the step wrote to `GITHUB_OUTPUT`
+ */
+function runResolve(gates: Record<string, unknown> | null): string {
+  const project = path.join(resources.dir, "project");
+  const output = path.join(resources.dir, "github-output");
+  const script = path.join(resources.dir, "resolve.sh");
+  const config = JSON.stringify(
+    gates === null ? { tracker: "github" } : { gates }
+  );
+  const body = resolveScript();
+  const env = {
+    ...process.env,
+    GATE_ID: GATE,
+    GATE_MOMENT: PULL_REQUEST,
+    FALLBACK_RUNNER: "npm run",
+    GITHUB_OUTPUT: output,
+  };
+
+  mkdirSync(path.join(project, "scripts", "lib"), { recursive: true });
+  // The host-side copy of the registry, which is what an applied project
+  // carries. The step prefers the installed package and falls back to this.
+  copyFileSync(GATES_SCRIPT, path.join(project, "scripts", "lisa-gates.mjs"));
+  copyFileSync(
+    INVOKED_AS_SCRIPT,
+    path.join(project, "scripts", "lib", "invoked-as-script.mjs")
+  );
+  writeFileSync(path.join(project, ".lisa.config.json"), config);
+  writeFileSync(output, "");
+  writeFileSync(script, body);
+  assertResolved(
+    spawnSync(BASH, ["-e", script], { cwd: project, encoding: "utf8", env })
+  );
+  return readFileSync(output, "utf8");
+}
+
+describe("the traceability job resolves its gate from .lisa.config.json", () => {
+  it("emits configured=off when the project declared the gate off", () => {
+    // The acceptance criterion of #2680: a declared level has to change what
+    // CI does. Before the fix nothing in this job read the config at all.
+    expect(runResolve({ traceability: { [PULL_REQUEST]: "off" } })).toContain(
+      "configured=off"
+    );
+  });
+
+  it("emits configured=true and the registry task when declared required", () => {
+    const out = runResolve({ traceability: { [PULL_REQUEST]: "required" } });
+
+    expect(out).toContain("configured=true");
+    expect(out).toContain("task=check:work-item");
+  });
+
+  it("resolves an optional declaration exactly like a required one", () => {
+    // `optional` is expressed by `contextsFor` emitting no required context,
+    // NOT by the step swallowing its exit code — a step that reported green
+    // while failing is the defect this façade exists to prevent.
+    expect(
+      runResolve({ traceability: { [PULL_REQUEST]: "optional" } })
+    ).toContain("configured=true");
+  });
+
+  it("emits configured=false when the project never declared the gate", () => {
+    // The fallback path: an unmigrated project keeps today's built-in
+    // validator, byte for byte.
+    expect(runResolve(null)).toContain("configured=false");
+  });
+
+  it("emits configured=false when the gate is declared at another moment", () => {
+    expect(runResolve({ traceability: { push: "required" } })).toContain(
+      "configured=false"
+    );
+  });
+});
+
+describe("an off declaration reaches neither branch of the job", () => {
+  it("runs the project's task only on configured=true", () => {
+    expect(stepNamed("🔗 Run the traceability gate")?.if).toBe(
+      "steps.gate.outputs.configured == 'true'"
+    );
+  });
+
+  it("runs the built-in validator only on configured=false", () => {
+    // `== 'false'`, never `!= 'true'`: `off` satisfies the negative form, so
+    // the built-in would keep failing pull requests the declaration disabled.
+    expect(stepNamed("🔗 Validate Work-Item traceability")?.if).toBe(
+      "steps.gate.outputs.configured == 'false'"
+    );
+  });
+
+  it("leaves the job's own condition free of the gates block", () => {
+    // A required status context that runs ZERO steps reports SATISFIED on
+    // GitHub. `off` must therefore empty the job, not skip it; retiring the
+    // context is `contextsFor`'s job, from the same declaration.
+    const condition = workflow.jobs[JOB]?.if ?? "";
+    expect(condition).toContain("github.event_name == 'pull_request'");
+    expect(condition).not.toContain("lisa.config");
+    expect(condition).not.toContain("gates");
+  });
+});
+
+describe("the local runner and CI reach the same verdict", () => {
+  it("hides an off gate from the local runner while CI reports it off", () => {
+    const gates = { traceability: { [PULL_REQUEST]: "off" } };
+
+    // Local: `lisa-run-gates` resolves without `includeOff`, so the gate is
+    // absent and nothing runs it.
+    expect(
+      resolveMoment({ gates, moment: PULL_REQUEST }).map(gate => gate.id)
+    ).toEqual([]);
+    // CI: the façade asks for the off state and runs neither branch.
+    expect(runResolve(gates)).toContain("configured=off");
+  });
+
+  it("gives both surfaces the same task when the gate is required", () => {
+    const gates = { traceability: { [PULL_REQUEST]: "required" } };
+    const local = resolveMoment({ gates, moment: PULL_REQUEST }).find(
+      gate => gate.id === GATE
+    );
+
+    expect(local?.task).toBe("check:work-item");
+    expect(runResolve(gates)).toContain("task=check:work-item");
+  });
+});


### PR DESCRIPTION
## What was wrong

`gates.traceability` in `.lisa.config.json` did not change what the CI job
bearing its name did. The job's condition read:

```yaml
if: ${{ github.event_name == 'pull_request'
        && !contains(format(',{0},', inputs.skip_jobs), ',work_item_traceability,') }}
```

`skip_jobs` and nothing else. Verified before building: `grep` over
`quality.yml` finds no `lisa.config`, no `gates`, and no resolve block anywhere
in `work_item_traceability`, while fifteen sibling jobs each carry a
byte-identical `🎛️ Resolve the <gate> gate` step. So declaring `off` still
reddened every PR, and declaring `required` changed nothing because the job
already ran.

Not fully inert, as the issue says: the registry entry (`moments: PR_ONLY`)
drives the local runner, so one key meant one thing locally and nothing in CI.

## What changed

Option 1 from the issue, through the existing façade rather than a second
mechanism. The job now carries the same resolve block as every other gated job
— the drift test proves all **sixteen** copies are byte-identical once
`GATE_ID` is normalised.

| declaration | resolves to | job behaviour |
| --- | --- | --- |
| `off` | `configured=off` | neither branch runs; green, having correctly done nothing |
| `required` / `optional` | `configured=true` | runs the project's declared task (`check:work-item` by default) |
| undeclared / other moment / `await` | `configured=false` | today's built-in validator, byte for byte |

`optional` needs no branch: it resolves exactly like `required` and the job
still fails on a missing trailer, but `contextsFor` emits a required context
only for `required`, so the red check blocks nothing. Making the step swallow
its own exit code would be a `continue-on-error` green — the defect the façade
exists to prevent.

Three deliberate choices worth reviewing:

- **The job's own `if:` is untouched.** A required status context that runs
  zero steps reports SATISFIED on GitHub, so `off` must *empty* the job, not
  skip it. `tests/integration/quality-gate-facade.test.ts` pins this.
- **No `permissions:` block added.** This job must keep inheriting the
  caller's grant; requesting a scope the caller lacks is a `startup_failure`
  for the caller's whole run.
- **Setup Bun + install are new**, so a project-declared task can execute its
  own tooling. That is *all* they buy — see the measured finding below.

## Correction to the issue's framing

The `🔗 Resolve the branch-authored commit range` step stays **unconditional**
rather than moving to the fallback path. `validate-pr` refuses to run without
`LISA_PR_BASE_SHA`, so gating that step would leave a project's own task
without the input it requires. It computes a SHA and proves nothing, so an
`off` declaration still reaches no gate work.

Also scoped out, and now documented rather than left silent: `quality-rails.yml`
ships the same job and **no façade at all** — it has neither the `moment` nor
the `package_manager` input the shared resolve block reads. `gates.traceability`
remains inert for a Rails consumer. Closing that means bringing the whole façade
to that workflow, not bolting a second on/off switch onto one job. Stated in the
job itself and in the design doc's open items.

## Bite control

Each behavioural claim was broken, the named test watched to fail, and restored.

**Bite 1 — delete `if: steps.gate.outputs.configured == 'false'` from the
built-in validator** (so `off` would keep failing PRs):

- `tests/unit/config/work-item-traceability-gate-level.test.ts` › *an off declaration reaches neither branch of the job* › **runs the built-in validator only on configured=false**
- `tests/integration/quality-gate-off-state.test.ts` › **'work_item_traceability''s fallback fires only on false, never on off**
- `tests/integration/quality-gate-facade.test.ts` › **'work_item_traceability' keeps its hardcoded invocation, gated on no 'traceability' being configured**

**Bite 2 — delete the `off` branch from the resolve body** (so a declared `off`
would resolve as never-declared):

- `tests/unit/config/work-item-traceability-gate-level.test.ts` › **emits configured=off when the project declared the gate off**
- `tests/unit/config/work-item-traceability-gate-level.test.ts` › **hides an off gate from the local runner while CI reports it off**
- `tests/integration/quality-gate-off-state.test.ts` › **'work_item_traceability' emits a third state for an off gate**
- `tests/integration/quality-gate-facade.test.ts` › **resolves every gate with one byte-identical block, differing only in GATE_ID**

The new test file does not read the parsed YAML for the resolution claims — it
**extracts the step's `run:` body from `quality.yml` and executes it** against
fixture projects, the same technique the token-scope readiness gate uses. An
assertion over parsed YAML could not tell a working resolver from a deleted one.

## Verification

- `bun run test` — 724 files, 13083 tests, all passing
- Targeted re-run after the final edits: 6 files, 456 tests, passing
- `bun run lint:staged` clean; pre-push audit, conflict-marker, parity and
  routing checks all passed
- The job ran green on this branch in 39s, resolving the gate and taking the
  fallback branch — see below.

## A finding this PR measured and did not fix

I expected this PR to exercise the new `configured=true` path, because Lisa
declares `traceability: {"pull-request": "required"}`. It did not. The run took
the fallback:

```
✓ 🎛️ Resolve the traceability gate
- 🔗 Run the traceability gate        (skipped)
✓ 🔗 Validate Work-Item traceability
```

`🧹 Lint` did the same thing in the same run, with `code-style` declared
`required`. The cause: the façade resolves through
`node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs` or a
copied `scripts/lisa-gates.mjs`, and **this repository has neither** — it
devDepends on a `^2.x` range that predates the script, and it carries no copy of
its own copy-overwrite output. `RESOLVER` is empty, so all sixteen façade jobs
write `configured=false`.

Nothing is unenforced by it — the fallbacks are the same tooling — but every
level Lisa declares for itself is currently inert in Lisa's own CI. That is the
#2680 shape one layer up, it is a different defect, and this PR does not fix it.
It is recorded in the design doc's open items and in the install step's comment,
whose first draft asserted the opposite and has been corrected.

This does not weaken the fix. A host repo carries the copied resolver, which is
where the declaration has to work, and the resolution itself is proven by
executing the extracted step against fixture projects rather than by this run.

## Acceptance criteria

- *a declared level changes CI behaviour* — `off` resolves to `configured=off`;
  neither branch runs. Executed, not asserted over YAML.
- *an undeclared gate behaves as documented* — `configured=false` runs the
  built-in; stated in `docs/design/gates-and-policy.md` under the level table.
- *local and CI agree* — one test resolves the same declaration through
  `resolveMoment` and through the extracted step and compares both verdicts.

Work-Item: CodySwannGT/lisa#2680
