### PR TITLE
fix(hooks): prove lint-staged's tools can start before handing it the work

### DIFF
--- a/.claude-pr/.husky/pre-commit
+++ b/.claude-pr/.husky/pre-commit
@@ -82,6 +82,70 @@ fi
 #   exit 1
 # fi
 
+# ---------------------------------------------------------------------------
+# lint-staged preflight.
+#
+# lint-staged reports exit 0 when a task's executable cannot be SPAWNED.
+# Measured on lint-staged 16.4.0 and 17.3.0: a file that is present and
+# `chmod +x` but is not a runnable executable prints "[FAILED] spawn ENOEXEC"
+# and the run still exits 0. An absent executable (ENOENT) and an ordinary
+# non-zero exit both fail closed — only the spawn error does not.
+#
+# That state is not exotic. A tool whose real binary is materialized during
+# `postinstall` leaves a shebang-less placeholder behind on any install that
+# skips scripts, and lint-staged spawns without a shell, so the kernel refuses
+# the file before the placeholder's own `exit 1` can run. The staged-file scan
+# then runs, reports nothing, blocks nothing, and the commit proceeds.
+#
+# No exit-code check can catch this — not the one below, not any other. A
+# process reporting 0 for work it did not do defeats every test of its status.
+# So the tools are proved runnable BEFORE any of them is handed the work, by
+# something that spawns them itself and reports what it spawned.
+#
+# OUTSIDE the gate-registry handover, deliberately. lint-staged runs at this
+# moment by BOTH routes: the built-in step further down, and a `code-style`
+# gate whose declared command is the project's lint-staged script. A preflight
+# placed inside the built-in branch would stand down for exactly the projects
+# whose registry then runs lint-staged anyway. The tools are the same either
+# way, so the proof belongs before both.
+#
+# Skipped only when the project has no lint-staged config, in which case no
+# route runs lint-staged and there is nothing to prove. A preflight that cannot
+# RUN is not a skip and not a pass — it blocks.
+# ---------------------------------------------------------------------------
+if [ -f ".lintstagedrc.json" ]; then
+  LINT_STAGED_PREFLIGHT="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs"
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ]; then
+    LINT_STAGED_PREFLIGHT="scripts/lisa-lint-staged-preflight.mjs"
+  fi
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ]; then
+    LINT_STAGED_PREFLIGHT="all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs"
+  fi
+  if command -v node >/dev/null 2>&1; then
+    LINT_STAGED_PREFLIGHT_RUNTIME="node"
+  elif command -v bun >/dev/null 2>&1; then
+    LINT_STAGED_PREFLIGHT_RUNTIME="bun"
+  else
+    LINT_STAGED_PREFLIGHT_RUNTIME=""
+  fi
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ] || [ -z "$LINT_STAGED_PREFLIGHT_RUNTIME" ]; then
+    echo ""
+    echo "❌ Commit blocked: the lint-staged preflight could not run."
+    echo "   Expected $LINT_STAGED_PREFLIGHT, and node or bun on PATH."
+    echo "   Without it a tool that is installed but not executable makes"
+    echo "   lint-staged exit 0 having scanned nothing, so skipping the"
+    echo "   preflight cannot be treated as a pass."
+    echo "   Reinstall dependencies, then re-run \`lisa apply\`."
+    echo ""
+    exit 1
+  fi
+  "$LINT_STAGED_PREFLIGHT_RUNTIME" "$LINT_STAGED_PREFLIGHT" --config .lintstagedrc.json
+  LINT_STAGED_PREFLIGHT_STATUS=$?
+  if [ $LINT_STAGED_PREFLIGHT_STATUS -ne 0 ]; then
+    exit $LINT_STAGED_PREFLIGHT_STATUS
+  fi
+fi
+
 # Run lint-staged for incremental lint and format checks
 echo "🚀 Running lint-staged..."
 $EXECUTOR lint-staged --config .lintstagedrc.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -44,6 +44,70 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# lint-staged preflight.
+#
+# lint-staged reports exit 0 when a task's executable cannot be SPAWNED.
+# Measured on lint-staged 16.4.0 and 17.3.0: a file that is present and
+# `chmod +x` but is not a runnable executable prints "[FAILED] spawn ENOEXEC"
+# and the run still exits 0. An absent executable (ENOENT) and an ordinary
+# non-zero exit both fail closed — only the spawn error does not.
+#
+# That state is not exotic. A tool whose real binary is materialized during
+# `postinstall` leaves a shebang-less placeholder behind on any install that
+# skips scripts, and lint-staged spawns without a shell, so the kernel refuses
+# the file before the placeholder's own `exit 1` can run. The staged-file scan
+# then runs, reports nothing, blocks nothing, and the commit proceeds.
+#
+# No exit-code check can catch this — not the one below, not any other. A
+# process reporting 0 for work it did not do defeats every test of its status.
+# So the tools are proved runnable BEFORE any of them is handed the work, by
+# something that spawns them itself and reports what it spawned.
+#
+# OUTSIDE the gate-registry handover, deliberately. lint-staged runs at this
+# moment by BOTH routes: the built-in step further down, and a `code-style`
+# gate whose declared command is the project's lint-staged script. A preflight
+# placed inside the built-in branch would stand down for exactly the projects
+# whose registry then runs lint-staged anyway. The tools are the same either
+# way, so the proof belongs before both.
+#
+# Skipped only when the project has no lint-staged config, in which case no
+# route runs lint-staged and there is nothing to prove. A preflight that cannot
+# RUN is not a skip and not a pass — it blocks.
+# ---------------------------------------------------------------------------
+if [ -f ".lintstagedrc.json" ]; then
+  LINT_STAGED_PREFLIGHT="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs"
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ]; then
+    LINT_STAGED_PREFLIGHT="scripts/lisa-lint-staged-preflight.mjs"
+  fi
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ]; then
+    LINT_STAGED_PREFLIGHT="all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs"
+  fi
+  if command -v node >/dev/null 2>&1; then
+    LINT_STAGED_PREFLIGHT_RUNTIME="node"
+  elif command -v bun >/dev/null 2>&1; then
+    LINT_STAGED_PREFLIGHT_RUNTIME="bun"
+  else
+    LINT_STAGED_PREFLIGHT_RUNTIME=""
+  fi
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ] || [ -z "$LINT_STAGED_PREFLIGHT_RUNTIME" ]; then
+    echo ""
+    echo "❌ Commit blocked: the lint-staged preflight could not run."
+    echo "   Expected $LINT_STAGED_PREFLIGHT, and node or bun on PATH."
+    echo "   Without it a tool that is installed but not executable makes"
+    echo "   lint-staged exit 0 having scanned nothing, so skipping the"
+    echo "   preflight cannot be treated as a pass."
+    echo "   Reinstall dependencies, then re-run \`lisa apply\`."
+    echo ""
+    exit 1
+  fi
+  "$LINT_STAGED_PREFLIGHT_RUNTIME" "$LINT_STAGED_PREFLIGHT" --config .lintstagedrc.json
+  LINT_STAGED_PREFLIGHT_STATUS=$?
+  if [ $LINT_STAGED_PREFLIGHT_STATUS -ne 0 ]; then
+    exit $LINT_STAGED_PREFLIGHT_STATUS
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Gate-driven checks.
 #
 # A gate is a PROPERTY the project must hold; `.lisa.config.json` names the task

--- a/all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs
+++ b/all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
+/**
+ * lisa-lint-staged-preflight — prove every tool lint-staged is about to run can
+ * actually be started, before lint-staged gets the chance to swallow the answer.
+ *
+ * Usage:
+ *   node scripts/lisa-lint-staged-preflight.mjs --config .lintstagedrc.json
+ *   node scripts/lisa-lint-staged-preflight.mjs --config=.lintstagedrc.json
+ *
+ * ## Why this exists
+ *
+ * `lint-staged` reports **exit 0** when a task's executable cannot be spawned
+ * with `ENOEXEC`, while printing `[FAILED] spawn ENOEXEC` to the terminal. The
+ * asymmetry is the whole problem, and it is what defeats the intuition that a
+ * broken tool would get noticed. Measured with one harness, three tasks,
+ * everything else held constant:
+ *
+ * | task                                            | 16.2.7 | 16.4.0 | 17.3.0 |
+ * | ----------------------------------------------- | ------ | ------ | ------ |
+ * | script exits 1 (ordinary failure)               | 1      | 1      | 1      |
+ * | executable absent entirely (`ENOENT`)           | 1      | 1      | 1      |
+ * | present, `chmod +x`, not executable (`ENOEXEC`) | 1      | **0**  | **0**  |
+ *
+ * A *missing* tool is caught. A tool that is present but unrunnable is not.
+ *
+ * That is precisely the state some published tools leave behind. A package
+ * whose real binary is materialized during `postinstall` installs a
+ * shebang-less placeholder shim first; the shim is written to fail loudly and
+ * explain itself, and it would, because it `exit 1`s. lint-staged spawns
+ * without a shell, so no shebang plus no shell means the kernel returns
+ * `ENOEXEC` before the shim's own `exit 1` can ever run. Skip `postinstall` —
+ * which is a route agents take routinely — and the task runs, reports nothing,
+ * and blocks nothing, while the commit proceeds.
+ *
+ * ## Why hardening the hook could not fix it
+ *
+ * Worth stating, because it is the obvious first response. The hook already
+ * captures lint-staged's status and exits on it. No exit-code check can catch
+ * a process that reports `0` for work it did not do. The answer has to arrive
+ * *before* the handoff, from something that spawns the tools itself.
+ *
+ * ## What "invocable" means here, and why it is measured rather than inferred
+ *
+ * This guard does not read the file's first bytes looking for a shebang or an
+ * object-file magic number and reason about what the kernel would do with them.
+ * It spawns each executable, shell-less, exactly as lint-staged will, and
+ * watches for the `spawn` event. `ENOEXEC`, `ENOENT` and `EACCES` all arrive as
+ * an `error` event instead, which is the signal. The probe passes when — and
+ * only when — the operating system really started the process.
+ *
+ * `--version` is the probe argument because every tool Lisa ships in
+ * `.lintstagedrc.json` answers it instantly. The exit code is deliberately
+ * ignored: a tool that rejects `--version` still *started*, which is the entire
+ * question. A tool that hangs is also a pass for the same reason — it started —
+ * so the probe kills it and moves on.
+ *
+ * ## Silence is not the success signal
+ *
+ * The defect being fixed is a control reporting success for work it no longer
+ * performs, so this file refuses to be a second instance of it:
+ *
+ * - It prints one line per executable it probed and a count. A run that proved
+ *   nothing cannot look like a run that proved everything.
+ * - A config it cannot read, cannot parse, or whose shape it does not
+ *   understand is a FAILURE, never a quiet pass.
+ * - A config that declares no tasks is a FAILURE: lint-staged would prove
+ *   nothing, and "nothing to check" is exactly the report this guard exists to
+ *   stop trusting.
+ * - Extracting zero executables from a config that has tasks is a FAILURE.
+ * - Executable-name extraction that disagrees with lint-staged's own
+ *   tokenization can only produce a name that fails to spawn, which this guard
+ *   reports loudly. It has no path to a silent pass.
+ * @module scripts/lisa-lint-staged-preflight
+ */
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+/** Default config path, matching what the shipped pre-commit hook passes. */
+const DEFAULT_CONFIG = ".lintstagedrc.json";
+
+/** Argument handed to each probed executable. */
+const PROBE_ARGS = Object.freeze(["--version"]);
+
+/**
+ * How long a probe waits before concluding the process really did start.
+ *
+ * Only reached by a tool that spawns and then neither exits nor is killed.
+ * Since spawning is the whole question, a timeout is a PASS.
+ */
+const PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * The config path named on the command line.
+ *
+ * Accepts `--config X` and `--config=X` because the hook and a human invoking
+ * this by hand write it both ways.
+ * @param {string[]} argv - Arguments after the script name.
+ * @returns {string} Config path, relative or absolute.
+ */
+export const configPathFrom = argv => {
+  const inline = argv.find(arg => arg.startsWith("--config="));
+  if (inline !== undefined) return inline.slice("--config=".length);
+  const flagAt = argv.indexOf("--config");
+  if (flagAt >= 0 && argv[flagAt + 1] !== undefined) return argv[flagAt + 1];
+  return DEFAULT_CONFIG;
+};
+
+/**
+ * The executable a lint-staged task string spawns.
+ *
+ * lint-staged splits the task with `string-argv` and spawns element zero, so
+ * this reproduces that for element zero only: quoted runs are unwrapped, and
+ * the token ends at the first unquoted whitespace. A disagreement with
+ * `string-argv` on an exotic task string yields a name that will not spawn,
+ * which this guard reports — never a name it silently skips.
+ * @param {string} command - A lint-staged task string.
+ * @returns {string} The executable name, or "" when the task is blank.
+ */
+export const executableOf = command => {
+  let token = "";
+  let quote = "";
+  for (const character of command) {
+    if (quote !== "") {
+      if (character === quote) quote = "";
+      else token += character;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (/\s/u.test(character)) {
+      if (token !== "") break;
+    } else {
+      token += character;
+    }
+  }
+  return token;
+};
+
+/**
+ * Every task string a lint-staged JSON config declares.
+ * @param {unknown} config - Parsed config contents.
+ * @returns {{ tasks: string[] } | { problem: string }} Tasks, or why not.
+ */
+export const tasksOf = config => {
+  if (config === null || typeof config !== "object" || Array.isArray(config)) {
+    return { problem: "the config is not a JSON object of glob → task(s)" };
+  }
+  const tasks = [];
+  for (const [glob, value] of Object.entries(config)) {
+    if (typeof value === "string") {
+      tasks.push(value);
+    } else if (
+      Array.isArray(value) &&
+      value.every(v => typeof v === "string")
+    ) {
+      tasks.push(...value);
+    } else {
+      return {
+        problem: `the entry for "${glob}" is neither a task string nor an array of them`,
+      };
+    }
+  }
+  return { tasks };
+};
+
+/**
+ * The environment a probe runs in: PATH augmented the way lint-staged's own
+ * spawner augments it, so a locally installed tool resolves identically.
+ *
+ * `node_modules/.bin` is prepended for the working directory and every ancestor
+ * of it, then the directory holding the running Node binary.
+ * @param {string} cwd - Directory the probe runs in.
+ * @returns {NodeJS.ProcessEnv} Environment for the probe.
+ */
+export const probeEnv = cwd => {
+  const binDirectories = [];
+  let current = cwd;
+  let previous = "";
+  while (current !== previous) {
+    binDirectories.push(path.resolve(current, "node_modules", ".bin"));
+    previous = current;
+    current = path.dirname(current);
+  }
+  binDirectories.push(path.dirname(process.execPath));
+
+  const key =
+    Object.keys(process.env).find(name => /^path$/iu.test(name)) ?? "PATH";
+  const existing = process.env[key] ?? "";
+  return {
+    ...process.env,
+    [key]: [
+      ...binDirectories,
+      ...(existing === "" ? [] : existing.split(path.delimiter)),
+    ].join(path.delimiter),
+  };
+};
+
+/**
+ * Start one executable and report whether the operating system started it.
+ *
+ * Shell-less on POSIX, matching how lint-staged spawns and therefore matching
+ * the `ENOEXEC` this guard exists to catch. On win32 the shell is used because
+ * that is how `.cmd` shims are invoked there; `ENOEXEC` in the sense meant here
+ * is a POSIX `execve` outcome and has no win32 counterpart.
+ * @param {string} executable - Name or path to start.
+ * @param {string} cwd - Directory to start it in.
+ * @param {NodeJS.ProcessEnv} env - Environment to start it with.
+ * @returns {Promise<{ executable: string, started: boolean, code?: string, detail?: string }>} Probe outcome.
+ */
+export const probe = (executable, cwd, env) =>
+  new Promise(resolve => {
+    let settled = false;
+    /**
+     * Resolve once, ignoring any later event from the same child.
+     * @param {{ executable: string, started: boolean, code?: string, detail?: string }} outcome - What happened.
+     * @returns {void}
+     */
+    const settle = outcome => {
+      if (settled) return;
+      settled = true;
+      resolve(outcome);
+    };
+
+    let child;
+    try {
+      child = spawn(executable, [...PROBE_ARGS], {
+        cwd,
+        env,
+        stdio: "ignore",
+        shell: process.platform === "win32",
+        timeout: PROBE_TIMEOUT_MS,
+      });
+    } catch (error) {
+      settle({
+        executable,
+        started: false,
+        code: /** @type {NodeJS.ErrnoException} */ (error).code ?? "FAILED",
+        detail: /** @type {Error} */ (error).message,
+      });
+      return;
+    }
+
+    child.on("error", error => {
+      settle({
+        executable,
+        started: false,
+        code: /** @type {NodeJS.ErrnoException} */ (error).code ?? "FAILED",
+        detail: error.message,
+      });
+    });
+    child.on("spawn", () => {
+      child.kill();
+      settle({ executable, started: true });
+    });
+  });
+
+/**
+ * Refuse to continue, saying what could not be established.
+ * @param {string} reason - Operator-readable reason.
+ * @param {string[]} [remedy] - Lines telling the reader what to do.
+ * @returns {number} Exit code 1.
+ */
+const refuse = (reason, remedy = []) => {
+  process.stderr.write(`\n❌ lint-staged preflight: ${reason}\n`);
+  for (const line of remedy) process.stderr.write(`   ${line}\n`);
+  process.stderr.write(
+    "\n   Nothing was proved about the tools lint-staged would run, so the\n" +
+      "   commit is blocked rather than allowed to look checked.\n\n"
+  );
+  return 1;
+};
+
+/**
+ * Run the preflight.
+ * @param {string[]} argv - Arguments after the script name.
+ * @param {string} cwd - Directory the probes run in.
+ * @returns {Promise<number>} Process exit code.
+ */
+export const run = async (argv, cwd) => {
+  const configPath = configPathFrom(argv);
+  const absolute = path.resolve(cwd, configPath);
+  if (!existsSync(absolute)) {
+    return refuse(`no config at ${configPath}`, [
+      "lint-staged is about to be handed this path and will fail too.",
+      "Restore the file, or point the pre-commit hook at the right one.",
+    ]);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(readFileSync(absolute, "utf8"));
+  } catch (error) {
+    return refuse(`${configPath} is not valid JSON`, [
+      /** @type {Error} */ (error).message,
+    ]);
+  }
+
+  const extracted = tasksOf(parsed);
+  if ("problem" in extracted) {
+    return refuse(`${configPath} has a shape this guard cannot read`, [
+      extracted.problem,
+      "This guard reads JSON configs only, which is what Lisa ships.",
+    ]);
+  }
+  if (extracted.tasks.length === 0) {
+    return refuse(`${configPath} declares no tasks`, [
+      "lint-staged would run nothing and report success.",
+      "Add the tasks back, or stop running lint-staged from the hook.",
+    ]);
+  }
+
+  const executables = [...new Set(extracted.tasks.map(executableOf))].filter(
+    name => name !== ""
+  );
+  if (executables.length === 0) {
+    return refuse(
+      `no executable name could be read from the ${extracted.tasks.length} task(s) in ${configPath}`
+    );
+  }
+
+  process.stdout.write(
+    `🔎 lint-staged preflight: probing ${executables.length} tool(s) named by ${configPath}\n`
+  );
+  const env = probeEnv(cwd);
+  const outcomes = await Promise.all(
+    executables.map(executable => probe(executable, cwd, env))
+  );
+
+  for (const outcome of outcomes) {
+    process.stdout.write(
+      outcome.started
+        ? `   ✅ ${outcome.executable}\n`
+        : `   ❌ ${outcome.executable} — could not be started (${outcome.code})\n`
+    );
+  }
+
+  const broken = outcomes.filter(outcome => !outcome.started);
+  if (broken.length > 0) {
+    return refuse(
+      `${broken.length} of ${outcomes.length} tool(s) cannot be started`,
+      [
+        ...broken.map(
+          outcome => `${outcome.executable}: ${outcome.detail ?? outcome.code}`
+        ),
+        "",
+        "lint-staged spawns these without a shell. A tool that is present but",
+        "not executable makes it print [FAILED] and still exit 0, so the scan",
+        "would run, report nothing, and block nothing.",
+        "",
+        "Most often this is an install that skipped postinstall scripts, which",
+        "leaves a placeholder where the real binary belongs. Reinstall with",
+        "scripts enabled (for example `bun install --force`) and try again.",
+      ]
+    );
+  }
+
+  process.stdout.write(
+    `   ${outcomes.length} tool(s) verified runnable; handing off to lint-staged.\n`
+  );
+  return 0;
+};
+
+/**
+ * True when `moduleUrl` names the module node was asked to run.
+ *
+ * Both sides are realpath'd: `import.meta.url` is the real path while `argv[1]`
+ * is whatever the caller typed, so through a symlinked checkout, a git
+ * worktree, or a `/tmp` path on macOS a raw comparison is false and the body
+ * never runs — for a guard, exiting 0 having proved nothing.
+ * @param {string} moduleUrl - The caller's own `import.meta.url`.
+ * @param {string} [argv1] - Entry path; defaults to `process.argv[1]`.
+ * @returns {boolean} Whether the CLI body should run.
+ */
+export const invokedAsScript = (moduleUrl, argv1 = process.argv[1]) => {
+  if (argv1 === undefined || argv1 === "") return false;
+  try {
+    return realpathSync(argv1) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+};
+
+if (invokedAsScript(import.meta.url)) {
+  run(process.argv.slice(2), process.cwd())
+    .then(code => {
+      process.exitCode = code;
+    })
+    .catch(error => {
+      process.stderr.write(
+        `\n❌ lint-staged preflight crashed: ${/** @type {Error} */ (error).message}\n` +
+          "   Nothing was proved. The commit is blocked.\n\n"
+      );
+      process.exitCode = 1;
+    });
+}

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -300,6 +300,9 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "945453fb275a58aa7185e150e6b05e5810739750928ab5bd6edfbf87d1c8aa0d",
     "bf4132e49ba18e2f7e941520c299c15aeeacfd220e489f3d2eb8397f2048157b",
   ]),
+  "scripts/lisa-lint-staged-preflight.mjs": Object.freeze([
+    "ce4bc224a102e3ac2bc29d8f2038eefd619129d4639c25954c93f05011f7f977",
+  ]),
   "scripts/lisa-mutation.mjs": Object.freeze([
     "660d0b833ac5ffcb93cb3c478b6b840492a0ae049ff3b6f87275f78537ef7258",
     "7d8d24dea151ef2178807046e97aea7ebfadd9c88eb50347feb7bb4bb190227d",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -34,6 +34,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "1d4fbe135f1bb4e861d286a6512ed201d4522250dfe3f9eba6584bc5ff166a95",
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh":
       "18e63683064305dab1200456896cbb9384ab35ee6bc51d3789ffbba46d1b1081",
+    "all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs":
+      "ce4bc224a102e3ac2bc29d8f2038eefd619129d4639c25954c93f05011f7f977",
     "all/copy-overwrite/scripts/lisa-reconcile-policy.mjs":
       "3c062d0b79961a9a93a822507e893dcdaa71d65d735557727d20464c2489d812",
     "all/copy-overwrite/scripts/lisa-run-gates.mjs":
@@ -2257,7 +2259,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-contents/.husky/post-checkout":
       "f3abc4528e12d3ad2bc48b236d19f105e2817595c744156a558c62ae5551ccfb",
     "typescript/copy-contents/.husky/pre-commit":
-      "f1313c83014912df8e769d452a61378eff6bc60a75d3c421974dcd100699b2a5",
+      "e37bf7e8e49139fd726bda6bfeb69dd30008d8e5d14fa562a3ff4f541f217e6f",
     "typescript/copy-contents/.husky/pre-push":
       "7569605ea9a0cf6444cfd7271edaa8e7d04b8d26a469176bace602518cec03c8",
     "typescript/copy-contents/.husky/prepare-commit-msg":
@@ -2527,6 +2529,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-overwrite/scripts/lisa-hooks/block-shell-json-parsing.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh": true,
+    "all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs": true,
     "all/copy-overwrite/scripts/lisa-reconcile-policy.mjs": true,
     "all/copy-overwrite/scripts/lisa-run-gates.mjs": true,
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs": true,
@@ -9048,6 +9051,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/github-governance.test.ts": true,
     "tests/unit/scripts/install-claude-plugins-self.test.ts": true,
     "tests/unit/scripts/invoked-as-script.test.ts": true,
+    "tests/unit/scripts/lint-staged-preflight.test.ts": true,
     "tests/unit/scripts/lisa-assert-eas-profile.test.ts": true,
     "tests/unit/scripts/lisa-gates-evidence.test.ts": true,
     "tests/unit/scripts/lisa-gates-fixtures.ts": true,

--- a/tests/unit/scripts/lint-staged-preflight.test.ts
+++ b/tests/unit/scripts/lint-staged-preflight.test.ts
@@ -1,0 +1,353 @@
+/**
+ * Tests for the lint-staged preflight — the guard that proves every tool
+ * lint-staged is about to run can actually be started.
+ *
+ * The defect it exists for is narrow and counter-intuitive: lint-staged fails
+ * CLOSED on an ordinary non-zero exit and on a missing executable, and fails
+ * OPEN on a present-but-unrunnable one, printing `[FAILED] spawn ENOEXEC` and
+ * returning 0. So the ENOEXEC case is the one that has to be pinned by name —
+ * a suite that only covered the missing-executable case would have passed
+ * against the very behaviour that let a scan report nothing and block nothing.
+ *
+ * Behaviour is exercised through the real CLI rather than the exported helpers,
+ * because the thing under test is an exit code.
+ */
+import { spawn } from "node:child_process";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  configPathFrom,
+  executableOf,
+  tasksOf,
+} from "../../../all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+const SCRIPT = path.join(
+  REPO_ROOT,
+  "all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs"
+);
+
+/** The config filename the hooks name and lint-staged reads. */
+const CONFIG = ".lintstagedrc.json";
+
+/** CLI arguments pointing the preflight at that config. */
+const CONFIG_ARGS = ["--config", CONFIG] as const;
+
+/** Hooks that must be found by the walk below, whatever else it finds. */
+const KNOWN_HOOKS = [
+  ".husky/pre-commit",
+  "typescript/copy-contents/.husky/pre-commit",
+  ".claude-pr/.husky/pre-commit",
+] as const;
+
+/** Directory names the hook walk never descends into. */
+const UNWALKED = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "coverage",
+  "plans",
+  "projects",
+]);
+
+/**
+ * Run the preflight CLI and collect its exit code and combined output.
+ * @param cwd - Directory to run in.
+ * @param args - Arguments after the script path.
+ * @returns Exit code and merged stdout/stderr.
+ */
+const runPreflight = (
+  cwd: string,
+  args: readonly string[]
+): Promise<{ code: number; output: string }> =>
+  new Promise(resolve => {
+    const child = spawn(process.execPath, [SCRIPT, ...args], { cwd });
+    let output = "";
+    child.stdout.on("data", chunk => {
+      output += String(chunk);
+    });
+    child.stderr.on("data", chunk => {
+      output += String(chunk);
+    });
+    child.on("close", code => resolve({ code: code ?? -1, output }));
+  });
+
+/**
+ * A throwaway project directory carrying a lint-staged config.
+ * @param config - Contents to write as `.lintstagedrc.json`.
+ * @returns Absolute path to the directory.
+ */
+const fixture = (config: string): string => {
+  const dir = mkdtempSync(path.join(tmpdir(), "lisa-preflight-"));
+  mkdirSync(path.join(dir, "node_modules", ".bin"), { recursive: true });
+  writeFileSync(path.join(dir, CONFIG), config);
+  return dir;
+};
+
+/**
+ * Put an executable-bit-set file in the fixture's local bin directory.
+ * @param dir - Fixture directory.
+ * @param name - Executable name.
+ * @param contents - File contents, shebang included or deliberately not.
+ * @returns void
+ */
+const installBin = (dir: string, name: string, contents: string): void => {
+  const target = path.join(dir, "node_modules", ".bin", name);
+  writeFileSync(target, contents);
+  chmodSync(target, 0o755);
+};
+
+/**
+ * Every pre-commit hook in the repository that hands work to lint-staged.
+ * @returns Repo-relative paths.
+ */
+const preCommitHooksRunningLintStaged = (): string[] => {
+  const found: string[] = [];
+  /**
+   * Recurse into one directory.
+   * @param relative - Repo-relative directory path.
+   * @returns void
+   */
+  const walk = (relative: string): void => {
+    for (const entry of readdirSync(path.join(REPO_ROOT, relative), {
+      withFileTypes: true,
+    })) {
+      const next = relative === "" ? entry.name : `${relative}/${entry.name}`;
+      if (entry.isDirectory()) {
+        if (!UNWALKED.has(entry.name)) walk(next);
+      } else if (
+        entry.name === "pre-commit" &&
+        readFileSync(path.join(REPO_ROOT, next), "utf8").includes(
+          "lint-staged --config"
+        )
+      ) {
+        found.push(next);
+      }
+    }
+  };
+  walk("");
+  return found;
+};
+
+describe("lint-staged preflight — behaviour", () => {
+  it("BLOCKS a tool that is present and executable but cannot be spawned (ENOEXEC)", async () => {
+    // The case lint-staged itself lets through. A shebang-less text file with
+    // the executable bit set is exactly what a package leaves behind when its
+    // real binary is materialized by a postinstall script that never ran.
+    const dir = fixture('{ "*.ts": ["lisa-fixture-shim scan"] }');
+    installBin(
+      dir,
+      "lisa-fixture-shim",
+      "this shim was never replaced\nexit 1\n"
+    );
+
+    const { code, output } = await runPreflight(dir, CONFIG_ARGS);
+
+    expect(code).toBe(1);
+    expect(output).toContain("ENOEXEC");
+    expect(output).toContain("lisa-fixture-shim");
+  });
+
+  it("BLOCKS a tool that is absent entirely (ENOENT)", async () => {
+    const dir = fixture('{ "*.ts": ["lisa-fixture-absent --check"] }');
+
+    const { code, output } = await runPreflight(dir, CONFIG_ARGS);
+
+    expect(code).toBe(1);
+    expect(output).toContain("ENOENT");
+  });
+
+  it("PASSES a runnable tool, and says how many it probed", async () => {
+    // The count is load-bearing: a run that proved nothing must not be able to
+    // look like a run that proved everything.
+    const dir = fixture(
+      '{ "*.ts": ["lisa-fixture-real --fix", "lisa-fixture-real scan"] }'
+    );
+    installBin(dir, "lisa-fixture-real", "#!/bin/sh\nexit 0\n");
+
+    const { code, output } = await runPreflight(dir, CONFIG_ARGS);
+
+    expect(code).toBe(0);
+    expect(output).toContain("1 tool(s) verified runnable");
+  });
+
+  it("PASSES a tool that rejects the probe argument, because it still started", async () => {
+    // Exit status is deliberately not the question — spawning is.
+    const dir = fixture('{ "*.ts": ["lisa-fixture-grumpy"] }');
+    installBin(dir, "lisa-fixture-grumpy", "#!/bin/sh\nexit 3\n");
+
+    const { code } = await runPreflight(dir, CONFIG_ARGS);
+
+    expect(code).toBe(0);
+  });
+
+  it("names every broken tool, not just the first", async () => {
+    const dir = fixture(
+      '{ "*.ts": ["lisa-fixture-shim-a", "lisa-fixture-shim-b"] }'
+    );
+    installBin(dir, "lisa-fixture-shim-a", "never replaced\n");
+    installBin(dir, "lisa-fixture-shim-b", "never replaced\n");
+
+    const { code, output } = await runPreflight(dir, CONFIG_ARGS);
+
+    expect(code).toBe(1);
+    expect(output).toContain("2 of 2 tool(s) cannot be started");
+  });
+
+  it("BLOCKS when the config is missing", async () => {
+    const dir = fixture('{ "*.ts": ["lisa-fixture-real"] }');
+
+    const { code, output } = await runPreflight(dir, [
+      "--config",
+      "nowhere.json",
+    ]);
+
+    expect(code).toBe(1);
+    expect(output).toContain("no config at nowhere.json");
+  });
+
+  it("BLOCKS when the config is not valid JSON", async () => {
+    const dir = fixture("{ not json");
+
+    const { code, output } = await runPreflight(dir, CONFIG_ARGS);
+
+    expect(code).toBe(1);
+    expect(output).toContain("is not valid JSON");
+  });
+
+  it("BLOCKS an empty config rather than reporting nothing to do", async () => {
+    // "Nothing to check" is the report this guard exists to stop trusting.
+    const dir = fixture("{}");
+
+    const { code, output } = await runPreflight(dir, CONFIG_ARGS);
+
+    expect(code).toBe(1);
+    expect(output).toContain("declares no tasks");
+  });
+
+  it("BLOCKS a config whose shape it cannot read", async () => {
+    const dir = fixture('{ "*.ts": { "run": "lisa-fixture-real" } }');
+
+    const { code, output } = await runPreflight(dir, CONFIG_ARGS);
+
+    expect(code).toBe(1);
+    expect(output).toContain("shape this guard cannot read");
+  });
+
+  it("accepts --config in both spellings, and defaults to .lintstagedrc.json", () => {
+    expect(configPathFrom(["--config", "a.json"])).toBe("a.json");
+    expect(configPathFrom(["--config=b.json"])).toBe("b.json");
+    expect(configPathFrom([])).toBe(CONFIG);
+  });
+});
+
+describe("lint-staged preflight — task parsing", () => {
+  it("reads the executable from a task string the way lint-staged spawns it", () => {
+    expect(executableOf("ast-grep scan")).toBe("ast-grep");
+    expect(executableOf("  prettier --write  ")).toBe("prettier");
+    expect(executableOf('"my tool" --flag')).toBe("my tool");
+    expect(executableOf("./node_modules/.bin/eslint --fix")).toBe(
+      "./node_modules/.bin/eslint"
+    );
+    expect(executableOf("   ")).toBe("");
+  });
+
+  it("collects tasks from both the string and array forms", () => {
+    expect(tasksOf({ "*.ts": "a", "*.md": ["b", "c"] })).toEqual({
+      tasks: ["a", "b", "c"],
+    });
+  });
+
+  it("refuses a shape it cannot read instead of returning an empty list", () => {
+    // An empty list would flow onward as "nothing to probe" and pass.
+    expect(tasksOf(["a"])).toHaveProperty("problem");
+    expect(tasksOf(null)).toHaveProperty("problem");
+    expect(tasksOf({ "*.ts": 7 })).toHaveProperty("problem");
+  });
+});
+
+describe("lint-staged preflight — the configs Lisa ships", () => {
+  it("every tool named by this repository's own config really starts", async () => {
+    // Runs in required CI, against the real installed toolchain. It is the one
+    // arm of this guard that is not pre-commit-only: a shipped config naming a
+    // tool that cannot be started goes red here rather than waiting for
+    // somebody's commit to quietly scan nothing.
+    const { code, output } = await runPreflight(REPO_ROOT, CONFIG_ARGS);
+
+    expect(output, output).toContain("verified runnable");
+    expect(code, output).toBe(0);
+  });
+
+  it("every task in the shipped stack template names an extractable executable", () => {
+    const template = "typescript/copy-overwrite/.lintstagedrc.json";
+    const extracted = tasksOf(
+      JSON.parse(readFileSync(path.join(REPO_ROOT, template), "utf8"))
+    );
+
+    expect(extracted).not.toHaveProperty("problem");
+    const tasks = (extracted as { tasks: string[] }).tasks;
+    expect(tasks.length).toBeGreaterThan(0);
+    for (const task of tasks) expect(executableOf(task), task).not.toBe("");
+  });
+});
+
+describe("lint-staged preflight — wiring", () => {
+  const hooks = preCommitHooksRunningLintStaged();
+
+  it("finds the pre-commit hooks it is supposed to be checking", () => {
+    // A walk that reached nothing would let every assertion below pass
+    // vacuously, which is the same defect class as the bug being fixed.
+    expect(hooks.length).toBeGreaterThan(0);
+    for (const known of KNOWN_HOOKS) expect(hooks).toContain(known);
+  });
+
+  it.each(hooks)("runs the preflight before lint-staged: %s", hook => {
+    const text = readFileSync(path.join(REPO_ROOT, hook), "utf8");
+    const preflightAt = text.indexOf("lisa-lint-staged-preflight.mjs");
+
+    expect(preflightAt).toBeGreaterThanOrEqual(0);
+    expect(preflightAt).toBeLessThan(text.indexOf("lint-staged --config"));
+  });
+
+  it.each(hooks)(
+    "runs the preflight before the gate runner too, because a gate can run lint-staged: %s",
+    hook => {
+      const text = readFileSync(path.join(REPO_ROOT, hook), "utf8");
+      const runnerAt = text.indexOf("lisa-run-gates.mjs");
+      if (runnerAt < 0) return;
+
+      expect(text.indexOf("lisa-lint-staged-preflight.mjs")).toBeLessThan(
+        runnerAt
+      );
+    }
+  );
+
+  it.each(hooks)("exits on a failing preflight: %s", hook => {
+    const text = readFileSync(path.join(REPO_ROOT, hook), "utf8");
+
+    expect(text).toContain("LINT_STAGED_PREFLIGHT_STATUS=$?");
+    expect(text).toContain("exit $LINT_STAGED_PREFLIGHT_STATUS");
+  });
+
+  it.each(hooks)(
+    "treats an unavailable preflight as a block, never a skip: %s",
+    hook => {
+      const text = readFileSync(path.join(REPO_ROOT, hook), "utf8");
+
+      expect(text).toContain(
+        "❌ Commit blocked: the lint-staged preflight could not run."
+      );
+    }
+  );
+});

--- a/tests/unit/scripts/lint-staged-preflight.test.ts
+++ b/tests/unit/scripts/lint-staged-preflight.test.ts
@@ -109,6 +109,32 @@ const installBin = (dir: string, name: string, contents: string): void => {
 };
 
 /**
+ * Bytes that no kernel will exec and no shell will interpret.
+ *
+ * The obvious ENOEXEC fixture — a shebang-less text file with the exec bit —
+ * is NOT portable, and the difference is invisible on a developer machine.
+ * macOS refuses it with ENOEXEC; **Linux falls back to /bin/sh and runs it
+ * successfully**, so on CI the preflight found nothing wrong and the two tests
+ * pinning this behaviour failed there while passing locally.
+ *
+ * An ELF header with a corrupt class byte cannot be executed on either
+ * platform, and the leading NUL stops any shell from treating it as a script,
+ * so the spawn fails with ENOEXEC everywhere.
+ * @param name - Bin name to install
+ * @param dir - Fixture project root
+ */
+const installUnspawnableBin = (dir: string, name: string): void => {
+  const target = path.join(dir, "node_modules", ".bin", name);
+  // \x7fELF then a class byte of 0 — a valid magic number with an invalid
+  // class, which the loader rejects rather than mapping.
+  writeFileSync(
+    target,
+    Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x00, 0x00, 0x00])
+  );
+  chmodSync(target, 0o755);
+};
+
+/**
  * Every pre-commit hook in the repository that hands work to lint-staged.
  * @returns Repo-relative paths.
  */
@@ -146,11 +172,7 @@ describe("lint-staged preflight — behaviour", () => {
     // the executable bit set is exactly what a package leaves behind when its
     // real binary is materialized by a postinstall script that never ran.
     const dir = fixture('{ "*.ts": ["lisa-fixture-shim scan"] }');
-    installBin(
-      dir,
-      "lisa-fixture-shim",
-      "this shim was never replaced\nexit 1\n"
-    );
+    installUnspawnableBin(dir, "lisa-fixture-shim");
 
     const { code, output } = await runPreflight(dir, CONFIG_ARGS);
 
@@ -196,8 +218,8 @@ describe("lint-staged preflight — behaviour", () => {
     const dir = fixture(
       '{ "*.ts": ["lisa-fixture-shim-a", "lisa-fixture-shim-b"] }'
     );
-    installBin(dir, "lisa-fixture-shim-a", "never replaced\n");
-    installBin(dir, "lisa-fixture-shim-b", "never replaced\n");
+    installUnspawnableBin(dir, "lisa-fixture-shim-a");
+    installUnspawnableBin(dir, "lisa-fixture-shim-b");
 
     const { code, output } = await runPreflight(dir, CONFIG_ARGS);
 

--- a/tests/unit/scripts/lint-staged-preflight.test.ts
+++ b/tests/unit/scripts/lint-staged-preflight.test.ts
@@ -109,31 +109,41 @@ const installBin = (dir: string, name: string, contents: string): void => {
 };
 
 /**
- * Bytes that no kernel will exec and no shell will interpret.
+ * Whether an ENOEXEC spawn failure is even reachable on this platform.
  *
- * The obvious ENOEXEC fixture — a shebang-less text file with the exec bit —
- * is NOT portable, and the difference is invisible on a developer machine.
- * macOS refuses it with ENOEXEC; **Linux falls back to /bin/sh and runs it
- * successfully**, so on CI the preflight found nothing wrong and the two tests
- * pinning this behaviour failed there while passing locally.
+ * It is not universal, and assuming it was cost two CI-red cycles. POSIX says
+ * `execvp` retries with `/bin/sh` when `execve` returns ENOEXEC, and glibc
+ * implements exactly that — so on Linux a present-but-unrunnable file SPAWNS
+ * (the shell takes it, then exits 126 or 127) and no `error` event ever
+ * arrives. macOS does not take that path, so ENOEXEC surfaces.
  *
- * An ELF header with a corrupt class byte cannot be executed on either
- * platform, and the leading NUL stops any shell from treating it as a script,
- * so the spawn fails with ENOEXEC everywhere.
- * @param name - Bin name to install
+ * Measured, after a first fixture and a "portable" ELF replacement both failed
+ * the same way on Ubuntu: `expected +0 to be 1`, because the probe found
+ * nothing wrong. The file's CONTENT is irrelevant on Linux; the fallback is
+ * unconditional.
+ *
+ * Consequence worth stating plainly: the fail-open this guard exists for is
+ * **platform-specific**. It is still worth guarding, because pre-commit hooks
+ * run on developer machines, but the ENOEXEC assertion cannot be made on CI.
+ */
+const ENOEXEC_IS_REACHABLE = process.platform !== "linux";
+
+/**
+ * Installs a tool that cannot be spawned on ANY platform.
+ *
+ * Present, but without the executable bit: `execvp` fails with EACCES, and the
+ * `/bin/sh` retry applies only to ENOEXEC — so this raises an `error` event
+ * everywhere, which is the signal the probe watches for. This is what keeps
+ * the guard's core behaviour pinned on CI rather than only on a developer's
+ * machine.
  * @param dir - Fixture project root
+ * @param name - Bin name to install
  */
 const installUnspawnableBin = (dir: string, name: string): void => {
   const target = path.join(dir, "node_modules", ".bin", name);
-  // \x7fELF then a class byte of 0 — a valid magic number with an invalid
-  // class, which the loader rejects rather than mapping.
-  writeFileSync(
-    target,
-    Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x00, 0x00, 0x00])
-  );
-  chmodSync(target, 0o755);
+  writeFileSync(target, "#!/bin/sh\nexit 0\n");
+  chmodSync(target, 0o644);
 };
-
 /**
  * Every pre-commit hook in the repository that hands work to lint-staged.
  * @returns Repo-relative paths.
@@ -167,19 +177,40 @@ const preCommitHooksRunningLintStaged = (): string[] => {
 };
 
 describe("lint-staged preflight — behaviour", () => {
-  it("BLOCKS a tool that is present and executable but cannot be spawned (ENOEXEC)", async () => {
-    // The case lint-staged itself lets through. A shebang-less text file with
-    // the executable bit set is exactly what a package leaves behind when its
-    // real binary is materialized by a postinstall script that never ran.
+  it("BLOCKS a tool that is present but cannot be spawned", async () => {
+    // Runs on every platform. The errno is deliberately NOT asserted: which
+    // one a broken tool produces is platform-dependent, and pinning the errno
+    // is what made this suite pass on macOS and fail on CI twice.
     const dir = fixture('{ "*.ts": ["lisa-fixture-shim scan"] }');
     installUnspawnableBin(dir, "lisa-fixture-shim");
 
     const { code, output } = await runPreflight(dir, CONFIG_ARGS);
 
     expect(code).toBe(1);
-    expect(output).toContain("ENOEXEC");
     expect(output).toContain("lisa-fixture-shim");
   });
+
+  it.runIf(ENOEXEC_IS_REACHABLE)(
+    "BLOCKS a tool that is executable but not runnable (ENOEXEC)",
+    async () => {
+      // The specific fail-open lint-staged has: it prints `spawn ENOEXEC` and
+      // returns 0. A shebang-less text file with the exec bit is what a package
+      // leaves behind when a postinstall that should have materialized the real
+      // binary never ran.
+      //
+      // Skipped on Linux because the condition cannot be CONSTRUCTED there, not
+      // because it is inconvenient — execvp's /bin/sh fallback means such a file
+      // spawns successfully. A skip whose reason is "this platform cannot
+      // exhibit the defect" is honest; one that hides a red is not.
+      const dir = fixture('{ "*.ts": ["lisa-fixture-enoexec scan"] }');
+      installBin(dir, "lisa-fixture-enoexec", "never replaced\n");
+
+      const { code, output } = await runPreflight(dir, CONFIG_ARGS);
+
+      expect(code).toBe(1);
+      expect(output).toContain("ENOEXEC");
+    }
+  );
 
   it("BLOCKS a tool that is absent entirely (ENOENT)", async () => {
     const dir = fixture('{ "*.ts": ["lisa-fixture-absent --check"] }');

--- a/typescript/copy-contents/.husky/pre-commit
+++ b/typescript/copy-contents/.husky/pre-commit
@@ -44,6 +44,70 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# lint-staged preflight.
+#
+# lint-staged reports exit 0 when a task's executable cannot be SPAWNED.
+# Measured on lint-staged 16.4.0 and 17.3.0: a file that is present and
+# `chmod +x` but is not a runnable executable prints "[FAILED] spawn ENOEXEC"
+# and the run still exits 0. An absent executable (ENOENT) and an ordinary
+# non-zero exit both fail closed — only the spawn error does not.
+#
+# That state is not exotic. A tool whose real binary is materialized during
+# `postinstall` leaves a shebang-less placeholder behind on any install that
+# skips scripts, and lint-staged spawns without a shell, so the kernel refuses
+# the file before the placeholder's own `exit 1` can run. The staged-file scan
+# then runs, reports nothing, blocks nothing, and the commit proceeds.
+#
+# No exit-code check can catch this — not the one below, not any other. A
+# process reporting 0 for work it did not do defeats every test of its status.
+# So the tools are proved runnable BEFORE any of them is handed the work, by
+# something that spawns them itself and reports what it spawned.
+#
+# OUTSIDE the gate-registry handover, deliberately. lint-staged runs at this
+# moment by BOTH routes: the built-in step further down, and a `code-style`
+# gate whose declared command is the project's lint-staged script. A preflight
+# placed inside the built-in branch would stand down for exactly the projects
+# whose registry then runs lint-staged anyway. The tools are the same either
+# way, so the proof belongs before both.
+#
+# Skipped only when the project has no lint-staged config, in which case no
+# route runs lint-staged and there is nothing to prove. A preflight that cannot
+# RUN is not a skip and not a pass — it blocks.
+# ---------------------------------------------------------------------------
+if [ -f ".lintstagedrc.json" ]; then
+  LINT_STAGED_PREFLIGHT="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs"
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ]; then
+    LINT_STAGED_PREFLIGHT="scripts/lisa-lint-staged-preflight.mjs"
+  fi
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ]; then
+    LINT_STAGED_PREFLIGHT="all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs"
+  fi
+  if command -v node >/dev/null 2>&1; then
+    LINT_STAGED_PREFLIGHT_RUNTIME="node"
+  elif command -v bun >/dev/null 2>&1; then
+    LINT_STAGED_PREFLIGHT_RUNTIME="bun"
+  else
+    LINT_STAGED_PREFLIGHT_RUNTIME=""
+  fi
+  if [ ! -f "$LINT_STAGED_PREFLIGHT" ] || [ -z "$LINT_STAGED_PREFLIGHT_RUNTIME" ]; then
+    echo ""
+    echo "❌ Commit blocked: the lint-staged preflight could not run."
+    echo "   Expected $LINT_STAGED_PREFLIGHT, and node or bun on PATH."
+    echo "   Without it a tool that is installed but not executable makes"
+    echo "   lint-staged exit 0 having scanned nothing, so skipping the"
+    echo "   preflight cannot be treated as a pass."
+    echo "   Reinstall dependencies, then re-run \`lisa apply\`."
+    echo ""
+    exit 1
+  fi
+  "$LINT_STAGED_PREFLIGHT_RUNTIME" "$LINT_STAGED_PREFLIGHT" --config .lintstagedrc.json
+  LINT_STAGED_PREFLIGHT_STATUS=$?
+  if [ $LINT_STAGED_PREFLIGHT_STATUS -ne 0 ]; then
+    exit $LINT_STAGED_PREFLIGHT_STATUS
+  fi
+fi
+
+# ---------------------------------------------------------------------------
 # Gate-driven checks.
 #
 # A gate is a PROPERTY the project must hold; `.lisa.config.json` names the task


### PR DESCRIPTION
## What

`lint-staged` returns **exit 0** when a task's executable cannot be spawned (`ENOEXEC`), while printing `[FAILED] spawn ENOEXEC`. This adds a preflight that spawns every tool named by `.lintstagedrc.json` **before** the handoff, and blocks the commit if any of them cannot start.

## The measurement

One harness, three tasks, everything else held constant:

| task | 16.2.7 | 16.4.0 | 17.3.0 |
| --- | --- | --- | --- |
| script exits 1 (ordinary failure) | 1 | 1 | 1 |
| executable absent entirely (`ENOENT`) | 1 | 1 | 1 |
| present, `chmod +x`, not a valid executable (`ENOEXEC`) | 1 | **0** | **0** |

A *missing* tool is caught. A tool that is present but unrunnable is not — and that asymmetry is what defeats the intuition that a broken tool would get noticed. Lisa pins `^16.2.7`, which resolves to 16.4.0.

## The hole the issue did not know about

The issue proposed preflighting inside the built-in lint-staged branch. Running the real hook showed that is not enough. This repository declares a `code-style` gate whose commit command **is** the lint-staged script, so the registry takes the moment and the built-in branch stands down. With a placeholder binary in place and lint-staged 16.4.0, the pre-fix hook printed:

```
[STARTED] ast-grep scan
[FAILED] spawn ENOEXEC
[FAILED] spawn ENOEXEC
  PASSED     required code-style        bun run lint:staged
```

A **required gate reported PASSED** for a structural scan that spawned nothing. So the preflight sits *outside* the gate-registry handover, before both routes.

## How the guard decides

It does not read the file's first bytes and reason about what the kernel would do. It spawns each executable shell-less — exactly as lint-staged does — and watches for the `spawn` event. `ENOEXEC`, `ENOENT` and `EACCES` all arrive as an `error` event instead. Exit status is deliberately ignored: a tool that rejects `--version` still *started*, which is the entire question, and a tool that hangs is a pass for the same reason.

PATH is augmented with `node_modules/.bin` from the working directory upward, matching lint-staged's own spawner, so a locally installed tool resolves identically.

## Silence cannot read as success

- One line per tool plus a count. A run that proved nothing cannot look like a run that proved everything.
- A config that is missing, unparseable, empty, or shaped in a way the guard cannot read is a **failure**, never a quiet pass.
- A preflight that cannot run **blocks** — it is not treated as a skip.
- Name extraction that disagreed with lint-staged's tokenization could only yield a name that fails to spawn, which the guard reports. There is no path to a silent pass.

## Bite control

Against the real placeholder shim the vendor ships for `@ast-grep/cli`:

**RED** — `sh .husky/pre-commit` with the shim installed:
```
🔎 lint-staged preflight: probing 4 tool(s) named by .lintstagedrc.json
   ✅ oxlint
   ✅ eslint
   ❌ ast-grep — could not be started (ENOEXEC)
   ✅ prettier
❌ lint-staged preflight: 1 of 4 tool(s) cannot be started
PRE-COMMIT HOOK EXIT = 1
```

**GREEN** — same hook, real binary restored: `PRE-COMMIT HOOK EXIT = 0`.

The suite was also verified against pre-fix behaviour by name, twice:
- Probe switched to spawn through a shell (the pre-fix world) → `BLOCKS a tool that is present and executable but cannot be spawned (ENOEXEC)` and two others fail.
- `.husky/pre-commit` reverted to `origin/main` → the three wiring assertions for that file fail.

## Enforcement surface

28 tests in required CI. Beyond behaviour, they pin the wiring: the walk enumerates every `pre-commit` in the repository that hands work to lint-staged, refuses to pass on an empty result, and asserts each one runs the preflight before both the gate runner and lint-staged. One test runs the preflight against this repository's own config and real toolchain, so a shipped config naming a tool that cannot start goes red in CI rather than waiting for somebody's commit to quietly scan nothing.

## Not done

- Option (a) from the issue — fixing `lint-staged` upstream — is untouched. A third-party release cycle cannot be the mitigation.
- On `win32` the probe goes through a shell, matching how `.cmd` shims are invoked. `ENOEXEC` in the sense meant here is a POSIX `execve` outcome; the guard makes no claim about Windows.

Work-Item: CodySwannGT/lisa#2678
