### PR TITLE
fix(intake): sweep pre-work lanes by type, and state the denominator

### DIFF
--- a/plugins/lisa-agy/scripts/automation-run-record.mjs
+++ b/plugins/lisa-agy/scripts/automation-run-record.mjs
@@ -11,6 +11,8 @@ import path from "node:path";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { assertDenominatorReported } from "./intake-prework-denominator.mjs";
+
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
   "candidate-proposed",
@@ -55,6 +57,15 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
  */
 export async function recordAutomationRun(input) {
+  // Write path only. Stored rows are re-validated on read through
+  // `validateStoredRecord`, and a history written before this contract existed
+  // must stay readable — so the denominator gate lives here, where a NEW row is
+  // minted, and never on the read path.
+  assertDenominatorReported({
+    loopId: input.loopId,
+    outcome: input.outcome,
+    denominator: input.extras?.denominator,
+  });
   const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
   const maxEntries =
     input.maxEntries ??
@@ -303,14 +314,19 @@ async function writeJsonlAtomically(filePath, records) {
 const CLI_USAGE = `Usage: node automation-run-record.mjs \\
   --loop-id <slug> --outcome <${AUTOMATION_RUN_OUTCOMES.join("|")}> \\
   --summary "<operator-readable one-liner>" --runbook <path> \\
-  [--ref <url>]... [--run-id <id>] [--project-root <dir>]`;
+  [--ref <url>]... [--run-id <id>] [--project-root <dir>] \\
+  [--denominator '<json from buildIntakeDenominator()>']
+
+--denominator is REQUIRED for a "nothing-needed" run on a build-intake loop: a
+dry lane that does not say which lanes it looked in cannot be checked.`;
 
 /**
  * Translate a repeatable-flag argv into a {@link RecordAutomationRunInput}.
  *
  * Every flag takes a following value; `--ref` may repeat and accumulates into
- * `refs`. Unknown flags and value-less flags throw so a typo never silently
- * records the wrong thing.
+ * `refs`, and `--denominator` carries the swept-lane JSON into `extras`.
+ * Unknown flags and value-less flags throw so a typo never silently records the
+ * wrong thing.
  *
  * @param {readonly string[]} argv
  * @returns {RecordAutomationRunInput}
@@ -320,6 +336,8 @@ function parseAutomationRunRecordArgv(argv) {
   const single = {};
   /** @type {string[]} */
   const refs = [];
+  /** @type {Record<string, unknown>} */
+  const extras = {};
   const flags = {
     "--loop-id": "loopId",
     "--outcome": "outcome",
@@ -349,6 +367,10 @@ function parseAutomationRunRecordArgv(argv) {
       refs.push(takeValue());
       continue;
     }
+    if (flag === "--denominator") {
+      extras.denominator = parseDenominatorFlag(takeValue());
+      continue;
+    }
     const key = flags[flag];
     if (!key) {
       throw new Error(`Unknown flag "${flag}".`);
@@ -356,7 +378,21 @@ function parseAutomationRunRecordArgv(argv) {
     single[key] = takeValue();
   }
 
-  return { ...single, refs };
+  return { ...single, refs, extras };
+}
+
+/**
+ * @param {string} value
+ * @returns {unknown}
+ */
+function parseDenominatorFlag(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(
+      "--denominator must be JSON produced by buildIntakeDenominator()."
+    );
+  }
 }
 
 /**

--- a/plugins/lisa-agy/scripts/intake-blocker-reprobe.mjs
+++ b/plugins/lisa-agy/scripts/intake-blocker-reprobe.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Blocker re-probe gate for pre-work build-intake candidates.
+ *
+ * A blocker is a claim with a timestamp, not a fact. It is written once, and it
+ * decays the moment its condition goes true — a dependency lands on trunk, a
+ * CVE gets patched, a package publishes. Nothing in the old intake loop ever
+ * re-read one, so a discharged blocker held its item out of the queue forever.
+ *
+ * This module decides, per candidate, whether intake may select it. It never
+ * probes anything itself: the caller runs the probe and hands back the result,
+ * which keeps the decision auditable and testable apart from the network.
+ */
+
+import { isPreWorkLaneType } from "./intake-prework-denominator.mjs";
+
+/** Marker a writer stamps on an item a human deliberately parked. */
+export const HUMAN_GATE_MARKER = "[lisa-human-gate]";
+
+/** Default label naming a block only a human can clear. */
+export const DEFAULT_HUMAN_NEEDED_LABEL = "human-needed";
+
+/**
+ * @param {unknown} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabels(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label =>
+      typeof label === "string"
+        ? label
+        : typeof label?.name === "string"
+          ? label.name
+          : ""
+    )
+    .map(label => label.trim().toLowerCase())
+    .filter(label => label.length > 0);
+}
+
+/**
+ * @param {{ labels?: unknown, body?: unknown, humanNeededLabel?: unknown }} input
+ * @returns {boolean}
+ */
+function isHumanGated(input) {
+  const configured = String(
+    input.humanNeededLabel ?? DEFAULT_HUMAN_NEEDED_LABEL
+  )
+    .trim()
+    .toLowerCase();
+  if (
+    configured.length > 0 &&
+    normalizeLabels(input.labels).includes(configured)
+  ) {
+    return true;
+  }
+
+  return String(input.body ?? "").includes(HUMAN_GATE_MARKER);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function trimmedString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {{ discharged?: unknown, evidence?: unknown }} probe
+ * @returns {{ selectable: boolean, reason: string, evidence: string }}
+ */
+function judgeProbe(probe) {
+  const evidence = trimmedString(probe.evidence);
+
+  if (probe.discharged !== true) {
+    return {
+      selectable: false,
+      reason: "blocker-holds",
+      evidence,
+    };
+  }
+  if (evidence.length === 0) {
+    return {
+      selectable: false,
+      reason: "blocker-discharge-unevidenced",
+      evidence,
+    };
+  }
+
+  return { selectable: true, reason: "blocker-discharged", evidence };
+}
+
+/**
+ * Decide whether a pre-work item may be selected as a build candidate.
+ *
+ * Order is load-bearing. The human gate is checked before anything else, so no
+ * probe result — however conclusive — can promote an item a human parked.
+ *
+ * @param {{
+ *   laneType?: unknown
+ *   labels?: unknown
+ *   body?: unknown
+ *   humanNeededLabel?: unknown
+ *   statedBlocker?: unknown
+ *   probe?: { discharged?: unknown, evidence?: unknown } | null
+ * }} input
+ * @returns {{ selectable: boolean, reason: string, humanGated: boolean, evidence: string }}
+ */
+export function classifyPreWorkCandidate(input = {}) {
+  if (isHumanGated(input)) {
+    return {
+      selectable: false,
+      reason: "human-gate",
+      humanGated: true,
+      evidence: "",
+    };
+  }
+  if (!isPreWorkLaneType(input.laneType)) {
+    return {
+      selectable: false,
+      reason: "not-pre-work",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (trimmedString(input.statedBlocker).length === 0) {
+    return {
+      selectable: true,
+      reason: "no-blocker",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (!input.probe || typeof input.probe !== "object") {
+    return {
+      selectable: false,
+      reason: "blocker-unprobed",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+
+  return { ...judgeProbe(input.probe), humanGated: false };
+}
+
+/** Plain-English wording for each verdict, for the note left on the item. */
+const REASON_COPY = Object.freeze({
+  "human-gate": "A person parked this one on purpose, so intake left it alone.",
+  "not-pre-work": "This item is not sitting in a not-yet-started lane.",
+  "no-blocker": "No blocker was written on this item, so it is buildable.",
+  "blocker-unprobed":
+    "This item states a blocker that was not re-checked this cycle, so it stays put.",
+  "blocker-holds":
+    "The blocker was re-checked and still holds, so it stays put.",
+  "blocker-discharge-unevidenced":
+    "The blocker looked clear but no proof was recorded, so it stays put.",
+  "blocker-discharged":
+    "The blocker was re-checked and no longer applies, so this item is buildable again.",
+});
+
+/**
+ * Render the re-probe result to leave on the item, so the next cycle reads the
+ * answer instead of deriving it again.
+ *
+ * @param {{
+ *   statedBlocker?: unknown
+ *   checkedAt?: string | Date
+ * }} candidate
+ * @param {{ reason: string, evidence?: string }} verdict
+ * @returns {string}
+ */
+export function formatReprobeNote(candidate = {}, verdict) {
+  const checkedAt =
+    candidate.checkedAt instanceof Date
+      ? candidate.checkedAt.toISOString()
+      : trimmedString(candidate.checkedAt) || new Date().toISOString();
+  const lines = [
+    "**Blocker re-check**",
+    "",
+    `- What has to be true: ${trimmedString(candidate.statedBlocker) || "(none written on this item)"}`,
+    `- What we found: ${REASON_COPY[verdict.reason] ?? verdict.reason}`,
+  ];
+  const evidence = trimmedString(verdict.evidence);
+  if (evidence.length > 0) {
+    lines.push(`- Proof: ${evidence}`);
+  }
+  lines.push(`- Checked at: ${checkedAt}`);
+
+  return lines.join("\n");
+}

--- a/plugins/lisa-agy/scripts/intake-prework-denominator.mjs
+++ b/plugins/lisa-agy/scripts/intake-prework-denominator.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Pre-work denominator for build-queue intake scanners.
+ *
+ * A build-intake cycle that reports an empty lane is only as trustworthy as the
+ * set of lanes it swept. Sweeping by lane NAME (`Backlog`, `Todo`, `Ready`)
+ * omits every pre-work lane a team invented — most commonly a `Blocked` lane,
+ * which is not a distinct Linear state type at all: teams model it as
+ * `unstarted`, i.e. work that was never started. Items parked there carry a
+ * written blocker that nothing ever re-reads, so the lane reads as terminal
+ * while it is in fact a queue.
+ *
+ * This module fixes both halves: lanes are selected by TYPE, never by name, and
+ * the swept set is reported alongside the total so a wrong denominator is
+ * visible on inspection instead of silent forever.
+ */
+
+/** Lane types that hold work which has not started. Both belong to intake. */
+export const PRE_WORK_LANE_TYPES = Object.freeze(["backlog", "unstarted"]);
+
+/** Loop ids whose `nothing-needed` runs must state their denominator. */
+export const DENOMINATOR_REQUIRED_LOOP_IDS = Object.freeze(["intake-tickets"]);
+
+/**
+ * Vendor lane-type vocabularies normalized onto Linear's five-value type set.
+ * JIRA exposes the same idea as `statusCategory` (key or display name); GitHub
+ * has no type field at all, so its callers pass a type explicitly.
+ */
+const LANE_TYPE_ALIASES = Object.freeze({
+  backlog: "backlog",
+  unstarted: "unstarted",
+  started: "started",
+  completed: "completed",
+  canceled: "canceled",
+  cancelled: "canceled",
+  new: "unstarted",
+  indeterminate: "started",
+  done: "completed",
+  "to do": "unstarted",
+  "in progress": "started",
+});
+
+/**
+ * Map a vendor lane type onto the normalized vocabulary.
+ *
+ * @param {unknown} type
+ * @returns {string | null} normalized type, or null when unrecognized
+ */
+export function normalizeLaneType(type) {
+  if (typeof type !== "string") {
+    return null;
+  }
+  return LANE_TYPE_ALIASES[type.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * @param {unknown} type
+ * @returns {boolean} whether this lane holds not-yet-started work
+ */
+export function isPreWorkLaneType(type) {
+  const normalized = normalizeLaneType(type);
+  return normalized !== null && PRE_WORK_LANE_TYPES.includes(normalized);
+}
+
+/**
+ * @param {unknown} lane
+ * @returns {{ name: string, type: string | null, count: number, position: number } | null}
+ */
+function normalizeLane(lane) {
+  if (!lane || typeof lane !== "object") {
+    return null;
+  }
+  const name = String(lane.name ?? "").trim();
+  if (name.length === 0) {
+    return null;
+  }
+  const rawCount = Number(lane.count ?? 0);
+  const rawPosition = Number(lane.position ?? Number.POSITIVE_INFINITY);
+
+  return {
+    name,
+    type: normalizeLaneType(lane.type ?? lane.statusCategory),
+    count: Number.isFinite(rawCount) && rawCount > 0 ? Math.trunc(rawCount) : 0,
+    position: Number.isFinite(rawPosition)
+      ? rawPosition
+      : Number.POSITIVE_INFINITY,
+  };
+}
+
+/**
+ * @param {{ position: number, name: string }} left
+ * @param {{ position: number, name: string }} right
+ * @returns {number}
+ */
+function compareLanes(left, right) {
+  if (left.position !== right.position) {
+    return left.position - right.position;
+  }
+  return left.name.localeCompare(right.name);
+}
+
+/**
+ * Select every lane holding not-yet-started work, by type.
+ *
+ * Deliberately name-blind: a team that adds `Blocked`, `Triaged`, or `Icebox`
+ * as an `unstarted` state gets it swept without a code change, and no hardcoded
+ * roster can fall behind the board.
+ *
+ * @param {readonly unknown[]} lanes
+ * @returns {readonly {name: string, type: string, count: number, position: number}[]}
+ */
+export function selectPreWorkLanes(lanes) {
+  return (Array.isArray(lanes) ? lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null && isPreWorkLaneType(lane.type))
+    .sort(compareLanes);
+}
+
+/**
+ * Build the denominator a scanner must report with its verdict.
+ *
+ * `totalOpen` is the count of open items on the queue, independent of lanes —
+ * supplying it is what makes an omitted lane arithmetically visible.
+ *
+ * @param {{ lanes?: readonly unknown[], totalOpen?: number }} input
+ * @returns {{
+ *   swept: readonly {name: string, type: string, count: number}[]
+ *   omitted: readonly {name: string, type: string | null, count: number}[]
+ *   sweptCount: number
+ *   totalOpen: number
+ *   unsweptCount: number
+ * }}
+ */
+export function buildIntakeDenominator(input = {}) {
+  const normalized = (Array.isArray(input.lanes) ? input.lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null)
+    .sort(compareLanes);
+  const swept = normalized.filter(lane => isPreWorkLaneType(lane.type));
+  const omitted = normalized.filter(lane => !isPreWorkLaneType(lane.type));
+  const sweptCount = swept.reduce((total, lane) => total + lane.count, 0);
+  const laneTotal = normalized.reduce((total, lane) => total + lane.count, 0);
+  const rawTotalOpen = Number(input.totalOpen);
+  const totalOpen =
+    Number.isFinite(rawTotalOpen) && rawTotalOpen >= 0
+      ? Math.trunc(rawTotalOpen)
+      : laneTotal;
+
+  return {
+    swept: swept.map(({ name, type, count }) => ({ name, type, count })),
+    omitted: omitted.map(({ name, type, count }) => ({ name, type, count })),
+    sweptCount,
+    totalOpen,
+    unsweptCount: Math.max(totalOpen - sweptCount, 0),
+  };
+}
+
+/**
+ * Render the denominator for a non-technical operator.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @returns {string}
+ */
+export function formatIntakeDenominator(denominator) {
+  const lanes = denominator?.swept ?? [];
+  const listed =
+    lanes.length > 0
+      ? lanes.map(lane => `${lane.name} (${lane.count})`).join(", ")
+      : "no pre-work lanes found";
+
+  return `Looked in every lane holding work that has not started — ${listed} — ${denominator.sweptCount} items checked out of ${denominator.totalOpen} still open.`;
+}
+
+/**
+ * Render the full operator-readable one-liner for a dry build lane.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @param {{ queue?: string }} [context]
+ * @returns {string}
+ */
+export function summarizeDryLane(denominator, context = {}) {
+  const queue =
+    typeof context.queue === "string" && context.queue.trim().length > 0
+      ? ` on ${context.queue.trim()}`
+      : "";
+
+  return `Nothing ready to build${queue}. ${formatIntakeDenominator(denominator)}`;
+}
+
+/**
+ * @param {unknown} loopId
+ * @param {unknown} outcome
+ * @returns {boolean} whether this run must carry a denominator
+ */
+export function requiresDenominator(loopId, outcome) {
+  return (
+    outcome === "nothing-needed" &&
+    DENOMINATOR_REQUIRED_LOOP_IDS.includes(String(loopId ?? "").trim())
+  );
+}
+
+/**
+ * @param {unknown} denominator
+ * @returns {string | null} the reason it is unusable, or null when valid
+ */
+function findDenominatorDefect(denominator) {
+  if (!denominator || typeof denominator !== "object") {
+    return "no denominator was supplied";
+  }
+  if (!Array.isArray(denominator.swept) || denominator.swept.length === 0) {
+    return "it names no swept lanes";
+  }
+  if (!Number.isInteger(denominator.sweptCount)) {
+    return "its swept count is not a whole number";
+  }
+  if (!Number.isInteger(denominator.totalOpen)) {
+    return "its open-item total is not a whole number";
+  }
+  if (denominator.sweptCount > denominator.totalOpen) {
+    return "it claims to have swept more items than are open";
+  }
+  return null;
+}
+
+/**
+ * Refuse to record a dry build lane that does not say what it looked at.
+ *
+ * Thirty-one consecutive cycles reported an empty lane against a queue holding
+ * unswept pre-work rows. Every record was honest and every conclusion was
+ * false, because none of them stated a denominator. This turns that silent
+ * wrong answer into a loud one.
+ *
+ * @param {{ loopId?: unknown, outcome?: unknown, denominator?: unknown }} input
+ * @throws {Error} when a denominator is required and missing or malformed
+ */
+export function assertDenominatorReported(input = {}) {
+  if (!requiresDenominator(input.loopId, input.outcome)) {
+    return;
+  }
+  const defect = findDenominatorDefect(input.denominator);
+  if (defect === null) {
+    return;
+  }
+
+  throw new Error(
+    `A "nothing-needed" run for loop "${String(input.loopId).trim()}" must state the lanes it swept, and ${defect}. ` +
+      `Pass a denominator built by buildIntakeDenominator() so an omitted lane is visible instead of silent.`
+  );
+}

--- a/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-github-build-intake/SKILL.md
@@ -110,7 +110,7 @@ The only legitimate reasons to stop early:
 
 - Missing repo or required configuration. Surface the missing value and exit.
 - Label namespace not adopted (no issue carries any of `$READY` / `$CLAIMED` / `$DONE`). Surface a label-convention error and exit (this is setup, not a normal idle cycle — see "Adoption" at the bottom).
-- Empty ready set. Exit cleanly with `"No GitHub issues labeled $READY in <org>/<repo>. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -166,7 +166,57 @@ gh label list --repo <org>/<repo> --json name \
       '[.[] | .name | select(. == $r or . == $c or (. as $n | $d | index($n)))] | length'
 ```
 
-If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
+If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit.
+
+#### 2a. Sweep every pre-work lane, and state the denominator
+
+GitHub Issues has no state-type field, so labels are the only lane available here — a constraint of
+GitHub's data model, not a preference (see "Why labels" above). That makes the omission risk
+*higher*, not lower: there is no `type` to fall back on, so the pre-work set must be derived from
+**configured roles**, never from a hardcoded roster of label names. The pre-work lanes are:
+
+- the configured `$READY` label — the human-flipped lane, worked first;
+- the configured `$BLOCKED` label (`github.labels.build.blocked`) — items that were *never started*,
+  each carrying a written blocker that nothing re-read until Phase 2.5;
+- open issues carrying **no** build role label — which this scanner must see anyway in order to
+  determine and stamp their repo.
+
+Count each lane and the repo's **total open** count (`gh issue list --state open --limit 1000 --json
+number | jq length`), then build the denominator with the shared helper — GitHub callers pass the
+lane type explicitly, since there is none to read:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "$READY", type: "unstarted", count: <n>},
+                                 {name: "$BLOCKED", type: "unstarted", count: <n>},
+                                 {name: "(no role label)", type: "backlog", count: <n>},
+                                 {name: "$CLAIMED", type: "started", count: <n>}, …],
+                         totalOpen: <open issue count> })
+summarizeDryLane(denominator, { queue: "<org>/<repo>" })
+```
+
+Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all. If
+nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a bare
+"nothing to do". The run recorder rejects a dry build-intake run that does not name what it swept
+(see `automation-runbook-contract`).
+
+#### 2a.1 Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each `$BLOCKED` candidate:
+
+1. **Human gate first, and it is absolute.** An issue carrying the configured human-needed label
+   (`github.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in
+   its body is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from `scripts/intake-blocker-reprobe.mjs`. A
+   discharge with no recorded evidence is not a discharge, and neither is a candidate nothing
+   probed this cycle — the helper refuses both.
+4. **Record the result on the issue either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, relabel `$BLOCKED → $READY` with the discharging evidence in the same
+   comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 #### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
 
@@ -251,7 +301,7 @@ GitHub Issues live in one repo by definition, so the scanned repo's issues are u
    - **Container visibility is allowed.** A multi-repo Epic / Story / Spike may legitimately carry multiple `repo:<name>` labels for operator visibility. Do not split or claim it here; leave the repo markers intact and fall through to the leaf-only gate, which repairs the stale build-ready label instead of dispatching the container.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (repair containers)
 

--- a/plugins/lisa-agy/skills/lisa-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-intake/SKILL.md
@@ -126,7 +126,7 @@ matches the mode this cycle ran in: **`intake-prd`** (PRD-side dispatch) or **`i
 
 | This cycle's exit path | Run outcome |
 |---|---|
-| Empty `Ready` set — the idle case (step 3), nothing to claim | `nothing-needed` |
+| Empty pre-work set — the idle case (step 3), nothing to claim. **Must state its denominator** (see below) | `nothing-needed` |
 | A PRD routed to `Blocked` (clarifying questions) or `Ticketed`; a build ticket claimed and dispatched | `candidate-proposed` |
 | A build cycle that shipped and verified (merged PR + evidence), or a shipped PRD moved to `verified` | `change-proved` |
 | A protected deployment (or other autonomy boundary the lifecycle hits) waiting on a human approval | `approval-requested` |
@@ -149,6 +149,22 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
   --loop-id intake-tickets --outcome candidate-proposed \
   --summary "Routed PRD #1810 to Blocked with clarifying questions; the run succeeded." \
   --runbook .lisa/automations/intake-tickets.runbook.md [--ref <item-url>]...
+```
+
+**A dry build lane must say what it looked in.** A `nothing-needed` run on `intake-tickets`
+additionally passes `--denominator` — the JSON from `buildIntakeDenominator()` in
+`scripts/intake-prework-denominator.mjs` — and the recorder **refuses the row without it**. This is
+not decoration: 31 consecutive cycles reported a dry lane against a queue holding 61 unswept
+pre-work rows, and every one of those records was honest. A missing row is noisy on inspection; a
+wrong denominator is silent forever and looks exactly like a healthy dry queue. Stating the swept
+set is what turns the silent wrong answer into an inspectable one (#2657).
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
+  --loop-id intake-tickets --outcome nothing-needed \
+  --summary "Nothing ready to build on team ENG. Looked in every lane holding work that has not started — Backlog (20), Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open." \
+  --denominator "$DENOMINATOR_JSON" \
+  --runbook .lisa/automations/intake-tickets.runbook.md
 ```
 
 If `${CLAUDE_PLUGIN_ROOT}` is unset, resolve the plugin scripts directory directly — the built copy

--- a/plugins/lisa-agy/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-jira-build-intake/SKILL.md
@@ -85,7 +85,7 @@ The only legitimate reasons to stop early:
 
 - Missing project key / JQL or required configuration. Surface the missing value and exit.
 - Workflow misconfigured (pre-flight check finds `$CLAIMED` or `$DONE` not reachable, or `$READY` status absent). Surface and exit.
-- Empty ready set. Exit cleanly with `"No tickets with Status=$READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -130,11 +130,59 @@ JQL="${BASE_JQL} ORDER BY priority DESC, created ASC"
 
 4. Confirm the configured Atlassian site by invoking `lisa-atlassian-access` `operation: list-sites` (it enforces connection match against `.lisa.config.json`).
 
-### Phase 2 — Find ready tickets
+### Phase 2 — Sweep every pre-work status by CATEGORY
 
-Invoke `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), labels, components.
+**Sweep by `statusCategory`, never by a roster of status names.** JIRA groups statuses into three
+categories — `To Do` (`new`), `In Progress` (`indeterminate`), `Done` (`done`) — and a `Blocked`
+status is not a fourth category: a project that wants one models it under **`To Do`**, i.e. work
+that was never started. Keying the candidate set on status *names* therefore omits every pre-work
+lane a project invented, and the scanner reports an empty queue over a full one. The same defect on
+the Linear side produced 31 consecutive false "dry lane" cycles (#2657).
 
-If empty, report `"No tickets with Status=$READY. Nothing to do."` and exit. This is the common idle case.
+1. Run the ready query first: `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. This
+   is the human-flipped lane and it is worked first.
+2. Then sweep the rest of pre-work with the same base JQL, swapping the status clause for
+   `statusCategory = "To Do"`, and read the **total open** count (`statusCategory != Done`). The
+   open total is what makes an omitted lane arithmetically visible.
+3. Page to exhaustion — a single unpaged `search-issues` call is not a count.
+
+Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), status (with
+its category), labels, components.
+
+Build the denominator with the shared helper, which owns the pre-work vocabulary so no two
+scanners can disagree about what counts:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "<status>", type: "<statusCategory>", count: <rows>}, …],
+                         totalOpen: <statusCategory != Done count> })
+summarizeDryLane(denominator, { queue: "<project key>" })
+```
+
+The helper accepts JIRA's category vocabulary directly (`new` / `To Do` normalize to pre-work).
+
+**Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at
+all.** If nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a
+bare "nothing to do". The run recorder rejects a dry build-intake run that does not name what it
+swept (see `automation-runbook-contract`).
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each pre-work candidate outside `$READY`:
+
+1. **Human gate first, and it is absolute.** A ticket carrying the configured human-needed label
+   (`jira.labels.human_needed`, default `Human Needed`) or a `[lisa-human-gate]` marker in its
+   description is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from
+   `scripts/intake-blocker-reprobe.mjs`. A discharge with no recorded evidence is not a discharge,
+   and neither is a candidate nothing probed this cycle — the helper refuses both.
+4. **Record the result on the ticket either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, transition the ticket to `$READY` with the discharging evidence in the
+   same comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 ### Phase 3 — Process the first eligible ready ticket
 
@@ -149,7 +197,7 @@ A JIRA project can oversee multiple repos (`frontend` / `backend` / `infrastruct
    - **Unlabeled** → determine the target repo(s) from the ticket (description, AC, technical approach) confirmed against the code surfaces, then **stamp** `repo:<name>` via `lisa-atlassian-access` `operation: write-ticket` (add the label / set the component) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure to break it into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready tickets for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa-agy/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-linear-build-intake/SKILL.md
@@ -99,7 +99,7 @@ The only legitimate reasons to stop early:
 
 - Missing team key or required configuration. Surface and exit.
 - Workflow states not yet adopted (the `ready` state does not exist on the team). Surface and exit with an Adoption hint pointing at `/lisa:setup:linear`.
-- Empty ready set. Exit cleanly with `"No Linear Issues in state $READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -112,7 +112,7 @@ ready → claimed → review → done(env-keyed) (downstream)
 
 (Defaults: `Ready` / `In Progress` / `In Review` / `On Dev`/`On Stg`/`Done`.)
 
-This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done`, `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`), or `$BLOCKED` (owned by the pre-flight gate).
+This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done` or `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`). It never *sets* `$BLOCKED` either — that stays owned by the pre-flight gate — but Phase 2.5 does move an Issue **out** of a pre-work blocked lane back to `$READY` when it re-probes the Issue's own stated discharge condition and finds it no longer holds, recording the discharging evidence on the Issue.
 
 **Pre-flight check**: at start of each cycle, confirm `$READY`, `$CLAIMED`, and the relevant `$DONE` variants exist on the team via `lisa-linear-access operation: list-workflow-states`. If `$READY` is missing, stop and report adoption needed. **Unlike labels, a missing state cannot be created on demand here** — a workflow state is team configuration with a `type` and a board position, and guessing either would put an Issue somewhere a human did not sanction. Any missing state is a setup defect: report it, name the role and the expected state, and point at `/lisa:setup:linear`.
 
@@ -125,15 +125,56 @@ This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $D
    - Literal `linear` → fall back to `linear.teamKey` from config.
 2. Resolve team ID via `lisa-linear-access operation: list-teams({query: <teamKey>})`.
 
-### Phase 2 — Find ready Issues
+### Phase 2 — Sweep every pre-work lane by state TYPE
 
-Query: `lisa-linear-access operation: list-issues({team: <teamId>, state: "$READY"})`.
+**Sweep by `type`, never by a roster of state names.** Linear state types are `backlog | unstarted | started | completed | canceled`, and there is no `blocked` type — a team that wants a `Blocked` lane models it as **`unstarted`**, i.e. work that was *never started*. Selecting candidates from a hardcoded `Backlog / Todo / Ready` name list therefore omits an entire pre-work lane and reports an empty queue over a full one. Measured on one team: the name sweep saw **39 of 343 open rows**; the type sweep sees **100**, and the 61-row difference produced 31 consecutive false "dry lane" cycles (#2657).
 
-Capture each Issue's: identifier, title, type label, priority, assignee, project, state, labels, description summary.
+1. List the team's workflow states via `lisa-linear-access operation: list-workflow-states`.
+2. Keep every state whose `type` is `backlog` or `unstarted` — that is the pre-work set. `$READY` is one member of it, not the whole of it.
+3. Query each pre-work state: `lisa-linear-access operation: list-issues({team: <teamId>, state: "<state>"})`, paging to `hasNextPage=false`. Linear's GraphQL complexity ceiling silently truncates at `first: 250`, so a single unpaged call is not a count.
+4. Also read the **total open** count for the team (every state whose `type` is not `completed` / `canceled`). This number is what makes an omitted lane arithmetically visible.
+
+Capture each Issue's: identifier, title, type label, priority, assignee, project, state (with its `type`), labels, description summary.
+
+Build the denominator with the shared helper, which owns the type vocabulary so no two scanners can disagree about what counts as pre-work:
+
+```bash
+node -e '
+import("'"${CLAUDE_PLUGIN_ROOT:-plugins/src/base}"'/scripts/intake-prework-denominator.mjs").then(m => {
+  const d = m.buildIntakeDenominator({ lanes: JSON.parse(process.argv[1]), totalOpen: Number(process.argv[2]) });
+  console.log(JSON.stringify(d));
+  console.log(m.summarizeDryLane(d, { queue: process.argv[3] }));
+});' "$LANES_JSON" "$TOTAL_OPEN" "team $TEAM_KEY"
+```
+
+`$LANES_JSON` is `[{"name":"<state>","type":"<state.type>","position":<state.position>,"count":<open rows>}, …]` for **every** state on the team, pre-work and not — the helper does the selecting.
+
+**Candidate order.** Work `$READY` first (it is the human-flipped signal), then the remaining pre-work lanes oldest-first. Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all.
 
 > **No query-time repo pre-filter here (by design).** Unlike `lisa-jira-build-intake`, which narrows its JQL with `AND (labels = "repo:<current>" OR labels IS EMPTY)` (the query-time arm of `repo-scope-split`), the Linear `list_issues` label filter is an AND-of-labels and cannot express "current-repo **or** unlabeled" in one query. Adding `repo:<current>` to this query would strand unlabeled Issues the determine + stamp path must see. So the Linear scanner keeps this query broad and relies on the per-candidate 3a.0 gate below for repo scoping. (The `state` filter above is orthogonal to that — it narrows the lifecycle lane, not the repo, and is a single-valued equality so it has none of the AND-of-labels problem.)
 
-If empty, report `"No Linear Issues in state $READY. Nothing to do."` and exit. Common idle case.
+If every pre-work lane is empty, or nothing survives Phase 2.5, exit on the **denominator-stated** summary from `summarizeDryLane` — never a bare "nothing to do". See "Run outcome" below; the run recorder rejects a dry build-intake run that does not name what it swept.
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact**. It is written once and goes stale the moment its condition comes true — a dependency lands on trunk, an advisory gets patched, a package publishes. Nothing re-read one before this phase, so a discharged blocker held its Issue out of the queue indefinitely. Measured: one Issue's stated condition went true ~15 hours before anything noticed.
+
+For each pre-work candidate that is **not** in `$READY`:
+
+1. **Human gate first, and it is absolute.** An Issue carrying the configured human-needed label (`linear.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in its description is **never** auto-selected, whatever any probe says. Skip it and move on.
+2. **Extract the stated discharge condition** from the description or the most recent blocking comment — the sentence naming what has to become true.
+3. **Probe it.** Machine-testable conditions are the ones that rot fastest and are cheapest to check: a version on trunk (`git show origin/<trunk>:<manifest>`), a published package, a run history (`gh run list`), an advisory's patched status. A condition that is a human decision is not machine-testable — leave it and move on.
+4. **Classify with the shared helper** so the ordering and the evidence requirement cannot drift per vendor:
+
+```text
+classifyPreWorkCandidate({ laneType, labels, body, humanNeededLabel, statedBlocker, probe })
+  → { selectable, reason, humanGated, evidence }
+```
+
+   A discharge with **no recorded evidence is not a discharge** — the helper refuses it. So is a candidate nothing probed this cycle.
+
+5. **Record the result on the Issue either way**, via `lisa-linear-access operation: save-comment` using `formatReprobeNote(...)`, so the next cycle reads the answer rather than re-deriving it. Keep it idempotent — skip the post when an identical note already exists.
+6. **On `selectable: true`**, move the Issue to `$READY` (recording the discharging evidence in the same comment) and treat it as an ordinary candidate from Phase 3 onward. On anything else, leave the Issue exactly where it is.
 
 ### Phase 3 — Process the first eligible ready Issue
 
@@ -148,7 +189,7 @@ A Linear team can oversee multiple repos (`frontend` / `backend` / `infrastructu
    - **Unlabeled** → determine the target repo(s) from the Issue + code surfaces, then **stamp** `repo:<name>` via `lisa-linear-access operation: save-issue` (resolve/create the label via `list_issue_labels`/`create_issue_label`) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready Issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa-agy/skills/lisa-tracker-build-intake/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-tracker-build-intake/SKILL.md
@@ -42,6 +42,30 @@ This is the claim-time arm of the rule. Its siblings are the write-time labeling
 
 The shim never needs to inspect the item itself — it forwards `$ARGUMENTS` verbatim and the resolved vendor scanner runs its Phase 3a gate before any claim.
 
+## Pre-work denominator contract (forwarded to every vendor)
+
+Also part of the build-intake API, and the reason a dry queue can be believed. Two obligations,
+uniform across `jira`, `github`, and `linear`:
+
+1. **Sweep every pre-work lane by its machine-readable category, never by a roster of lane names.**
+   No tracker has a `blocked` category: Linear models a `Blocked` state as `unstarted`, JIRA models
+   a `Blocked` status under `To Do`, and GitHub has no category at all, so its lanes come from
+   configured roles. In every case a `Blocked` lane is *pre-work* — items that were never started,
+   each carrying a written blocker. Keying selection on names omits it silently.
+2. **A `nothing-needed` run states its denominator** — which lanes were swept, how many rows each
+   held, and the total open. This is enforced, not requested: `automation-run-record.mjs` refuses a
+   `nothing-needed` row for `intake-tickets` without a `--denominator`.
+
+Shared helpers own both, so the vocabulary cannot drift per vendor:
+`scripts/intake-prework-denominator.mjs` (`buildIntakeDenominator`, `summarizeDryLane`) and
+`scripts/intake-blocker-reprobe.mjs` (`classifyPreWorkCandidate`, `formatReprobeNote`). The
+blocker re-probe carries an absolute human gate: an item carrying the configured human-needed label
+or a `[lisa-human-gate]` marker is never auto-selected, whatever a probe returns.
+
+Measured: sweeping one team by lane name saw 39 of 343 open rows; by category it sees 100. The
+61-row gap produced 31 consecutive false "dry lane" cycles, every record honest and every
+conclusion wrong (#2657).
+
 ## Repo-scope claim contract (forwarded to every vendor)
 
 Equally part of the build-intake API, and forwarded identically: when the tracker oversees multiple repos, each vendor scanner claims only tickets for the repo it is running in. Per the `repo-scope-split` rule's "Claim-time repo scoping" section, before the leaf-only gate each scanner (Phase 3a.0) resolves the current repo (`config-resolution` "Repo scoping": `repo` → `github.repo` → git remote basename), then for each ready candidate: skips a ticket labeled `repo:<other>`, determines + stamps `repo:<name>` on an unlabeled one, splits a multi-repo leaf into single-repo build-ready siblings, and claims only a single-repo leaf for the current repo. This shim does not re-implement the gate — it relies on the vendor scanner's Phase 3a.0 — but the contract is uniform across `jira`, `github`, and `linear` so behavior never drifts by tracker. It is the claim-time complement to the write-time S10 scope gate (`lisa-tracker-validate`) and `task-decomposition` step 1.5; all cite `repo-scope-split`.

--- a/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/eager/automation-runbook-contract.md
@@ -48,6 +48,8 @@ Exactly one per run:
 Health and operator action are **orthogonal** — a healthy run can still need an answer:
 
 - `nothing-needed` — the loop ran and found nothing to act on. **Healthy.** Operator action: none.
+  A queue scanner's `nothing-needed` summary must name the lanes it swept and the total open — a dry
+  queue and a wrong denominator are otherwise indistinguishable. See the reference body.
 - `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation). **Healthy.** Operator
   action: review the proposed item and flip it ready when you want it built.
 - `change-proved` — the loop made a change and proved it with evidence. **Healthy.** Operator

--- a/plugins/lisa-copilot/rules/reference/automation-runbook-contract.md
+++ b/plugins/lisa-copilot/rules/reference/automation-runbook-contract.md
@@ -120,6 +120,25 @@ recovery-required   Lost access to the tracker; filed #1812 with the one decisio
 policy-obsolete     No work has reached this queue in 30 days; proposed teardown in #1813.
 ```
 
+### `nothing-needed` states its denominator
+
+A queue-scanning loop that reports nothing is only as trustworthy as the set it looked at, and a
+summary of the form "scanned N items" hides the one thing worth checking: **which lanes N came
+from.** So a `nothing-needed` summary from a queue scanner names the lanes it swept, the count in
+each, and the total open — `Looked in every lane holding work that has not started — Backlog (20),
+Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open.`
+
+This is a measured requirement, not a style preference. One build lane reported 31 consecutive dry
+cycles over a queue holding 61 unswept rows, at least one of them buildable for ~15 hours. Every
+one of the 31 records was honest and every conclusion was false, because the scanner never said
+what its denominator was. **A missing run record is noisy on inspection; a wrong denominator is
+silent forever and looks exactly like a healthy dry queue.** Stating the swept set is what makes
+the second failure mode visible at all.
+
+The build-intake loop enforces this rather than requesting it: `automation-run-record.mjs` refuses
+a `nothing-needed` row for `intake-tickets` unless the call carries a `--denominator` built by
+`scripts/intake-prework-denominator.mjs`.
+
 **No silent exit.** Every run posts its outcome and its one-line summary before stopping —
 including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
 there is no silent exit for an operator to misread as health. A run that ends without a

--- a/plugins/lisa-copilot/scripts/automation-run-record.mjs
+++ b/plugins/lisa-copilot/scripts/automation-run-record.mjs
@@ -11,6 +11,8 @@ import path from "node:path";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { assertDenominatorReported } from "./intake-prework-denominator.mjs";
+
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
   "candidate-proposed",
@@ -55,6 +57,15 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
  */
 export async function recordAutomationRun(input) {
+  // Write path only. Stored rows are re-validated on read through
+  // `validateStoredRecord`, and a history written before this contract existed
+  // must stay readable — so the denominator gate lives here, where a NEW row is
+  // minted, and never on the read path.
+  assertDenominatorReported({
+    loopId: input.loopId,
+    outcome: input.outcome,
+    denominator: input.extras?.denominator,
+  });
   const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
   const maxEntries =
     input.maxEntries ??
@@ -303,14 +314,19 @@ async function writeJsonlAtomically(filePath, records) {
 const CLI_USAGE = `Usage: node automation-run-record.mjs \\
   --loop-id <slug> --outcome <${AUTOMATION_RUN_OUTCOMES.join("|")}> \\
   --summary "<operator-readable one-liner>" --runbook <path> \\
-  [--ref <url>]... [--run-id <id>] [--project-root <dir>]`;
+  [--ref <url>]... [--run-id <id>] [--project-root <dir>] \\
+  [--denominator '<json from buildIntakeDenominator()>']
+
+--denominator is REQUIRED for a "nothing-needed" run on a build-intake loop: a
+dry lane that does not say which lanes it looked in cannot be checked.`;
 
 /**
  * Translate a repeatable-flag argv into a {@link RecordAutomationRunInput}.
  *
  * Every flag takes a following value; `--ref` may repeat and accumulates into
- * `refs`. Unknown flags and value-less flags throw so a typo never silently
- * records the wrong thing.
+ * `refs`, and `--denominator` carries the swept-lane JSON into `extras`.
+ * Unknown flags and value-less flags throw so a typo never silently records the
+ * wrong thing.
  *
  * @param {readonly string[]} argv
  * @returns {RecordAutomationRunInput}
@@ -320,6 +336,8 @@ function parseAutomationRunRecordArgv(argv) {
   const single = {};
   /** @type {string[]} */
   const refs = [];
+  /** @type {Record<string, unknown>} */
+  const extras = {};
   const flags = {
     "--loop-id": "loopId",
     "--outcome": "outcome",
@@ -349,6 +367,10 @@ function parseAutomationRunRecordArgv(argv) {
       refs.push(takeValue());
       continue;
     }
+    if (flag === "--denominator") {
+      extras.denominator = parseDenominatorFlag(takeValue());
+      continue;
+    }
     const key = flags[flag];
     if (!key) {
       throw new Error(`Unknown flag "${flag}".`);
@@ -356,7 +378,21 @@ function parseAutomationRunRecordArgv(argv) {
     single[key] = takeValue();
   }
 
-  return { ...single, refs };
+  return { ...single, refs, extras };
+}
+
+/**
+ * @param {string} value
+ * @returns {unknown}
+ */
+function parseDenominatorFlag(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(
+      "--denominator must be JSON produced by buildIntakeDenominator()."
+    );
+  }
 }
 
 /**

--- a/plugins/lisa-copilot/scripts/intake-blocker-reprobe.mjs
+++ b/plugins/lisa-copilot/scripts/intake-blocker-reprobe.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Blocker re-probe gate for pre-work build-intake candidates.
+ *
+ * A blocker is a claim with a timestamp, not a fact. It is written once, and it
+ * decays the moment its condition goes true — a dependency lands on trunk, a
+ * CVE gets patched, a package publishes. Nothing in the old intake loop ever
+ * re-read one, so a discharged blocker held its item out of the queue forever.
+ *
+ * This module decides, per candidate, whether intake may select it. It never
+ * probes anything itself: the caller runs the probe and hands back the result,
+ * which keeps the decision auditable and testable apart from the network.
+ */
+
+import { isPreWorkLaneType } from "./intake-prework-denominator.mjs";
+
+/** Marker a writer stamps on an item a human deliberately parked. */
+export const HUMAN_GATE_MARKER = "[lisa-human-gate]";
+
+/** Default label naming a block only a human can clear. */
+export const DEFAULT_HUMAN_NEEDED_LABEL = "human-needed";
+
+/**
+ * @param {unknown} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabels(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label =>
+      typeof label === "string"
+        ? label
+        : typeof label?.name === "string"
+          ? label.name
+          : ""
+    )
+    .map(label => label.trim().toLowerCase())
+    .filter(label => label.length > 0);
+}
+
+/**
+ * @param {{ labels?: unknown, body?: unknown, humanNeededLabel?: unknown }} input
+ * @returns {boolean}
+ */
+function isHumanGated(input) {
+  const configured = String(
+    input.humanNeededLabel ?? DEFAULT_HUMAN_NEEDED_LABEL
+  )
+    .trim()
+    .toLowerCase();
+  if (
+    configured.length > 0 &&
+    normalizeLabels(input.labels).includes(configured)
+  ) {
+    return true;
+  }
+
+  return String(input.body ?? "").includes(HUMAN_GATE_MARKER);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function trimmedString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {{ discharged?: unknown, evidence?: unknown }} probe
+ * @returns {{ selectable: boolean, reason: string, evidence: string }}
+ */
+function judgeProbe(probe) {
+  const evidence = trimmedString(probe.evidence);
+
+  if (probe.discharged !== true) {
+    return {
+      selectable: false,
+      reason: "blocker-holds",
+      evidence,
+    };
+  }
+  if (evidence.length === 0) {
+    return {
+      selectable: false,
+      reason: "blocker-discharge-unevidenced",
+      evidence,
+    };
+  }
+
+  return { selectable: true, reason: "blocker-discharged", evidence };
+}
+
+/**
+ * Decide whether a pre-work item may be selected as a build candidate.
+ *
+ * Order is load-bearing. The human gate is checked before anything else, so no
+ * probe result — however conclusive — can promote an item a human parked.
+ *
+ * @param {{
+ *   laneType?: unknown
+ *   labels?: unknown
+ *   body?: unknown
+ *   humanNeededLabel?: unknown
+ *   statedBlocker?: unknown
+ *   probe?: { discharged?: unknown, evidence?: unknown } | null
+ * }} input
+ * @returns {{ selectable: boolean, reason: string, humanGated: boolean, evidence: string }}
+ */
+export function classifyPreWorkCandidate(input = {}) {
+  if (isHumanGated(input)) {
+    return {
+      selectable: false,
+      reason: "human-gate",
+      humanGated: true,
+      evidence: "",
+    };
+  }
+  if (!isPreWorkLaneType(input.laneType)) {
+    return {
+      selectable: false,
+      reason: "not-pre-work",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (trimmedString(input.statedBlocker).length === 0) {
+    return {
+      selectable: true,
+      reason: "no-blocker",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (!input.probe || typeof input.probe !== "object") {
+    return {
+      selectable: false,
+      reason: "blocker-unprobed",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+
+  return { ...judgeProbe(input.probe), humanGated: false };
+}
+
+/** Plain-English wording for each verdict, for the note left on the item. */
+const REASON_COPY = Object.freeze({
+  "human-gate": "A person parked this one on purpose, so intake left it alone.",
+  "not-pre-work": "This item is not sitting in a not-yet-started lane.",
+  "no-blocker": "No blocker was written on this item, so it is buildable.",
+  "blocker-unprobed":
+    "This item states a blocker that was not re-checked this cycle, so it stays put.",
+  "blocker-holds":
+    "The blocker was re-checked and still holds, so it stays put.",
+  "blocker-discharge-unevidenced":
+    "The blocker looked clear but no proof was recorded, so it stays put.",
+  "blocker-discharged":
+    "The blocker was re-checked and no longer applies, so this item is buildable again.",
+});
+
+/**
+ * Render the re-probe result to leave on the item, so the next cycle reads the
+ * answer instead of deriving it again.
+ *
+ * @param {{
+ *   statedBlocker?: unknown
+ *   checkedAt?: string | Date
+ * }} candidate
+ * @param {{ reason: string, evidence?: string }} verdict
+ * @returns {string}
+ */
+export function formatReprobeNote(candidate = {}, verdict) {
+  const checkedAt =
+    candidate.checkedAt instanceof Date
+      ? candidate.checkedAt.toISOString()
+      : trimmedString(candidate.checkedAt) || new Date().toISOString();
+  const lines = [
+    "**Blocker re-check**",
+    "",
+    `- What has to be true: ${trimmedString(candidate.statedBlocker) || "(none written on this item)"}`,
+    `- What we found: ${REASON_COPY[verdict.reason] ?? verdict.reason}`,
+  ];
+  const evidence = trimmedString(verdict.evidence);
+  if (evidence.length > 0) {
+    lines.push(`- Proof: ${evidence}`);
+  }
+  lines.push(`- Checked at: ${checkedAt}`);
+
+  return lines.join("\n");
+}

--- a/plugins/lisa-copilot/scripts/intake-prework-denominator.mjs
+++ b/plugins/lisa-copilot/scripts/intake-prework-denominator.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Pre-work denominator for build-queue intake scanners.
+ *
+ * A build-intake cycle that reports an empty lane is only as trustworthy as the
+ * set of lanes it swept. Sweeping by lane NAME (`Backlog`, `Todo`, `Ready`)
+ * omits every pre-work lane a team invented — most commonly a `Blocked` lane,
+ * which is not a distinct Linear state type at all: teams model it as
+ * `unstarted`, i.e. work that was never started. Items parked there carry a
+ * written blocker that nothing ever re-reads, so the lane reads as terminal
+ * while it is in fact a queue.
+ *
+ * This module fixes both halves: lanes are selected by TYPE, never by name, and
+ * the swept set is reported alongside the total so a wrong denominator is
+ * visible on inspection instead of silent forever.
+ */
+
+/** Lane types that hold work which has not started. Both belong to intake. */
+export const PRE_WORK_LANE_TYPES = Object.freeze(["backlog", "unstarted"]);
+
+/** Loop ids whose `nothing-needed` runs must state their denominator. */
+export const DENOMINATOR_REQUIRED_LOOP_IDS = Object.freeze(["intake-tickets"]);
+
+/**
+ * Vendor lane-type vocabularies normalized onto Linear's five-value type set.
+ * JIRA exposes the same idea as `statusCategory` (key or display name); GitHub
+ * has no type field at all, so its callers pass a type explicitly.
+ */
+const LANE_TYPE_ALIASES = Object.freeze({
+  backlog: "backlog",
+  unstarted: "unstarted",
+  started: "started",
+  completed: "completed",
+  canceled: "canceled",
+  cancelled: "canceled",
+  new: "unstarted",
+  indeterminate: "started",
+  done: "completed",
+  "to do": "unstarted",
+  "in progress": "started",
+});
+
+/**
+ * Map a vendor lane type onto the normalized vocabulary.
+ *
+ * @param {unknown} type
+ * @returns {string | null} normalized type, or null when unrecognized
+ */
+export function normalizeLaneType(type) {
+  if (typeof type !== "string") {
+    return null;
+  }
+  return LANE_TYPE_ALIASES[type.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * @param {unknown} type
+ * @returns {boolean} whether this lane holds not-yet-started work
+ */
+export function isPreWorkLaneType(type) {
+  const normalized = normalizeLaneType(type);
+  return normalized !== null && PRE_WORK_LANE_TYPES.includes(normalized);
+}
+
+/**
+ * @param {unknown} lane
+ * @returns {{ name: string, type: string | null, count: number, position: number } | null}
+ */
+function normalizeLane(lane) {
+  if (!lane || typeof lane !== "object") {
+    return null;
+  }
+  const name = String(lane.name ?? "").trim();
+  if (name.length === 0) {
+    return null;
+  }
+  const rawCount = Number(lane.count ?? 0);
+  const rawPosition = Number(lane.position ?? Number.POSITIVE_INFINITY);
+
+  return {
+    name,
+    type: normalizeLaneType(lane.type ?? lane.statusCategory),
+    count: Number.isFinite(rawCount) && rawCount > 0 ? Math.trunc(rawCount) : 0,
+    position: Number.isFinite(rawPosition)
+      ? rawPosition
+      : Number.POSITIVE_INFINITY,
+  };
+}
+
+/**
+ * @param {{ position: number, name: string }} left
+ * @param {{ position: number, name: string }} right
+ * @returns {number}
+ */
+function compareLanes(left, right) {
+  if (left.position !== right.position) {
+    return left.position - right.position;
+  }
+  return left.name.localeCompare(right.name);
+}
+
+/**
+ * Select every lane holding not-yet-started work, by type.
+ *
+ * Deliberately name-blind: a team that adds `Blocked`, `Triaged`, or `Icebox`
+ * as an `unstarted` state gets it swept without a code change, and no hardcoded
+ * roster can fall behind the board.
+ *
+ * @param {readonly unknown[]} lanes
+ * @returns {readonly {name: string, type: string, count: number, position: number}[]}
+ */
+export function selectPreWorkLanes(lanes) {
+  return (Array.isArray(lanes) ? lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null && isPreWorkLaneType(lane.type))
+    .sort(compareLanes);
+}
+
+/**
+ * Build the denominator a scanner must report with its verdict.
+ *
+ * `totalOpen` is the count of open items on the queue, independent of lanes —
+ * supplying it is what makes an omitted lane arithmetically visible.
+ *
+ * @param {{ lanes?: readonly unknown[], totalOpen?: number }} input
+ * @returns {{
+ *   swept: readonly {name: string, type: string, count: number}[]
+ *   omitted: readonly {name: string, type: string | null, count: number}[]
+ *   sweptCount: number
+ *   totalOpen: number
+ *   unsweptCount: number
+ * }}
+ */
+export function buildIntakeDenominator(input = {}) {
+  const normalized = (Array.isArray(input.lanes) ? input.lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null)
+    .sort(compareLanes);
+  const swept = normalized.filter(lane => isPreWorkLaneType(lane.type));
+  const omitted = normalized.filter(lane => !isPreWorkLaneType(lane.type));
+  const sweptCount = swept.reduce((total, lane) => total + lane.count, 0);
+  const laneTotal = normalized.reduce((total, lane) => total + lane.count, 0);
+  const rawTotalOpen = Number(input.totalOpen);
+  const totalOpen =
+    Number.isFinite(rawTotalOpen) && rawTotalOpen >= 0
+      ? Math.trunc(rawTotalOpen)
+      : laneTotal;
+
+  return {
+    swept: swept.map(({ name, type, count }) => ({ name, type, count })),
+    omitted: omitted.map(({ name, type, count }) => ({ name, type, count })),
+    sweptCount,
+    totalOpen,
+    unsweptCount: Math.max(totalOpen - sweptCount, 0),
+  };
+}
+
+/**
+ * Render the denominator for a non-technical operator.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @returns {string}
+ */
+export function formatIntakeDenominator(denominator) {
+  const lanes = denominator?.swept ?? [];
+  const listed =
+    lanes.length > 0
+      ? lanes.map(lane => `${lane.name} (${lane.count})`).join(", ")
+      : "no pre-work lanes found";
+
+  return `Looked in every lane holding work that has not started — ${listed} — ${denominator.sweptCount} items checked out of ${denominator.totalOpen} still open.`;
+}
+
+/**
+ * Render the full operator-readable one-liner for a dry build lane.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @param {{ queue?: string }} [context]
+ * @returns {string}
+ */
+export function summarizeDryLane(denominator, context = {}) {
+  const queue =
+    typeof context.queue === "string" && context.queue.trim().length > 0
+      ? ` on ${context.queue.trim()}`
+      : "";
+
+  return `Nothing ready to build${queue}. ${formatIntakeDenominator(denominator)}`;
+}
+
+/**
+ * @param {unknown} loopId
+ * @param {unknown} outcome
+ * @returns {boolean} whether this run must carry a denominator
+ */
+export function requiresDenominator(loopId, outcome) {
+  return (
+    outcome === "nothing-needed" &&
+    DENOMINATOR_REQUIRED_LOOP_IDS.includes(String(loopId ?? "").trim())
+  );
+}
+
+/**
+ * @param {unknown} denominator
+ * @returns {string | null} the reason it is unusable, or null when valid
+ */
+function findDenominatorDefect(denominator) {
+  if (!denominator || typeof denominator !== "object") {
+    return "no denominator was supplied";
+  }
+  if (!Array.isArray(denominator.swept) || denominator.swept.length === 0) {
+    return "it names no swept lanes";
+  }
+  if (!Number.isInteger(denominator.sweptCount)) {
+    return "its swept count is not a whole number";
+  }
+  if (!Number.isInteger(denominator.totalOpen)) {
+    return "its open-item total is not a whole number";
+  }
+  if (denominator.sweptCount > denominator.totalOpen) {
+    return "it claims to have swept more items than are open";
+  }
+  return null;
+}
+
+/**
+ * Refuse to record a dry build lane that does not say what it looked at.
+ *
+ * Thirty-one consecutive cycles reported an empty lane against a queue holding
+ * unswept pre-work rows. Every record was honest and every conclusion was
+ * false, because none of them stated a denominator. This turns that silent
+ * wrong answer into a loud one.
+ *
+ * @param {{ loopId?: unknown, outcome?: unknown, denominator?: unknown }} input
+ * @throws {Error} when a denominator is required and missing or malformed
+ */
+export function assertDenominatorReported(input = {}) {
+  if (!requiresDenominator(input.loopId, input.outcome)) {
+    return;
+  }
+  const defect = findDenominatorDefect(input.denominator);
+  if (defect === null) {
+    return;
+  }
+
+  throw new Error(
+    `A "nothing-needed" run for loop "${String(input.loopId).trim()}" must state the lanes it swept, and ${defect}. ` +
+      `Pass a denominator built by buildIntakeDenominator() so an omitted lane is visible instead of silent.`
+  );
+}

--- a/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-github-build-intake/SKILL.md
@@ -110,7 +110,7 @@ The only legitimate reasons to stop early:
 
 - Missing repo or required configuration. Surface the missing value and exit.
 - Label namespace not adopted (no issue carries any of `$READY` / `$CLAIMED` / `$DONE`). Surface a label-convention error and exit (this is setup, not a normal idle cycle — see "Adoption" at the bottom).
-- Empty ready set. Exit cleanly with `"No GitHub issues labeled $READY in <org>/<repo>. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -166,7 +166,57 @@ gh label list --repo <org>/<repo> --json name \
       '[.[] | .name | select(. == $r or . == $c or (. as $n | $d | index($n)))] | length'
 ```
 
-If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
+If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit.
+
+#### 2a. Sweep every pre-work lane, and state the denominator
+
+GitHub Issues has no state-type field, so labels are the only lane available here — a constraint of
+GitHub's data model, not a preference (see "Why labels" above). That makes the omission risk
+*higher*, not lower: there is no `type` to fall back on, so the pre-work set must be derived from
+**configured roles**, never from a hardcoded roster of label names. The pre-work lanes are:
+
+- the configured `$READY` label — the human-flipped lane, worked first;
+- the configured `$BLOCKED` label (`github.labels.build.blocked`) — items that were *never started*,
+  each carrying a written blocker that nothing re-read until Phase 2.5;
+- open issues carrying **no** build role label — which this scanner must see anyway in order to
+  determine and stamp their repo.
+
+Count each lane and the repo's **total open** count (`gh issue list --state open --limit 1000 --json
+number | jq length`), then build the denominator with the shared helper — GitHub callers pass the
+lane type explicitly, since there is none to read:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "$READY", type: "unstarted", count: <n>},
+                                 {name: "$BLOCKED", type: "unstarted", count: <n>},
+                                 {name: "(no role label)", type: "backlog", count: <n>},
+                                 {name: "$CLAIMED", type: "started", count: <n>}, …],
+                         totalOpen: <open issue count> })
+summarizeDryLane(denominator, { queue: "<org>/<repo>" })
+```
+
+Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all. If
+nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a bare
+"nothing to do". The run recorder rejects a dry build-intake run that does not name what it swept
+(see `automation-runbook-contract`).
+
+#### 2a.1 Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each `$BLOCKED` candidate:
+
+1. **Human gate first, and it is absolute.** An issue carrying the configured human-needed label
+   (`github.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in
+   its body is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from `scripts/intake-blocker-reprobe.mjs`. A
+   discharge with no recorded evidence is not a discharge, and neither is a candidate nothing
+   probed this cycle — the helper refuses both.
+4. **Record the result on the issue either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, relabel `$BLOCKED → $READY` with the discharging evidence in the same
+   comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 #### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
 
@@ -251,7 +301,7 @@ GitHub Issues live in one repo by definition, so the scanned repo's issues are u
    - **Container visibility is allowed.** A multi-repo Epic / Story / Spike may legitimately carry multiple `repo:<name>` labels for operator visibility. Do not split or claim it here; leave the repo markers intact and fall through to the leaf-only gate, which repairs the stale build-ready label instead of dispatching the container.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (repair containers)
 

--- a/plugins/lisa-copilot/skills/lisa-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-intake/SKILL.md
@@ -126,7 +126,7 @@ matches the mode this cycle ran in: **`intake-prd`** (PRD-side dispatch) or **`i
 
 | This cycle's exit path | Run outcome |
 |---|---|
-| Empty `Ready` set — the idle case (step 3), nothing to claim | `nothing-needed` |
+| Empty pre-work set — the idle case (step 3), nothing to claim. **Must state its denominator** (see below) | `nothing-needed` |
 | A PRD routed to `Blocked` (clarifying questions) or `Ticketed`; a build ticket claimed and dispatched | `candidate-proposed` |
 | A build cycle that shipped and verified (merged PR + evidence), or a shipped PRD moved to `verified` | `change-proved` |
 | A protected deployment (or other autonomy boundary the lifecycle hits) waiting on a human approval | `approval-requested` |
@@ -149,6 +149,22 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
   --loop-id intake-tickets --outcome candidate-proposed \
   --summary "Routed PRD #1810 to Blocked with clarifying questions; the run succeeded." \
   --runbook .lisa/automations/intake-tickets.runbook.md [--ref <item-url>]...
+```
+
+**A dry build lane must say what it looked in.** A `nothing-needed` run on `intake-tickets`
+additionally passes `--denominator` — the JSON from `buildIntakeDenominator()` in
+`scripts/intake-prework-denominator.mjs` — and the recorder **refuses the row without it**. This is
+not decoration: 31 consecutive cycles reported a dry lane against a queue holding 61 unswept
+pre-work rows, and every one of those records was honest. A missing row is noisy on inspection; a
+wrong denominator is silent forever and looks exactly like a healthy dry queue. Stating the swept
+set is what turns the silent wrong answer into an inspectable one (#2657).
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
+  --loop-id intake-tickets --outcome nothing-needed \
+  --summary "Nothing ready to build on team ENG. Looked in every lane holding work that has not started — Backlog (20), Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open." \
+  --denominator "$DENOMINATOR_JSON" \
+  --runbook .lisa/automations/intake-tickets.runbook.md
 ```
 
 If `${CLAUDE_PLUGIN_ROOT}` is unset, resolve the plugin scripts directory directly — the built copy

--- a/plugins/lisa-copilot/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-jira-build-intake/SKILL.md
@@ -85,7 +85,7 @@ The only legitimate reasons to stop early:
 
 - Missing project key / JQL or required configuration. Surface the missing value and exit.
 - Workflow misconfigured (pre-flight check finds `$CLAIMED` or `$DONE` not reachable, or `$READY` status absent). Surface and exit.
-- Empty ready set. Exit cleanly with `"No tickets with Status=$READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -130,11 +130,59 @@ JQL="${BASE_JQL} ORDER BY priority DESC, created ASC"
 
 4. Confirm the configured Atlassian site by invoking `lisa-atlassian-access` `operation: list-sites` (it enforces connection match against `.lisa.config.json`).
 
-### Phase 2 — Find ready tickets
+### Phase 2 — Sweep every pre-work status by CATEGORY
 
-Invoke `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), labels, components.
+**Sweep by `statusCategory`, never by a roster of status names.** JIRA groups statuses into three
+categories — `To Do` (`new`), `In Progress` (`indeterminate`), `Done` (`done`) — and a `Blocked`
+status is not a fourth category: a project that wants one models it under **`To Do`**, i.e. work
+that was never started. Keying the candidate set on status *names* therefore omits every pre-work
+lane a project invented, and the scanner reports an empty queue over a full one. The same defect on
+the Linear side produced 31 consecutive false "dry lane" cycles (#2657).
 
-If empty, report `"No tickets with Status=$READY. Nothing to do."` and exit. This is the common idle case.
+1. Run the ready query first: `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. This
+   is the human-flipped lane and it is worked first.
+2. Then sweep the rest of pre-work with the same base JQL, swapping the status clause for
+   `statusCategory = "To Do"`, and read the **total open** count (`statusCategory != Done`). The
+   open total is what makes an omitted lane arithmetically visible.
+3. Page to exhaustion — a single unpaged `search-issues` call is not a count.
+
+Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), status (with
+its category), labels, components.
+
+Build the denominator with the shared helper, which owns the pre-work vocabulary so no two
+scanners can disagree about what counts:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "<status>", type: "<statusCategory>", count: <rows>}, …],
+                         totalOpen: <statusCategory != Done count> })
+summarizeDryLane(denominator, { queue: "<project key>" })
+```
+
+The helper accepts JIRA's category vocabulary directly (`new` / `To Do` normalize to pre-work).
+
+**Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at
+all.** If nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a
+bare "nothing to do". The run recorder rejects a dry build-intake run that does not name what it
+swept (see `automation-runbook-contract`).
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each pre-work candidate outside `$READY`:
+
+1. **Human gate first, and it is absolute.** A ticket carrying the configured human-needed label
+   (`jira.labels.human_needed`, default `Human Needed`) or a `[lisa-human-gate]` marker in its
+   description is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from
+   `scripts/intake-blocker-reprobe.mjs`. A discharge with no recorded evidence is not a discharge,
+   and neither is a candidate nothing probed this cycle — the helper refuses both.
+4. **Record the result on the ticket either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, transition the ticket to `$READY` with the discharging evidence in the
+   same comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 ### Phase 3 — Process the first eligible ready ticket
 
@@ -149,7 +197,7 @@ A JIRA project can oversee multiple repos (`frontend` / `backend` / `infrastruct
    - **Unlabeled** → determine the target repo(s) from the ticket (description, AC, technical approach) confirmed against the code surfaces, then **stamp** `repo:<name>` via `lisa-atlassian-access` `operation: write-ticket` (add the label / set the component) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure to break it into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready tickets for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa-copilot/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-linear-build-intake/SKILL.md
@@ -99,7 +99,7 @@ The only legitimate reasons to stop early:
 
 - Missing team key or required configuration. Surface and exit.
 - Workflow states not yet adopted (the `ready` state does not exist on the team). Surface and exit with an Adoption hint pointing at `/lisa:setup:linear`.
-- Empty ready set. Exit cleanly with `"No Linear Issues in state $READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -112,7 +112,7 @@ ready → claimed → review → done(env-keyed) (downstream)
 
 (Defaults: `Ready` / `In Progress` / `In Review` / `On Dev`/`On Stg`/`Done`.)
 
-This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done`, `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`), or `$BLOCKED` (owned by the pre-flight gate).
+This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done` or `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`). It never *sets* `$BLOCKED` either — that stays owned by the pre-flight gate — but Phase 2.5 does move an Issue **out** of a pre-work blocked lane back to `$READY` when it re-probes the Issue's own stated discharge condition and finds it no longer holds, recording the discharging evidence on the Issue.
 
 **Pre-flight check**: at start of each cycle, confirm `$READY`, `$CLAIMED`, and the relevant `$DONE` variants exist on the team via `lisa-linear-access operation: list-workflow-states`. If `$READY` is missing, stop and report adoption needed. **Unlike labels, a missing state cannot be created on demand here** — a workflow state is team configuration with a `type` and a board position, and guessing either would put an Issue somewhere a human did not sanction. Any missing state is a setup defect: report it, name the role and the expected state, and point at `/lisa:setup:linear`.
 
@@ -125,15 +125,56 @@ This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $D
    - Literal `linear` → fall back to `linear.teamKey` from config.
 2. Resolve team ID via `lisa-linear-access operation: list-teams({query: <teamKey>})`.
 
-### Phase 2 — Find ready Issues
+### Phase 2 — Sweep every pre-work lane by state TYPE
 
-Query: `lisa-linear-access operation: list-issues({team: <teamId>, state: "$READY"})`.
+**Sweep by `type`, never by a roster of state names.** Linear state types are `backlog | unstarted | started | completed | canceled`, and there is no `blocked` type — a team that wants a `Blocked` lane models it as **`unstarted`**, i.e. work that was *never started*. Selecting candidates from a hardcoded `Backlog / Todo / Ready` name list therefore omits an entire pre-work lane and reports an empty queue over a full one. Measured on one team: the name sweep saw **39 of 343 open rows**; the type sweep sees **100**, and the 61-row difference produced 31 consecutive false "dry lane" cycles (#2657).
 
-Capture each Issue's: identifier, title, type label, priority, assignee, project, state, labels, description summary.
+1. List the team's workflow states via `lisa-linear-access operation: list-workflow-states`.
+2. Keep every state whose `type` is `backlog` or `unstarted` — that is the pre-work set. `$READY` is one member of it, not the whole of it.
+3. Query each pre-work state: `lisa-linear-access operation: list-issues({team: <teamId>, state: "<state>"})`, paging to `hasNextPage=false`. Linear's GraphQL complexity ceiling silently truncates at `first: 250`, so a single unpaged call is not a count.
+4. Also read the **total open** count for the team (every state whose `type` is not `completed` / `canceled`). This number is what makes an omitted lane arithmetically visible.
+
+Capture each Issue's: identifier, title, type label, priority, assignee, project, state (with its `type`), labels, description summary.
+
+Build the denominator with the shared helper, which owns the type vocabulary so no two scanners can disagree about what counts as pre-work:
+
+```bash
+node -e '
+import("'"${CLAUDE_PLUGIN_ROOT:-plugins/src/base}"'/scripts/intake-prework-denominator.mjs").then(m => {
+  const d = m.buildIntakeDenominator({ lanes: JSON.parse(process.argv[1]), totalOpen: Number(process.argv[2]) });
+  console.log(JSON.stringify(d));
+  console.log(m.summarizeDryLane(d, { queue: process.argv[3] }));
+});' "$LANES_JSON" "$TOTAL_OPEN" "team $TEAM_KEY"
+```
+
+`$LANES_JSON` is `[{"name":"<state>","type":"<state.type>","position":<state.position>,"count":<open rows>}, …]` for **every** state on the team, pre-work and not — the helper does the selecting.
+
+**Candidate order.** Work `$READY` first (it is the human-flipped signal), then the remaining pre-work lanes oldest-first. Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all.
 
 > **No query-time repo pre-filter here (by design).** Unlike `lisa-jira-build-intake`, which narrows its JQL with `AND (labels = "repo:<current>" OR labels IS EMPTY)` (the query-time arm of `repo-scope-split`), the Linear `list_issues` label filter is an AND-of-labels and cannot express "current-repo **or** unlabeled" in one query. Adding `repo:<current>` to this query would strand unlabeled Issues the determine + stamp path must see. So the Linear scanner keeps this query broad and relies on the per-candidate 3a.0 gate below for repo scoping. (The `state` filter above is orthogonal to that — it narrows the lifecycle lane, not the repo, and is a single-valued equality so it has none of the AND-of-labels problem.)
 
-If empty, report `"No Linear Issues in state $READY. Nothing to do."` and exit. Common idle case.
+If every pre-work lane is empty, or nothing survives Phase 2.5, exit on the **denominator-stated** summary from `summarizeDryLane` — never a bare "nothing to do". See "Run outcome" below; the run recorder rejects a dry build-intake run that does not name what it swept.
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact**. It is written once and goes stale the moment its condition comes true — a dependency lands on trunk, an advisory gets patched, a package publishes. Nothing re-read one before this phase, so a discharged blocker held its Issue out of the queue indefinitely. Measured: one Issue's stated condition went true ~15 hours before anything noticed.
+
+For each pre-work candidate that is **not** in `$READY`:
+
+1. **Human gate first, and it is absolute.** An Issue carrying the configured human-needed label (`linear.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in its description is **never** auto-selected, whatever any probe says. Skip it and move on.
+2. **Extract the stated discharge condition** from the description or the most recent blocking comment — the sentence naming what has to become true.
+3. **Probe it.** Machine-testable conditions are the ones that rot fastest and are cheapest to check: a version on trunk (`git show origin/<trunk>:<manifest>`), a published package, a run history (`gh run list`), an advisory's patched status. A condition that is a human decision is not machine-testable — leave it and move on.
+4. **Classify with the shared helper** so the ordering and the evidence requirement cannot drift per vendor:
+
+```text
+classifyPreWorkCandidate({ laneType, labels, body, humanNeededLabel, statedBlocker, probe })
+  → { selectable, reason, humanGated, evidence }
+```
+
+   A discharge with **no recorded evidence is not a discharge** — the helper refuses it. So is a candidate nothing probed this cycle.
+
+5. **Record the result on the Issue either way**, via `lisa-linear-access operation: save-comment` using `formatReprobeNote(...)`, so the next cycle reads the answer rather than re-deriving it. Keep it idempotent — skip the post when an identical note already exists.
+6. **On `selectable: true`**, move the Issue to `$READY` (recording the discharging evidence in the same comment) and treat it as an ordinary candidate from Phase 3 onward. On anything else, leave the Issue exactly where it is.
 
 ### Phase 3 — Process the first eligible ready Issue
 
@@ -148,7 +189,7 @@ A Linear team can oversee multiple repos (`frontend` / `backend` / `infrastructu
    - **Unlabeled** → determine the target repo(s) from the Issue + code surfaces, then **stamp** `repo:<name>` via `lisa-linear-access operation: save-issue` (resolve/create the label via `list_issue_labels`/`create_issue_label`) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready Issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa-copilot/skills/lisa-tracker-build-intake/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-tracker-build-intake/SKILL.md
@@ -42,6 +42,30 @@ This is the claim-time arm of the rule. Its siblings are the write-time labeling
 
 The shim never needs to inspect the item itself — it forwards `$ARGUMENTS` verbatim and the resolved vendor scanner runs its Phase 3a gate before any claim.
 
+## Pre-work denominator contract (forwarded to every vendor)
+
+Also part of the build-intake API, and the reason a dry queue can be believed. Two obligations,
+uniform across `jira`, `github`, and `linear`:
+
+1. **Sweep every pre-work lane by its machine-readable category, never by a roster of lane names.**
+   No tracker has a `blocked` category: Linear models a `Blocked` state as `unstarted`, JIRA models
+   a `Blocked` status under `To Do`, and GitHub has no category at all, so its lanes come from
+   configured roles. In every case a `Blocked` lane is *pre-work* — items that were never started,
+   each carrying a written blocker. Keying selection on names omits it silently.
+2. **A `nothing-needed` run states its denominator** — which lanes were swept, how many rows each
+   held, and the total open. This is enforced, not requested: `automation-run-record.mjs` refuses a
+   `nothing-needed` row for `intake-tickets` without a `--denominator`.
+
+Shared helpers own both, so the vocabulary cannot drift per vendor:
+`scripts/intake-prework-denominator.mjs` (`buildIntakeDenominator`, `summarizeDryLane`) and
+`scripts/intake-blocker-reprobe.mjs` (`classifyPreWorkCandidate`, `formatReprobeNote`). The
+blocker re-probe carries an absolute human gate: an item carrying the configured human-needed label
+or a `[lisa-human-gate]` marker is never auto-selected, whatever a probe returns.
+
+Measured: sweeping one team by lane name saw 39 of 343 open rows; by category it sees 100. The
+61-row gap produced 31 consecutive false "dry lane" cycles, every record honest and every
+conclusion wrong (#2657).
+
 ## Repo-scope claim contract (forwarded to every vendor)
 
 Equally part of the build-intake API, and forwarded identically: when the tracker oversees multiple repos, each vendor scanner claims only tickets for the repo it is running in. Per the `repo-scope-split` rule's "Claim-time repo scoping" section, before the leaf-only gate each scanner (Phase 3a.0) resolves the current repo (`config-resolution` "Repo scoping": `repo` → `github.repo` → git remote basename), then for each ready candidate: skips a ticket labeled `repo:<other>`, determines + stamps `repo:<name>` on an unlabeled one, splits a multi-repo leaf into single-repo build-ready siblings, and claims only a single-repo leaf for the current repo. This shim does not re-implement the gate — it relies on the vendor scanner's Phase 3a.0 — but the contract is uniform across `jira`, `github`, and `linear` so behavior never drifts by tracker. It is the claim-time complement to the write-time S10 scope gate (`lisa-tracker-validate`) and `task-decomposition` step 1.5; all cite `repo-scope-split`.

--- a/plugins/lisa-cursor/rules/automation-runbook-contract-reference.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract-reference.mdc
@@ -125,6 +125,25 @@ recovery-required   Lost access to the tracker; filed #1812 with the one decisio
 policy-obsolete     No work has reached this queue in 30 days; proposed teardown in #1813.
 ```
 
+### `nothing-needed` states its denominator
+
+A queue-scanning loop that reports nothing is only as trustworthy as the set it looked at, and a
+summary of the form "scanned N items" hides the one thing worth checking: **which lanes N came
+from.** So a `nothing-needed` summary from a queue scanner names the lanes it swept, the count in
+each, and the total open — `Looked in every lane holding work that has not started — Backlog (20),
+Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open.`
+
+This is a measured requirement, not a style preference. One build lane reported 31 consecutive dry
+cycles over a queue holding 61 unswept rows, at least one of them buildable for ~15 hours. Every
+one of the 31 records was honest and every conclusion was false, because the scanner never said
+what its denominator was. **A missing run record is noisy on inspection; a wrong denominator is
+silent forever and looks exactly like a healthy dry queue.** Stating the swept set is what makes
+the second failure mode visible at all.
+
+The build-intake loop enforces this rather than requesting it: `automation-run-record.mjs` refuses
+a `nothing-needed` row for `intake-tickets` unless the call carries a `--denominator` built by
+`scripts/intake-prework-denominator.mjs`.
+
 **No silent exit.** Every run posts its outcome and its one-line summary before stopping —
 including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
 there is no silent exit for an operator to misread as health. A run that ends without a

--- a/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
+++ b/plugins/lisa-cursor/rules/automation-runbook-contract.mdc
@@ -53,6 +53,8 @@ Exactly one per run:
 Health and operator action are **orthogonal** — a healthy run can still need an answer:
 
 - `nothing-needed` — the loop ran and found nothing to act on. **Healthy.** Operator action: none.
+  A queue scanner's `nothing-needed` summary must name the lanes it swept and the total open — a dry
+  queue and a wrong denominator are otherwise indistinguishable. See the reference body.
 - `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation). **Healthy.** Operator
   action: review the proposed item and flip it ready when you want it built.
 - `change-proved` — the loop made a change and proved it with evidence. **Healthy.** Operator

--- a/plugins/lisa-cursor/scripts/automation-run-record.mjs
+++ b/plugins/lisa-cursor/scripts/automation-run-record.mjs
@@ -11,6 +11,8 @@ import path from "node:path";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { assertDenominatorReported } from "./intake-prework-denominator.mjs";
+
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
   "candidate-proposed",
@@ -55,6 +57,15 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
  */
 export async function recordAutomationRun(input) {
+  // Write path only. Stored rows are re-validated on read through
+  // `validateStoredRecord`, and a history written before this contract existed
+  // must stay readable — so the denominator gate lives here, where a NEW row is
+  // minted, and never on the read path.
+  assertDenominatorReported({
+    loopId: input.loopId,
+    outcome: input.outcome,
+    denominator: input.extras?.denominator,
+  });
   const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
   const maxEntries =
     input.maxEntries ??
@@ -303,14 +314,19 @@ async function writeJsonlAtomically(filePath, records) {
 const CLI_USAGE = `Usage: node automation-run-record.mjs \\
   --loop-id <slug> --outcome <${AUTOMATION_RUN_OUTCOMES.join("|")}> \\
   --summary "<operator-readable one-liner>" --runbook <path> \\
-  [--ref <url>]... [--run-id <id>] [--project-root <dir>]`;
+  [--ref <url>]... [--run-id <id>] [--project-root <dir>] \\
+  [--denominator '<json from buildIntakeDenominator()>']
+
+--denominator is REQUIRED for a "nothing-needed" run on a build-intake loop: a
+dry lane that does not say which lanes it looked in cannot be checked.`;
 
 /**
  * Translate a repeatable-flag argv into a {@link RecordAutomationRunInput}.
  *
  * Every flag takes a following value; `--ref` may repeat and accumulates into
- * `refs`. Unknown flags and value-less flags throw so a typo never silently
- * records the wrong thing.
+ * `refs`, and `--denominator` carries the swept-lane JSON into `extras`.
+ * Unknown flags and value-less flags throw so a typo never silently records the
+ * wrong thing.
  *
  * @param {readonly string[]} argv
  * @returns {RecordAutomationRunInput}
@@ -320,6 +336,8 @@ function parseAutomationRunRecordArgv(argv) {
   const single = {};
   /** @type {string[]} */
   const refs = [];
+  /** @type {Record<string, unknown>} */
+  const extras = {};
   const flags = {
     "--loop-id": "loopId",
     "--outcome": "outcome",
@@ -349,6 +367,10 @@ function parseAutomationRunRecordArgv(argv) {
       refs.push(takeValue());
       continue;
     }
+    if (flag === "--denominator") {
+      extras.denominator = parseDenominatorFlag(takeValue());
+      continue;
+    }
     const key = flags[flag];
     if (!key) {
       throw new Error(`Unknown flag "${flag}".`);
@@ -356,7 +378,21 @@ function parseAutomationRunRecordArgv(argv) {
     single[key] = takeValue();
   }
 
-  return { ...single, refs };
+  return { ...single, refs, extras };
+}
+
+/**
+ * @param {string} value
+ * @returns {unknown}
+ */
+function parseDenominatorFlag(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(
+      "--denominator must be JSON produced by buildIntakeDenominator()."
+    );
+  }
 }
 
 /**

--- a/plugins/lisa-cursor/scripts/intake-blocker-reprobe.mjs
+++ b/plugins/lisa-cursor/scripts/intake-blocker-reprobe.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Blocker re-probe gate for pre-work build-intake candidates.
+ *
+ * A blocker is a claim with a timestamp, not a fact. It is written once, and it
+ * decays the moment its condition goes true — a dependency lands on trunk, a
+ * CVE gets patched, a package publishes. Nothing in the old intake loop ever
+ * re-read one, so a discharged blocker held its item out of the queue forever.
+ *
+ * This module decides, per candidate, whether intake may select it. It never
+ * probes anything itself: the caller runs the probe and hands back the result,
+ * which keeps the decision auditable and testable apart from the network.
+ */
+
+import { isPreWorkLaneType } from "./intake-prework-denominator.mjs";
+
+/** Marker a writer stamps on an item a human deliberately parked. */
+export const HUMAN_GATE_MARKER = "[lisa-human-gate]";
+
+/** Default label naming a block only a human can clear. */
+export const DEFAULT_HUMAN_NEEDED_LABEL = "human-needed";
+
+/**
+ * @param {unknown} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabels(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label =>
+      typeof label === "string"
+        ? label
+        : typeof label?.name === "string"
+          ? label.name
+          : ""
+    )
+    .map(label => label.trim().toLowerCase())
+    .filter(label => label.length > 0);
+}
+
+/**
+ * @param {{ labels?: unknown, body?: unknown, humanNeededLabel?: unknown }} input
+ * @returns {boolean}
+ */
+function isHumanGated(input) {
+  const configured = String(
+    input.humanNeededLabel ?? DEFAULT_HUMAN_NEEDED_LABEL
+  )
+    .trim()
+    .toLowerCase();
+  if (
+    configured.length > 0 &&
+    normalizeLabels(input.labels).includes(configured)
+  ) {
+    return true;
+  }
+
+  return String(input.body ?? "").includes(HUMAN_GATE_MARKER);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function trimmedString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {{ discharged?: unknown, evidence?: unknown }} probe
+ * @returns {{ selectable: boolean, reason: string, evidence: string }}
+ */
+function judgeProbe(probe) {
+  const evidence = trimmedString(probe.evidence);
+
+  if (probe.discharged !== true) {
+    return {
+      selectable: false,
+      reason: "blocker-holds",
+      evidence,
+    };
+  }
+  if (evidence.length === 0) {
+    return {
+      selectable: false,
+      reason: "blocker-discharge-unevidenced",
+      evidence,
+    };
+  }
+
+  return { selectable: true, reason: "blocker-discharged", evidence };
+}
+
+/**
+ * Decide whether a pre-work item may be selected as a build candidate.
+ *
+ * Order is load-bearing. The human gate is checked before anything else, so no
+ * probe result — however conclusive — can promote an item a human parked.
+ *
+ * @param {{
+ *   laneType?: unknown
+ *   labels?: unknown
+ *   body?: unknown
+ *   humanNeededLabel?: unknown
+ *   statedBlocker?: unknown
+ *   probe?: { discharged?: unknown, evidence?: unknown } | null
+ * }} input
+ * @returns {{ selectable: boolean, reason: string, humanGated: boolean, evidence: string }}
+ */
+export function classifyPreWorkCandidate(input = {}) {
+  if (isHumanGated(input)) {
+    return {
+      selectable: false,
+      reason: "human-gate",
+      humanGated: true,
+      evidence: "",
+    };
+  }
+  if (!isPreWorkLaneType(input.laneType)) {
+    return {
+      selectable: false,
+      reason: "not-pre-work",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (trimmedString(input.statedBlocker).length === 0) {
+    return {
+      selectable: true,
+      reason: "no-blocker",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (!input.probe || typeof input.probe !== "object") {
+    return {
+      selectable: false,
+      reason: "blocker-unprobed",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+
+  return { ...judgeProbe(input.probe), humanGated: false };
+}
+
+/** Plain-English wording for each verdict, for the note left on the item. */
+const REASON_COPY = Object.freeze({
+  "human-gate": "A person parked this one on purpose, so intake left it alone.",
+  "not-pre-work": "This item is not sitting in a not-yet-started lane.",
+  "no-blocker": "No blocker was written on this item, so it is buildable.",
+  "blocker-unprobed":
+    "This item states a blocker that was not re-checked this cycle, so it stays put.",
+  "blocker-holds":
+    "The blocker was re-checked and still holds, so it stays put.",
+  "blocker-discharge-unevidenced":
+    "The blocker looked clear but no proof was recorded, so it stays put.",
+  "blocker-discharged":
+    "The blocker was re-checked and no longer applies, so this item is buildable again.",
+});
+
+/**
+ * Render the re-probe result to leave on the item, so the next cycle reads the
+ * answer instead of deriving it again.
+ *
+ * @param {{
+ *   statedBlocker?: unknown
+ *   checkedAt?: string | Date
+ * }} candidate
+ * @param {{ reason: string, evidence?: string }} verdict
+ * @returns {string}
+ */
+export function formatReprobeNote(candidate = {}, verdict) {
+  const checkedAt =
+    candidate.checkedAt instanceof Date
+      ? candidate.checkedAt.toISOString()
+      : trimmedString(candidate.checkedAt) || new Date().toISOString();
+  const lines = [
+    "**Blocker re-check**",
+    "",
+    `- What has to be true: ${trimmedString(candidate.statedBlocker) || "(none written on this item)"}`,
+    `- What we found: ${REASON_COPY[verdict.reason] ?? verdict.reason}`,
+  ];
+  const evidence = trimmedString(verdict.evidence);
+  if (evidence.length > 0) {
+    lines.push(`- Proof: ${evidence}`);
+  }
+  lines.push(`- Checked at: ${checkedAt}`);
+
+  return lines.join("\n");
+}

--- a/plugins/lisa-cursor/scripts/intake-prework-denominator.mjs
+++ b/plugins/lisa-cursor/scripts/intake-prework-denominator.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Pre-work denominator for build-queue intake scanners.
+ *
+ * A build-intake cycle that reports an empty lane is only as trustworthy as the
+ * set of lanes it swept. Sweeping by lane NAME (`Backlog`, `Todo`, `Ready`)
+ * omits every pre-work lane a team invented — most commonly a `Blocked` lane,
+ * which is not a distinct Linear state type at all: teams model it as
+ * `unstarted`, i.e. work that was never started. Items parked there carry a
+ * written blocker that nothing ever re-reads, so the lane reads as terminal
+ * while it is in fact a queue.
+ *
+ * This module fixes both halves: lanes are selected by TYPE, never by name, and
+ * the swept set is reported alongside the total so a wrong denominator is
+ * visible on inspection instead of silent forever.
+ */
+
+/** Lane types that hold work which has not started. Both belong to intake. */
+export const PRE_WORK_LANE_TYPES = Object.freeze(["backlog", "unstarted"]);
+
+/** Loop ids whose `nothing-needed` runs must state their denominator. */
+export const DENOMINATOR_REQUIRED_LOOP_IDS = Object.freeze(["intake-tickets"]);
+
+/**
+ * Vendor lane-type vocabularies normalized onto Linear's five-value type set.
+ * JIRA exposes the same idea as `statusCategory` (key or display name); GitHub
+ * has no type field at all, so its callers pass a type explicitly.
+ */
+const LANE_TYPE_ALIASES = Object.freeze({
+  backlog: "backlog",
+  unstarted: "unstarted",
+  started: "started",
+  completed: "completed",
+  canceled: "canceled",
+  cancelled: "canceled",
+  new: "unstarted",
+  indeterminate: "started",
+  done: "completed",
+  "to do": "unstarted",
+  "in progress": "started",
+});
+
+/**
+ * Map a vendor lane type onto the normalized vocabulary.
+ *
+ * @param {unknown} type
+ * @returns {string | null} normalized type, or null when unrecognized
+ */
+export function normalizeLaneType(type) {
+  if (typeof type !== "string") {
+    return null;
+  }
+  return LANE_TYPE_ALIASES[type.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * @param {unknown} type
+ * @returns {boolean} whether this lane holds not-yet-started work
+ */
+export function isPreWorkLaneType(type) {
+  const normalized = normalizeLaneType(type);
+  return normalized !== null && PRE_WORK_LANE_TYPES.includes(normalized);
+}
+
+/**
+ * @param {unknown} lane
+ * @returns {{ name: string, type: string | null, count: number, position: number } | null}
+ */
+function normalizeLane(lane) {
+  if (!lane || typeof lane !== "object") {
+    return null;
+  }
+  const name = String(lane.name ?? "").trim();
+  if (name.length === 0) {
+    return null;
+  }
+  const rawCount = Number(lane.count ?? 0);
+  const rawPosition = Number(lane.position ?? Number.POSITIVE_INFINITY);
+
+  return {
+    name,
+    type: normalizeLaneType(lane.type ?? lane.statusCategory),
+    count: Number.isFinite(rawCount) && rawCount > 0 ? Math.trunc(rawCount) : 0,
+    position: Number.isFinite(rawPosition)
+      ? rawPosition
+      : Number.POSITIVE_INFINITY,
+  };
+}
+
+/**
+ * @param {{ position: number, name: string }} left
+ * @param {{ position: number, name: string }} right
+ * @returns {number}
+ */
+function compareLanes(left, right) {
+  if (left.position !== right.position) {
+    return left.position - right.position;
+  }
+  return left.name.localeCompare(right.name);
+}
+
+/**
+ * Select every lane holding not-yet-started work, by type.
+ *
+ * Deliberately name-blind: a team that adds `Blocked`, `Triaged`, or `Icebox`
+ * as an `unstarted` state gets it swept without a code change, and no hardcoded
+ * roster can fall behind the board.
+ *
+ * @param {readonly unknown[]} lanes
+ * @returns {readonly {name: string, type: string, count: number, position: number}[]}
+ */
+export function selectPreWorkLanes(lanes) {
+  return (Array.isArray(lanes) ? lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null && isPreWorkLaneType(lane.type))
+    .sort(compareLanes);
+}
+
+/**
+ * Build the denominator a scanner must report with its verdict.
+ *
+ * `totalOpen` is the count of open items on the queue, independent of lanes —
+ * supplying it is what makes an omitted lane arithmetically visible.
+ *
+ * @param {{ lanes?: readonly unknown[], totalOpen?: number }} input
+ * @returns {{
+ *   swept: readonly {name: string, type: string, count: number}[]
+ *   omitted: readonly {name: string, type: string | null, count: number}[]
+ *   sweptCount: number
+ *   totalOpen: number
+ *   unsweptCount: number
+ * }}
+ */
+export function buildIntakeDenominator(input = {}) {
+  const normalized = (Array.isArray(input.lanes) ? input.lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null)
+    .sort(compareLanes);
+  const swept = normalized.filter(lane => isPreWorkLaneType(lane.type));
+  const omitted = normalized.filter(lane => !isPreWorkLaneType(lane.type));
+  const sweptCount = swept.reduce((total, lane) => total + lane.count, 0);
+  const laneTotal = normalized.reduce((total, lane) => total + lane.count, 0);
+  const rawTotalOpen = Number(input.totalOpen);
+  const totalOpen =
+    Number.isFinite(rawTotalOpen) && rawTotalOpen >= 0
+      ? Math.trunc(rawTotalOpen)
+      : laneTotal;
+
+  return {
+    swept: swept.map(({ name, type, count }) => ({ name, type, count })),
+    omitted: omitted.map(({ name, type, count }) => ({ name, type, count })),
+    sweptCount,
+    totalOpen,
+    unsweptCount: Math.max(totalOpen - sweptCount, 0),
+  };
+}
+
+/**
+ * Render the denominator for a non-technical operator.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @returns {string}
+ */
+export function formatIntakeDenominator(denominator) {
+  const lanes = denominator?.swept ?? [];
+  const listed =
+    lanes.length > 0
+      ? lanes.map(lane => `${lane.name} (${lane.count})`).join(", ")
+      : "no pre-work lanes found";
+
+  return `Looked in every lane holding work that has not started — ${listed} — ${denominator.sweptCount} items checked out of ${denominator.totalOpen} still open.`;
+}
+
+/**
+ * Render the full operator-readable one-liner for a dry build lane.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @param {{ queue?: string }} [context]
+ * @returns {string}
+ */
+export function summarizeDryLane(denominator, context = {}) {
+  const queue =
+    typeof context.queue === "string" && context.queue.trim().length > 0
+      ? ` on ${context.queue.trim()}`
+      : "";
+
+  return `Nothing ready to build${queue}. ${formatIntakeDenominator(denominator)}`;
+}
+
+/**
+ * @param {unknown} loopId
+ * @param {unknown} outcome
+ * @returns {boolean} whether this run must carry a denominator
+ */
+export function requiresDenominator(loopId, outcome) {
+  return (
+    outcome === "nothing-needed" &&
+    DENOMINATOR_REQUIRED_LOOP_IDS.includes(String(loopId ?? "").trim())
+  );
+}
+
+/**
+ * @param {unknown} denominator
+ * @returns {string | null} the reason it is unusable, or null when valid
+ */
+function findDenominatorDefect(denominator) {
+  if (!denominator || typeof denominator !== "object") {
+    return "no denominator was supplied";
+  }
+  if (!Array.isArray(denominator.swept) || denominator.swept.length === 0) {
+    return "it names no swept lanes";
+  }
+  if (!Number.isInteger(denominator.sweptCount)) {
+    return "its swept count is not a whole number";
+  }
+  if (!Number.isInteger(denominator.totalOpen)) {
+    return "its open-item total is not a whole number";
+  }
+  if (denominator.sweptCount > denominator.totalOpen) {
+    return "it claims to have swept more items than are open";
+  }
+  return null;
+}
+
+/**
+ * Refuse to record a dry build lane that does not say what it looked at.
+ *
+ * Thirty-one consecutive cycles reported an empty lane against a queue holding
+ * unswept pre-work rows. Every record was honest and every conclusion was
+ * false, because none of them stated a denominator. This turns that silent
+ * wrong answer into a loud one.
+ *
+ * @param {{ loopId?: unknown, outcome?: unknown, denominator?: unknown }} input
+ * @throws {Error} when a denominator is required and missing or malformed
+ */
+export function assertDenominatorReported(input = {}) {
+  if (!requiresDenominator(input.loopId, input.outcome)) {
+    return;
+  }
+  const defect = findDenominatorDefect(input.denominator);
+  if (defect === null) {
+    return;
+  }
+
+  throw new Error(
+    `A "nothing-needed" run for loop "${String(input.loopId).trim()}" must state the lanes it swept, and ${defect}. ` +
+      `Pass a denominator built by buildIntakeDenominator() so an omitted lane is visible instead of silent.`
+  );
+}

--- a/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-github-build-intake/SKILL.md
@@ -110,7 +110,7 @@ The only legitimate reasons to stop early:
 
 - Missing repo or required configuration. Surface the missing value and exit.
 - Label namespace not adopted (no issue carries any of `$READY` / `$CLAIMED` / `$DONE`). Surface a label-convention error and exit (this is setup, not a normal idle cycle — see "Adoption" at the bottom).
-- Empty ready set. Exit cleanly with `"No GitHub issues labeled $READY in <org>/<repo>. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -166,7 +166,57 @@ gh label list --repo <org>/<repo> --json name \
       '[.[] | .name | select(. == $r or . == $c or (. as $n | $d | index($n)))] | length'
 ```
 
-If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
+If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit.
+
+#### 2a. Sweep every pre-work lane, and state the denominator
+
+GitHub Issues has no state-type field, so labels are the only lane available here — a constraint of
+GitHub's data model, not a preference (see "Why labels" above). That makes the omission risk
+*higher*, not lower: there is no `type` to fall back on, so the pre-work set must be derived from
+**configured roles**, never from a hardcoded roster of label names. The pre-work lanes are:
+
+- the configured `$READY` label — the human-flipped lane, worked first;
+- the configured `$BLOCKED` label (`github.labels.build.blocked`) — items that were *never started*,
+  each carrying a written blocker that nothing re-read until Phase 2.5;
+- open issues carrying **no** build role label — which this scanner must see anyway in order to
+  determine and stamp their repo.
+
+Count each lane and the repo's **total open** count (`gh issue list --state open --limit 1000 --json
+number | jq length`), then build the denominator with the shared helper — GitHub callers pass the
+lane type explicitly, since there is none to read:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "$READY", type: "unstarted", count: <n>},
+                                 {name: "$BLOCKED", type: "unstarted", count: <n>},
+                                 {name: "(no role label)", type: "backlog", count: <n>},
+                                 {name: "$CLAIMED", type: "started", count: <n>}, …],
+                         totalOpen: <open issue count> })
+summarizeDryLane(denominator, { queue: "<org>/<repo>" })
+```
+
+Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all. If
+nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a bare
+"nothing to do". The run recorder rejects a dry build-intake run that does not name what it swept
+(see `automation-runbook-contract`).
+
+#### 2a.1 Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each `$BLOCKED` candidate:
+
+1. **Human gate first, and it is absolute.** An issue carrying the configured human-needed label
+   (`github.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in
+   its body is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from `scripts/intake-blocker-reprobe.mjs`. A
+   discharge with no recorded evidence is not a discharge, and neither is a candidate nothing
+   probed this cycle — the helper refuses both.
+4. **Record the result on the issue either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, relabel `$BLOCKED → $READY` with the discharging evidence in the same
+   comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 #### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
 
@@ -251,7 +301,7 @@ GitHub Issues live in one repo by definition, so the scanned repo's issues are u
    - **Container visibility is allowed.** A multi-repo Epic / Story / Spike may legitimately carry multiple `repo:<name>` labels for operator visibility. Do not split or claim it here; leave the repo markers intact and fall through to the leaf-only gate, which repairs the stale build-ready label instead of dispatching the container.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (repair containers)
 

--- a/plugins/lisa-cursor/skills/lisa-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-intake/SKILL.md
@@ -126,7 +126,7 @@ matches the mode this cycle ran in: **`intake-prd`** (PRD-side dispatch) or **`i
 
 | This cycle's exit path | Run outcome |
 |---|---|
-| Empty `Ready` set — the idle case (step 3), nothing to claim | `nothing-needed` |
+| Empty pre-work set — the idle case (step 3), nothing to claim. **Must state its denominator** (see below) | `nothing-needed` |
 | A PRD routed to `Blocked` (clarifying questions) or `Ticketed`; a build ticket claimed and dispatched | `candidate-proposed` |
 | A build cycle that shipped and verified (merged PR + evidence), or a shipped PRD moved to `verified` | `change-proved` |
 | A protected deployment (or other autonomy boundary the lifecycle hits) waiting on a human approval | `approval-requested` |
@@ -149,6 +149,22 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
   --loop-id intake-tickets --outcome candidate-proposed \
   --summary "Routed PRD #1810 to Blocked with clarifying questions; the run succeeded." \
   --runbook .lisa/automations/intake-tickets.runbook.md [--ref <item-url>]...
+```
+
+**A dry build lane must say what it looked in.** A `nothing-needed` run on `intake-tickets`
+additionally passes `--denominator` — the JSON from `buildIntakeDenominator()` in
+`scripts/intake-prework-denominator.mjs` — and the recorder **refuses the row without it**. This is
+not decoration: 31 consecutive cycles reported a dry lane against a queue holding 61 unswept
+pre-work rows, and every one of those records was honest. A missing row is noisy on inspection; a
+wrong denominator is silent forever and looks exactly like a healthy dry queue. Stating the swept
+set is what turns the silent wrong answer into an inspectable one (#2657).
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
+  --loop-id intake-tickets --outcome nothing-needed \
+  --summary "Nothing ready to build on team ENG. Looked in every lane holding work that has not started — Backlog (20), Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open." \
+  --denominator "$DENOMINATOR_JSON" \
+  --runbook .lisa/automations/intake-tickets.runbook.md
 ```
 
 If `${CLAUDE_PLUGIN_ROOT}` is unset, resolve the plugin scripts directory directly — the built copy

--- a/plugins/lisa-cursor/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-jira-build-intake/SKILL.md
@@ -85,7 +85,7 @@ The only legitimate reasons to stop early:
 
 - Missing project key / JQL or required configuration. Surface the missing value and exit.
 - Workflow misconfigured (pre-flight check finds `$CLAIMED` or `$DONE` not reachable, or `$READY` status absent). Surface and exit.
-- Empty ready set. Exit cleanly with `"No tickets with Status=$READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -130,11 +130,59 @@ JQL="${BASE_JQL} ORDER BY priority DESC, created ASC"
 
 4. Confirm the configured Atlassian site by invoking `lisa-atlassian-access` `operation: list-sites` (it enforces connection match against `.lisa.config.json`).
 
-### Phase 2 — Find ready tickets
+### Phase 2 — Sweep every pre-work status by CATEGORY
 
-Invoke `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), labels, components.
+**Sweep by `statusCategory`, never by a roster of status names.** JIRA groups statuses into three
+categories — `To Do` (`new`), `In Progress` (`indeterminate`), `Done` (`done`) — and a `Blocked`
+status is not a fourth category: a project that wants one models it under **`To Do`**, i.e. work
+that was never started. Keying the candidate set on status *names* therefore omits every pre-work
+lane a project invented, and the scanner reports an empty queue over a full one. The same defect on
+the Linear side produced 31 consecutive false "dry lane" cycles (#2657).
 
-If empty, report `"No tickets with Status=$READY. Nothing to do."` and exit. This is the common idle case.
+1. Run the ready query first: `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. This
+   is the human-flipped lane and it is worked first.
+2. Then sweep the rest of pre-work with the same base JQL, swapping the status clause for
+   `statusCategory = "To Do"`, and read the **total open** count (`statusCategory != Done`). The
+   open total is what makes an omitted lane arithmetically visible.
+3. Page to exhaustion — a single unpaged `search-issues` call is not a count.
+
+Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), status (with
+its category), labels, components.
+
+Build the denominator with the shared helper, which owns the pre-work vocabulary so no two
+scanners can disagree about what counts:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "<status>", type: "<statusCategory>", count: <rows>}, …],
+                         totalOpen: <statusCategory != Done count> })
+summarizeDryLane(denominator, { queue: "<project key>" })
+```
+
+The helper accepts JIRA's category vocabulary directly (`new` / `To Do` normalize to pre-work).
+
+**Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at
+all.** If nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a
+bare "nothing to do". The run recorder rejects a dry build-intake run that does not name what it
+swept (see `automation-runbook-contract`).
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each pre-work candidate outside `$READY`:
+
+1. **Human gate first, and it is absolute.** A ticket carrying the configured human-needed label
+   (`jira.labels.human_needed`, default `Human Needed`) or a `[lisa-human-gate]` marker in its
+   description is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from
+   `scripts/intake-blocker-reprobe.mjs`. A discharge with no recorded evidence is not a discharge,
+   and neither is a candidate nothing probed this cycle — the helper refuses both.
+4. **Record the result on the ticket either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, transition the ticket to `$READY` with the discharging evidence in the
+   same comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 ### Phase 3 — Process the first eligible ready ticket
 
@@ -149,7 +197,7 @@ A JIRA project can oversee multiple repos (`frontend` / `backend` / `infrastruct
    - **Unlabeled** → determine the target repo(s) from the ticket (description, AC, technical approach) confirmed against the code surfaces, then **stamp** `repo:<name>` via `lisa-atlassian-access` `operation: write-ticket` (add the label / set the component) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure to break it into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready tickets for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa-cursor/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-linear-build-intake/SKILL.md
@@ -99,7 +99,7 @@ The only legitimate reasons to stop early:
 
 - Missing team key or required configuration. Surface and exit.
 - Workflow states not yet adopted (the `ready` state does not exist on the team). Surface and exit with an Adoption hint pointing at `/lisa:setup:linear`.
-- Empty ready set. Exit cleanly with `"No Linear Issues in state $READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -112,7 +112,7 @@ ready → claimed → review → done(env-keyed) (downstream)
 
 (Defaults: `Ready` / `In Progress` / `In Review` / `On Dev`/`On Stg`/`Done`.)
 
-This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done`, `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`), or `$BLOCKED` (owned by the pre-flight gate).
+This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done` or `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`). It never *sets* `$BLOCKED` either — that stays owned by the pre-flight gate — but Phase 2.5 does move an Issue **out** of a pre-work blocked lane back to `$READY` when it re-probes the Issue's own stated discharge condition and finds it no longer holds, recording the discharging evidence on the Issue.
 
 **Pre-flight check**: at start of each cycle, confirm `$READY`, `$CLAIMED`, and the relevant `$DONE` variants exist on the team via `lisa-linear-access operation: list-workflow-states`. If `$READY` is missing, stop and report adoption needed. **Unlike labels, a missing state cannot be created on demand here** — a workflow state is team configuration with a `type` and a board position, and guessing either would put an Issue somewhere a human did not sanction. Any missing state is a setup defect: report it, name the role and the expected state, and point at `/lisa:setup:linear`.
 
@@ -125,15 +125,56 @@ This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $D
    - Literal `linear` → fall back to `linear.teamKey` from config.
 2. Resolve team ID via `lisa-linear-access operation: list-teams({query: <teamKey>})`.
 
-### Phase 2 — Find ready Issues
+### Phase 2 — Sweep every pre-work lane by state TYPE
 
-Query: `lisa-linear-access operation: list-issues({team: <teamId>, state: "$READY"})`.
+**Sweep by `type`, never by a roster of state names.** Linear state types are `backlog | unstarted | started | completed | canceled`, and there is no `blocked` type — a team that wants a `Blocked` lane models it as **`unstarted`**, i.e. work that was *never started*. Selecting candidates from a hardcoded `Backlog / Todo / Ready` name list therefore omits an entire pre-work lane and reports an empty queue over a full one. Measured on one team: the name sweep saw **39 of 343 open rows**; the type sweep sees **100**, and the 61-row difference produced 31 consecutive false "dry lane" cycles (#2657).
 
-Capture each Issue's: identifier, title, type label, priority, assignee, project, state, labels, description summary.
+1. List the team's workflow states via `lisa-linear-access operation: list-workflow-states`.
+2. Keep every state whose `type` is `backlog` or `unstarted` — that is the pre-work set. `$READY` is one member of it, not the whole of it.
+3. Query each pre-work state: `lisa-linear-access operation: list-issues({team: <teamId>, state: "<state>"})`, paging to `hasNextPage=false`. Linear's GraphQL complexity ceiling silently truncates at `first: 250`, so a single unpaged call is not a count.
+4. Also read the **total open** count for the team (every state whose `type` is not `completed` / `canceled`). This number is what makes an omitted lane arithmetically visible.
+
+Capture each Issue's: identifier, title, type label, priority, assignee, project, state (with its `type`), labels, description summary.
+
+Build the denominator with the shared helper, which owns the type vocabulary so no two scanners can disagree about what counts as pre-work:
+
+```bash
+node -e '
+import("'"${CLAUDE_PLUGIN_ROOT:-plugins/src/base}"'/scripts/intake-prework-denominator.mjs").then(m => {
+  const d = m.buildIntakeDenominator({ lanes: JSON.parse(process.argv[1]), totalOpen: Number(process.argv[2]) });
+  console.log(JSON.stringify(d));
+  console.log(m.summarizeDryLane(d, { queue: process.argv[3] }));
+});' "$LANES_JSON" "$TOTAL_OPEN" "team $TEAM_KEY"
+```
+
+`$LANES_JSON` is `[{"name":"<state>","type":"<state.type>","position":<state.position>,"count":<open rows>}, …]` for **every** state on the team, pre-work and not — the helper does the selecting.
+
+**Candidate order.** Work `$READY` first (it is the human-flipped signal), then the remaining pre-work lanes oldest-first. Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all.
 
 > **No query-time repo pre-filter here (by design).** Unlike `lisa-jira-build-intake`, which narrows its JQL with `AND (labels = "repo:<current>" OR labels IS EMPTY)` (the query-time arm of `repo-scope-split`), the Linear `list_issues` label filter is an AND-of-labels and cannot express "current-repo **or** unlabeled" in one query. Adding `repo:<current>` to this query would strand unlabeled Issues the determine + stamp path must see. So the Linear scanner keeps this query broad and relies on the per-candidate 3a.0 gate below for repo scoping. (The `state` filter above is orthogonal to that — it narrows the lifecycle lane, not the repo, and is a single-valued equality so it has none of the AND-of-labels problem.)
 
-If empty, report `"No Linear Issues in state $READY. Nothing to do."` and exit. Common idle case.
+If every pre-work lane is empty, or nothing survives Phase 2.5, exit on the **denominator-stated** summary from `summarizeDryLane` — never a bare "nothing to do". See "Run outcome" below; the run recorder rejects a dry build-intake run that does not name what it swept.
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact**. It is written once and goes stale the moment its condition comes true — a dependency lands on trunk, an advisory gets patched, a package publishes. Nothing re-read one before this phase, so a discharged blocker held its Issue out of the queue indefinitely. Measured: one Issue's stated condition went true ~15 hours before anything noticed.
+
+For each pre-work candidate that is **not** in `$READY`:
+
+1. **Human gate first, and it is absolute.** An Issue carrying the configured human-needed label (`linear.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in its description is **never** auto-selected, whatever any probe says. Skip it and move on.
+2. **Extract the stated discharge condition** from the description or the most recent blocking comment — the sentence naming what has to become true.
+3. **Probe it.** Machine-testable conditions are the ones that rot fastest and are cheapest to check: a version on trunk (`git show origin/<trunk>:<manifest>`), a published package, a run history (`gh run list`), an advisory's patched status. A condition that is a human decision is not machine-testable — leave it and move on.
+4. **Classify with the shared helper** so the ordering and the evidence requirement cannot drift per vendor:
+
+```text
+classifyPreWorkCandidate({ laneType, labels, body, humanNeededLabel, statedBlocker, probe })
+  → { selectable, reason, humanGated, evidence }
+```
+
+   A discharge with **no recorded evidence is not a discharge** — the helper refuses it. So is a candidate nothing probed this cycle.
+
+5. **Record the result on the Issue either way**, via `lisa-linear-access operation: save-comment` using `formatReprobeNote(...)`, so the next cycle reads the answer rather than re-deriving it. Keep it idempotent — skip the post when an identical note already exists.
+6. **On `selectable: true`**, move the Issue to `$READY` (recording the discharging evidence in the same comment) and treat it as an ordinary candidate from Phase 3 onward. On anything else, leave the Issue exactly where it is.
 
 ### Phase 3 — Process the first eligible ready Issue
 
@@ -148,7 +189,7 @@ A Linear team can oversee multiple repos (`frontend` / `backend` / `infrastructu
    - **Unlabeled** → determine the target repo(s) from the Issue + code surfaces, then **stamp** `repo:<name>` via `lisa-linear-access operation: save-issue` (resolve/create the label via `list_issue_labels`/`create_issue_label`) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready Issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa-cursor/skills/lisa-tracker-build-intake/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-tracker-build-intake/SKILL.md
@@ -42,6 +42,30 @@ This is the claim-time arm of the rule. Its siblings are the write-time labeling
 
 The shim never needs to inspect the item itself — it forwards `$ARGUMENTS` verbatim and the resolved vendor scanner runs its Phase 3a gate before any claim.
 
+## Pre-work denominator contract (forwarded to every vendor)
+
+Also part of the build-intake API, and the reason a dry queue can be believed. Two obligations,
+uniform across `jira`, `github`, and `linear`:
+
+1. **Sweep every pre-work lane by its machine-readable category, never by a roster of lane names.**
+   No tracker has a `blocked` category: Linear models a `Blocked` state as `unstarted`, JIRA models
+   a `Blocked` status under `To Do`, and GitHub has no category at all, so its lanes come from
+   configured roles. In every case a `Blocked` lane is *pre-work* — items that were never started,
+   each carrying a written blocker. Keying selection on names omits it silently.
+2. **A `nothing-needed` run states its denominator** — which lanes were swept, how many rows each
+   held, and the total open. This is enforced, not requested: `automation-run-record.mjs` refuses a
+   `nothing-needed` row for `intake-tickets` without a `--denominator`.
+
+Shared helpers own both, so the vocabulary cannot drift per vendor:
+`scripts/intake-prework-denominator.mjs` (`buildIntakeDenominator`, `summarizeDryLane`) and
+`scripts/intake-blocker-reprobe.mjs` (`classifyPreWorkCandidate`, `formatReprobeNote`). The
+blocker re-probe carries an absolute human gate: an item carrying the configured human-needed label
+or a `[lisa-human-gate]` marker is never auto-selected, whatever a probe returns.
+
+Measured: sweeping one team by lane name saw 39 of 343 open rows; by category it sees 100. The
+61-row gap produced 31 consecutive false "dry lane" cycles, every record honest and every
+conclusion wrong (#2657).
+
 ## Repo-scope claim contract (forwarded to every vendor)
 
 Equally part of the build-intake API, and forwarded identically: when the tracker oversees multiple repos, each vendor scanner claims only tickets for the repo it is running in. Per the `repo-scope-split` rule's "Claim-time repo scoping" section, before the leaf-only gate each scanner (Phase 3a.0) resolves the current repo (`config-resolution` "Repo scoping": `repo` → `github.repo` → git remote basename), then for each ready candidate: skips a ticket labeled `repo:<other>`, determines + stamps `repo:<name>` on an unlabeled one, splits a multi-repo leaf into single-repo build-ready siblings, and claims only a single-repo leaf for the current repo. This shim does not re-implement the gate — it relies on the vendor scanner's Phase 3a.0 — but the contract is uniform across `jira`, `github`, and `linear` so behavior never drifts by tracker. It is the claim-time complement to the write-time S10 scope gate (`lisa-tracker-validate`) and `task-decomposition` step 1.5; all cite `repo-scope-split`.

--- a/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-github-build-intake/SKILL.md
@@ -110,7 +110,7 @@ The only legitimate reasons to stop early:
 
 - Missing repo or required configuration. Surface the missing value and exit.
 - Label namespace not adopted (no issue carries any of `$READY` / `$CLAIMED` / `$DONE`). Surface a label-convention error and exit (this is setup, not a normal idle cycle — see "Adoption" at the bottom).
-- Empty ready set. Exit cleanly with `"No GitHub issues labeled $READY in <org>/<repo>. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -166,7 +166,57 @@ gh label list --repo <org>/<repo> --json name \
       '[.[] | .name | select(. == $r or . == $c or (. as $n | $d | index($n)))] | length'
 ```
 
-If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
+If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit.
+
+#### 2a. Sweep every pre-work lane, and state the denominator
+
+GitHub Issues has no state-type field, so labels are the only lane available here — a constraint of
+GitHub's data model, not a preference (see "Why labels" above). That makes the omission risk
+*higher*, not lower: there is no `type` to fall back on, so the pre-work set must be derived from
+**configured roles**, never from a hardcoded roster of label names. The pre-work lanes are:
+
+- the configured `$READY` label — the human-flipped lane, worked first;
+- the configured `$BLOCKED` label (`github.labels.build.blocked`) — items that were *never started*,
+  each carrying a written blocker that nothing re-read until Phase 2.5;
+- open issues carrying **no** build role label — which this scanner must see anyway in order to
+  determine and stamp their repo.
+
+Count each lane and the repo's **total open** count (`gh issue list --state open --limit 1000 --json
+number | jq length`), then build the denominator with the shared helper — GitHub callers pass the
+lane type explicitly, since there is none to read:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "$READY", type: "unstarted", count: <n>},
+                                 {name: "$BLOCKED", type: "unstarted", count: <n>},
+                                 {name: "(no role label)", type: "backlog", count: <n>},
+                                 {name: "$CLAIMED", type: "started", count: <n>}, …],
+                         totalOpen: <open issue count> })
+summarizeDryLane(denominator, { queue: "<org>/<repo>" })
+```
+
+Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all. If
+nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a bare
+"nothing to do". The run recorder rejects a dry build-intake run that does not name what it swept
+(see `automation-runbook-contract`).
+
+#### 2a.1 Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each `$BLOCKED` candidate:
+
+1. **Human gate first, and it is absolute.** An issue carrying the configured human-needed label
+   (`github.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in
+   its body is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from `scripts/intake-blocker-reprobe.mjs`. A
+   discharge with no recorded evidence is not a discharge, and neither is a candidate nothing
+   probed this cycle — the helper refuses both.
+4. **Record the result on the issue either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, relabel `$BLOCKED → $READY` with the discharging evidence in the same
+   comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 #### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
 
@@ -251,7 +301,7 @@ GitHub Issues live in one repo by definition, so the scanned repo's issues are u
    - **Container visibility is allowed.** A multi-repo Epic / Story / Spike may legitimately carry multiple `repo:<name>` labels for operator visibility. Do not split or claim it here; leave the repo markers intact and fall through to the leaf-only gate, which repairs the stale build-ready label instead of dispatching the container.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (repair containers)
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-intake/SKILL.md
@@ -126,7 +126,7 @@ matches the mode this cycle ran in: **`intake-prd`** (PRD-side dispatch) or **`i
 
 | This cycle's exit path | Run outcome |
 |---|---|
-| Empty `Ready` set — the idle case (step 3), nothing to claim | `nothing-needed` |
+| Empty pre-work set — the idle case (step 3), nothing to claim. **Must state its denominator** (see below) | `nothing-needed` |
 | A PRD routed to `Blocked` (clarifying questions) or `Ticketed`; a build ticket claimed and dispatched | `candidate-proposed` |
 | A build cycle that shipped and verified (merged PR + evidence), or a shipped PRD moved to `verified` | `change-proved` |
 | A protected deployment (or other autonomy boundary the lifecycle hits) waiting on a human approval | `approval-requested` |
@@ -149,6 +149,22 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
   --loop-id intake-tickets --outcome candidate-proposed \
   --summary "Routed PRD #1810 to Blocked with clarifying questions; the run succeeded." \
   --runbook .lisa/automations/intake-tickets.runbook.md [--ref <item-url>]...
+```
+
+**A dry build lane must say what it looked in.** A `nothing-needed` run on `intake-tickets`
+additionally passes `--denominator` — the JSON from `buildIntakeDenominator()` in
+`scripts/intake-prework-denominator.mjs` — and the recorder **refuses the row without it**. This is
+not decoration: 31 consecutive cycles reported a dry lane against a queue holding 61 unswept
+pre-work rows, and every one of those records was honest. A missing row is noisy on inspection; a
+wrong denominator is silent forever and looks exactly like a healthy dry queue. Stating the swept
+set is what turns the silent wrong answer into an inspectable one (#2657).
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
+  --loop-id intake-tickets --outcome nothing-needed \
+  --summary "Nothing ready to build on team ENG. Looked in every lane holding work that has not started — Backlog (20), Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open." \
+  --denominator "$DENOMINATOR_JSON" \
+  --runbook .lisa/automations/intake-tickets.runbook.md
 ```
 
 If `${CLAUDE_PLUGIN_ROOT}` is unset, resolve the plugin scripts directory directly — the built copy

--- a/plugins/lisa/.codex-plugin/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-jira-build-intake/SKILL.md
@@ -85,7 +85,7 @@ The only legitimate reasons to stop early:
 
 - Missing project key / JQL or required configuration. Surface the missing value and exit.
 - Workflow misconfigured (pre-flight check finds `$CLAIMED` or `$DONE` not reachable, or `$READY` status absent). Surface and exit.
-- Empty ready set. Exit cleanly with `"No tickets with Status=$READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -130,11 +130,59 @@ JQL="${BASE_JQL} ORDER BY priority DESC, created ASC"
 
 4. Confirm the configured Atlassian site by invoking `lisa-atlassian-access` `operation: list-sites` (it enforces connection match against `.lisa.config.json`).
 
-### Phase 2 — Find ready tickets
+### Phase 2 — Sweep every pre-work status by CATEGORY
 
-Invoke `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), labels, components.
+**Sweep by `statusCategory`, never by a roster of status names.** JIRA groups statuses into three
+categories — `To Do` (`new`), `In Progress` (`indeterminate`), `Done` (`done`) — and a `Blocked`
+status is not a fourth category: a project that wants one models it under **`To Do`**, i.e. work
+that was never started. Keying the candidate set on status *names* therefore omits every pre-work
+lane a project invented, and the scanner reports an empty queue over a full one. The same defect on
+the Linear side produced 31 consecutive false "dry lane" cycles (#2657).
 
-If empty, report `"No tickets with Status=$READY. Nothing to do."` and exit. This is the common idle case.
+1. Run the ready query first: `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. This
+   is the human-flipped lane and it is worked first.
+2. Then sweep the rest of pre-work with the same base JQL, swapping the status clause for
+   `statusCategory = "To Do"`, and read the **total open** count (`statusCategory != Done`). The
+   open total is what makes an omitted lane arithmetically visible.
+3. Page to exhaustion — a single unpaged `search-issues` call is not a count.
+
+Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), status (with
+its category), labels, components.
+
+Build the denominator with the shared helper, which owns the pre-work vocabulary so no two
+scanners can disagree about what counts:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "<status>", type: "<statusCategory>", count: <rows>}, …],
+                         totalOpen: <statusCategory != Done count> })
+summarizeDryLane(denominator, { queue: "<project key>" })
+```
+
+The helper accepts JIRA's category vocabulary directly (`new` / `To Do` normalize to pre-work).
+
+**Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at
+all.** If nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a
+bare "nothing to do". The run recorder rejects a dry build-intake run that does not name what it
+swept (see `automation-runbook-contract`).
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each pre-work candidate outside `$READY`:
+
+1. **Human gate first, and it is absolute.** A ticket carrying the configured human-needed label
+   (`jira.labels.human_needed`, default `Human Needed`) or a `[lisa-human-gate]` marker in its
+   description is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from
+   `scripts/intake-blocker-reprobe.mjs`. A discharge with no recorded evidence is not a discharge,
+   and neither is a candidate nothing probed this cycle — the helper refuses both.
+4. **Record the result on the ticket either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, transition the ticket to `$READY` with the discharging evidence in the
+   same comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 ### Phase 3 — Process the first eligible ready ticket
 
@@ -149,7 +197,7 @@ A JIRA project can oversee multiple repos (`frontend` / `backend` / `infrastruct
    - **Unlabeled** → determine the target repo(s) from the ticket (description, AC, technical approach) confirmed against the code surfaces, then **stamp** `repo:<name>` via `lisa-atlassian-access` `operation: write-ticket` (add the label / set the component) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure to break it into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready tickets for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-linear-build-intake/SKILL.md
@@ -99,7 +99,7 @@ The only legitimate reasons to stop early:
 
 - Missing team key or required configuration. Surface and exit.
 - Workflow states not yet adopted (the `ready` state does not exist on the team). Surface and exit with an Adoption hint pointing at `/lisa:setup:linear`.
-- Empty ready set. Exit cleanly with `"No Linear Issues in state $READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -112,7 +112,7 @@ ready → claimed → review → done(env-keyed) (downstream)
 
 (Defaults: `Ready` / `In Progress` / `In Review` / `On Dev`/`On Stg`/`Done`.)
 
-This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done`, `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`), or `$BLOCKED` (owned by the pre-flight gate).
+This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done` or `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`). It never *sets* `$BLOCKED` either — that stays owned by the pre-flight gate — but Phase 2.5 does move an Issue **out** of a pre-work blocked lane back to `$READY` when it re-probes the Issue's own stated discharge condition and finds it no longer holds, recording the discharging evidence on the Issue.
 
 **Pre-flight check**: at start of each cycle, confirm `$READY`, `$CLAIMED`, and the relevant `$DONE` variants exist on the team via `lisa-linear-access operation: list-workflow-states`. If `$READY` is missing, stop and report adoption needed. **Unlike labels, a missing state cannot be created on demand here** — a workflow state is team configuration with a `type` and a board position, and guessing either would put an Issue somewhere a human did not sanction. Any missing state is a setup defect: report it, name the role and the expected state, and point at `/lisa:setup:linear`.
 
@@ -125,15 +125,56 @@ This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $D
    - Literal `linear` → fall back to `linear.teamKey` from config.
 2. Resolve team ID via `lisa-linear-access operation: list-teams({query: <teamKey>})`.
 
-### Phase 2 — Find ready Issues
+### Phase 2 — Sweep every pre-work lane by state TYPE
 
-Query: `lisa-linear-access operation: list-issues({team: <teamId>, state: "$READY"})`.
+**Sweep by `type`, never by a roster of state names.** Linear state types are `backlog | unstarted | started | completed | canceled`, and there is no `blocked` type — a team that wants a `Blocked` lane models it as **`unstarted`**, i.e. work that was *never started*. Selecting candidates from a hardcoded `Backlog / Todo / Ready` name list therefore omits an entire pre-work lane and reports an empty queue over a full one. Measured on one team: the name sweep saw **39 of 343 open rows**; the type sweep sees **100**, and the 61-row difference produced 31 consecutive false "dry lane" cycles (#2657).
 
-Capture each Issue's: identifier, title, type label, priority, assignee, project, state, labels, description summary.
+1. List the team's workflow states via `lisa-linear-access operation: list-workflow-states`.
+2. Keep every state whose `type` is `backlog` or `unstarted` — that is the pre-work set. `$READY` is one member of it, not the whole of it.
+3. Query each pre-work state: `lisa-linear-access operation: list-issues({team: <teamId>, state: "<state>"})`, paging to `hasNextPage=false`. Linear's GraphQL complexity ceiling silently truncates at `first: 250`, so a single unpaged call is not a count.
+4. Also read the **total open** count for the team (every state whose `type` is not `completed` / `canceled`). This number is what makes an omitted lane arithmetically visible.
+
+Capture each Issue's: identifier, title, type label, priority, assignee, project, state (with its `type`), labels, description summary.
+
+Build the denominator with the shared helper, which owns the type vocabulary so no two scanners can disagree about what counts as pre-work:
+
+```bash
+node -e '
+import("'"${CLAUDE_PLUGIN_ROOT:-plugins/src/base}"'/scripts/intake-prework-denominator.mjs").then(m => {
+  const d = m.buildIntakeDenominator({ lanes: JSON.parse(process.argv[1]), totalOpen: Number(process.argv[2]) });
+  console.log(JSON.stringify(d));
+  console.log(m.summarizeDryLane(d, { queue: process.argv[3] }));
+});' "$LANES_JSON" "$TOTAL_OPEN" "team $TEAM_KEY"
+```
+
+`$LANES_JSON` is `[{"name":"<state>","type":"<state.type>","position":<state.position>,"count":<open rows>}, …]` for **every** state on the team, pre-work and not — the helper does the selecting.
+
+**Candidate order.** Work `$READY` first (it is the human-flipped signal), then the remaining pre-work lanes oldest-first. Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all.
 
 > **No query-time repo pre-filter here (by design).** Unlike `lisa-jira-build-intake`, which narrows its JQL with `AND (labels = "repo:<current>" OR labels IS EMPTY)` (the query-time arm of `repo-scope-split`), the Linear `list_issues` label filter is an AND-of-labels and cannot express "current-repo **or** unlabeled" in one query. Adding `repo:<current>` to this query would strand unlabeled Issues the determine + stamp path must see. So the Linear scanner keeps this query broad and relies on the per-candidate 3a.0 gate below for repo scoping. (The `state` filter above is orthogonal to that — it narrows the lifecycle lane, not the repo, and is a single-valued equality so it has none of the AND-of-labels problem.)
 
-If empty, report `"No Linear Issues in state $READY. Nothing to do."` and exit. Common idle case.
+If every pre-work lane is empty, or nothing survives Phase 2.5, exit on the **denominator-stated** summary from `summarizeDryLane` — never a bare "nothing to do". See "Run outcome" below; the run recorder rejects a dry build-intake run that does not name what it swept.
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact**. It is written once and goes stale the moment its condition comes true — a dependency lands on trunk, an advisory gets patched, a package publishes. Nothing re-read one before this phase, so a discharged blocker held its Issue out of the queue indefinitely. Measured: one Issue's stated condition went true ~15 hours before anything noticed.
+
+For each pre-work candidate that is **not** in `$READY`:
+
+1. **Human gate first, and it is absolute.** An Issue carrying the configured human-needed label (`linear.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in its description is **never** auto-selected, whatever any probe says. Skip it and move on.
+2. **Extract the stated discharge condition** from the description or the most recent blocking comment — the sentence naming what has to become true.
+3. **Probe it.** Machine-testable conditions are the ones that rot fastest and are cheapest to check: a version on trunk (`git show origin/<trunk>:<manifest>`), a published package, a run history (`gh run list`), an advisory's patched status. A condition that is a human decision is not machine-testable — leave it and move on.
+4. **Classify with the shared helper** so the ordering and the evidence requirement cannot drift per vendor:
+
+```text
+classifyPreWorkCandidate({ laneType, labels, body, humanNeededLabel, statedBlocker, probe })
+  → { selectable, reason, humanGated, evidence }
+```
+
+   A discharge with **no recorded evidence is not a discharge** — the helper refuses it. So is a candidate nothing probed this cycle.
+
+5. **Record the result on the Issue either way**, via `lisa-linear-access operation: save-comment` using `formatReprobeNote(...)`, so the next cycle reads the answer rather than re-deriving it. Keep it idempotent — skip the post when an identical note already exists.
+6. **On `selectable: true`**, move the Issue to `$READY` (recording the discharging evidence in the same comment) and treat it as an ordinary candidate from Phase 3 onward. On anything else, leave the Issue exactly where it is.
 
 ### Phase 3 — Process the first eligible ready Issue
 
@@ -148,7 +189,7 @@ A Linear team can oversee multiple repos (`frontend` / `backend` / `infrastructu
    - **Unlabeled** → determine the target repo(s) from the Issue + code surfaces, then **stamp** `repo:<name>` via `lisa-linear-access operation: save-issue` (resolve/create the label via `list_issue_labels`/`create_issue_label`) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready Issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-tracker-build-intake/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-tracker-build-intake/SKILL.md
@@ -42,6 +42,30 @@ This is the claim-time arm of the rule. Its siblings are the write-time labeling
 
 The shim never needs to inspect the item itself — it forwards `$ARGUMENTS` verbatim and the resolved vendor scanner runs its Phase 3a gate before any claim.
 
+## Pre-work denominator contract (forwarded to every vendor)
+
+Also part of the build-intake API, and the reason a dry queue can be believed. Two obligations,
+uniform across `jira`, `github`, and `linear`:
+
+1. **Sweep every pre-work lane by its machine-readable category, never by a roster of lane names.**
+   No tracker has a `blocked` category: Linear models a `Blocked` state as `unstarted`, JIRA models
+   a `Blocked` status under `To Do`, and GitHub has no category at all, so its lanes come from
+   configured roles. In every case a `Blocked` lane is *pre-work* — items that were never started,
+   each carrying a written blocker. Keying selection on names omits it silently.
+2. **A `nothing-needed` run states its denominator** — which lanes were swept, how many rows each
+   held, and the total open. This is enforced, not requested: `automation-run-record.mjs` refuses a
+   `nothing-needed` row for `intake-tickets` without a `--denominator`.
+
+Shared helpers own both, so the vocabulary cannot drift per vendor:
+`scripts/intake-prework-denominator.mjs` (`buildIntakeDenominator`, `summarizeDryLane`) and
+`scripts/intake-blocker-reprobe.mjs` (`classifyPreWorkCandidate`, `formatReprobeNote`). The
+blocker re-probe carries an absolute human gate: an item carrying the configured human-needed label
+or a `[lisa-human-gate]` marker is never auto-selected, whatever a probe returns.
+
+Measured: sweeping one team by lane name saw 39 of 343 open rows; by category it sees 100. The
+61-row gap produced 31 consecutive false "dry lane" cycles, every record honest and every
+conclusion wrong (#2657).
+
 ## Repo-scope claim contract (forwarded to every vendor)
 
 Equally part of the build-intake API, and forwarded identically: when the tracker oversees multiple repos, each vendor scanner claims only tickets for the repo it is running in. Per the `repo-scope-split` rule's "Claim-time repo scoping" section, before the leaf-only gate each scanner (Phase 3a.0) resolves the current repo (`config-resolution` "Repo scoping": `repo` → `github.repo` → git remote basename), then for each ready candidate: skips a ticket labeled `repo:<other>`, determines + stamps `repo:<name>` on an unlabeled one, splits a multi-repo leaf into single-repo build-ready siblings, and claims only a single-repo leaf for the current repo. This shim does not re-implement the gate — it relies on the vendor scanner's Phase 3a.0 — but the contract is uniform across `jira`, `github`, and `linear` so behavior never drifts by tracker. It is the claim-time complement to the write-time S10 scope gate (`lisa-tracker-validate`) and `task-decomposition` step 1.5; all cite `repo-scope-split`.

--- a/plugins/lisa/rules/eager/automation-runbook-contract.md
+++ b/plugins/lisa/rules/eager/automation-runbook-contract.md
@@ -48,6 +48,8 @@ Exactly one per run:
 Health and operator action are **orthogonal** — a healthy run can still need an answer:
 
 - `nothing-needed` — the loop ran and found nothing to act on. **Healthy.** Operator action: none.
+  A queue scanner's `nothing-needed` summary must name the lanes it swept and the total open — a dry
+  queue and a wrong denominator are otherwise indistinguishable. See the reference body.
 - `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation). **Healthy.** Operator
   action: review the proposed item and flip it ready when you want it built.
 - `change-proved` — the loop made a change and proved it with evidence. **Healthy.** Operator

--- a/plugins/lisa/rules/reference/automation-runbook-contract.md
+++ b/plugins/lisa/rules/reference/automation-runbook-contract.md
@@ -120,6 +120,25 @@ recovery-required   Lost access to the tracker; filed #1812 with the one decisio
 policy-obsolete     No work has reached this queue in 30 days; proposed teardown in #1813.
 ```
 
+### `nothing-needed` states its denominator
+
+A queue-scanning loop that reports nothing is only as trustworthy as the set it looked at, and a
+summary of the form "scanned N items" hides the one thing worth checking: **which lanes N came
+from.** So a `nothing-needed` summary from a queue scanner names the lanes it swept, the count in
+each, and the total open — `Looked in every lane holding work that has not started — Backlog (20),
+Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open.`
+
+This is a measured requirement, not a style preference. One build lane reported 31 consecutive dry
+cycles over a queue holding 61 unswept rows, at least one of them buildable for ~15 hours. Every
+one of the 31 records was honest and every conclusion was false, because the scanner never said
+what its denominator was. **A missing run record is noisy on inspection; a wrong denominator is
+silent forever and looks exactly like a healthy dry queue.** Stating the swept set is what makes
+the second failure mode visible at all.
+
+The build-intake loop enforces this rather than requesting it: `automation-run-record.mjs` refuses
+a `nothing-needed` row for `intake-tickets` unless the call carries a `--denominator` built by
+`scripts/intake-prework-denominator.mjs`.
+
 **No silent exit.** Every run posts its outcome and its one-line summary before stopping —
 including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
 there is no silent exit for an operator to misread as health. A run that ends without a

--- a/plugins/lisa/scripts/automation-run-record.mjs
+++ b/plugins/lisa/scripts/automation-run-record.mjs
@@ -11,6 +11,8 @@ import path from "node:path";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { assertDenominatorReported } from "./intake-prework-denominator.mjs";
+
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
   "candidate-proposed",
@@ -55,6 +57,15 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
  */
 export async function recordAutomationRun(input) {
+  // Write path only. Stored rows are re-validated on read through
+  // `validateStoredRecord`, and a history written before this contract existed
+  // must stay readable — so the denominator gate lives here, where a NEW row is
+  // minted, and never on the read path.
+  assertDenominatorReported({
+    loopId: input.loopId,
+    outcome: input.outcome,
+    denominator: input.extras?.denominator,
+  });
   const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
   const maxEntries =
     input.maxEntries ??
@@ -303,14 +314,19 @@ async function writeJsonlAtomically(filePath, records) {
 const CLI_USAGE = `Usage: node automation-run-record.mjs \\
   --loop-id <slug> --outcome <${AUTOMATION_RUN_OUTCOMES.join("|")}> \\
   --summary "<operator-readable one-liner>" --runbook <path> \\
-  [--ref <url>]... [--run-id <id>] [--project-root <dir>]`;
+  [--ref <url>]... [--run-id <id>] [--project-root <dir>] \\
+  [--denominator '<json from buildIntakeDenominator()>']
+
+--denominator is REQUIRED for a "nothing-needed" run on a build-intake loop: a
+dry lane that does not say which lanes it looked in cannot be checked.`;
 
 /**
  * Translate a repeatable-flag argv into a {@link RecordAutomationRunInput}.
  *
  * Every flag takes a following value; `--ref` may repeat and accumulates into
- * `refs`. Unknown flags and value-less flags throw so a typo never silently
- * records the wrong thing.
+ * `refs`, and `--denominator` carries the swept-lane JSON into `extras`.
+ * Unknown flags and value-less flags throw so a typo never silently records the
+ * wrong thing.
  *
  * @param {readonly string[]} argv
  * @returns {RecordAutomationRunInput}
@@ -320,6 +336,8 @@ function parseAutomationRunRecordArgv(argv) {
   const single = {};
   /** @type {string[]} */
   const refs = [];
+  /** @type {Record<string, unknown>} */
+  const extras = {};
   const flags = {
     "--loop-id": "loopId",
     "--outcome": "outcome",
@@ -349,6 +367,10 @@ function parseAutomationRunRecordArgv(argv) {
       refs.push(takeValue());
       continue;
     }
+    if (flag === "--denominator") {
+      extras.denominator = parseDenominatorFlag(takeValue());
+      continue;
+    }
     const key = flags[flag];
     if (!key) {
       throw new Error(`Unknown flag "${flag}".`);
@@ -356,7 +378,21 @@ function parseAutomationRunRecordArgv(argv) {
     single[key] = takeValue();
   }
 
-  return { ...single, refs };
+  return { ...single, refs, extras };
+}
+
+/**
+ * @param {string} value
+ * @returns {unknown}
+ */
+function parseDenominatorFlag(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(
+      "--denominator must be JSON produced by buildIntakeDenominator()."
+    );
+  }
 }
 
 /**

--- a/plugins/lisa/scripts/intake-blocker-reprobe.mjs
+++ b/plugins/lisa/scripts/intake-blocker-reprobe.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Blocker re-probe gate for pre-work build-intake candidates.
+ *
+ * A blocker is a claim with a timestamp, not a fact. It is written once, and it
+ * decays the moment its condition goes true — a dependency lands on trunk, a
+ * CVE gets patched, a package publishes. Nothing in the old intake loop ever
+ * re-read one, so a discharged blocker held its item out of the queue forever.
+ *
+ * This module decides, per candidate, whether intake may select it. It never
+ * probes anything itself: the caller runs the probe and hands back the result,
+ * which keeps the decision auditable and testable apart from the network.
+ */
+
+import { isPreWorkLaneType } from "./intake-prework-denominator.mjs";
+
+/** Marker a writer stamps on an item a human deliberately parked. */
+export const HUMAN_GATE_MARKER = "[lisa-human-gate]";
+
+/** Default label naming a block only a human can clear. */
+export const DEFAULT_HUMAN_NEEDED_LABEL = "human-needed";
+
+/**
+ * @param {unknown} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabels(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label =>
+      typeof label === "string"
+        ? label
+        : typeof label?.name === "string"
+          ? label.name
+          : ""
+    )
+    .map(label => label.trim().toLowerCase())
+    .filter(label => label.length > 0);
+}
+
+/**
+ * @param {{ labels?: unknown, body?: unknown, humanNeededLabel?: unknown }} input
+ * @returns {boolean}
+ */
+function isHumanGated(input) {
+  const configured = String(
+    input.humanNeededLabel ?? DEFAULT_HUMAN_NEEDED_LABEL
+  )
+    .trim()
+    .toLowerCase();
+  if (
+    configured.length > 0 &&
+    normalizeLabels(input.labels).includes(configured)
+  ) {
+    return true;
+  }
+
+  return String(input.body ?? "").includes(HUMAN_GATE_MARKER);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function trimmedString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {{ discharged?: unknown, evidence?: unknown }} probe
+ * @returns {{ selectable: boolean, reason: string, evidence: string }}
+ */
+function judgeProbe(probe) {
+  const evidence = trimmedString(probe.evidence);
+
+  if (probe.discharged !== true) {
+    return {
+      selectable: false,
+      reason: "blocker-holds",
+      evidence,
+    };
+  }
+  if (evidence.length === 0) {
+    return {
+      selectable: false,
+      reason: "blocker-discharge-unevidenced",
+      evidence,
+    };
+  }
+
+  return { selectable: true, reason: "blocker-discharged", evidence };
+}
+
+/**
+ * Decide whether a pre-work item may be selected as a build candidate.
+ *
+ * Order is load-bearing. The human gate is checked before anything else, so no
+ * probe result — however conclusive — can promote an item a human parked.
+ *
+ * @param {{
+ *   laneType?: unknown
+ *   labels?: unknown
+ *   body?: unknown
+ *   humanNeededLabel?: unknown
+ *   statedBlocker?: unknown
+ *   probe?: { discharged?: unknown, evidence?: unknown } | null
+ * }} input
+ * @returns {{ selectable: boolean, reason: string, humanGated: boolean, evidence: string }}
+ */
+export function classifyPreWorkCandidate(input = {}) {
+  if (isHumanGated(input)) {
+    return {
+      selectable: false,
+      reason: "human-gate",
+      humanGated: true,
+      evidence: "",
+    };
+  }
+  if (!isPreWorkLaneType(input.laneType)) {
+    return {
+      selectable: false,
+      reason: "not-pre-work",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (trimmedString(input.statedBlocker).length === 0) {
+    return {
+      selectable: true,
+      reason: "no-blocker",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (!input.probe || typeof input.probe !== "object") {
+    return {
+      selectable: false,
+      reason: "blocker-unprobed",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+
+  return { ...judgeProbe(input.probe), humanGated: false };
+}
+
+/** Plain-English wording for each verdict, for the note left on the item. */
+const REASON_COPY = Object.freeze({
+  "human-gate": "A person parked this one on purpose, so intake left it alone.",
+  "not-pre-work": "This item is not sitting in a not-yet-started lane.",
+  "no-blocker": "No blocker was written on this item, so it is buildable.",
+  "blocker-unprobed":
+    "This item states a blocker that was not re-checked this cycle, so it stays put.",
+  "blocker-holds":
+    "The blocker was re-checked and still holds, so it stays put.",
+  "blocker-discharge-unevidenced":
+    "The blocker looked clear but no proof was recorded, so it stays put.",
+  "blocker-discharged":
+    "The blocker was re-checked and no longer applies, so this item is buildable again.",
+});
+
+/**
+ * Render the re-probe result to leave on the item, so the next cycle reads the
+ * answer instead of deriving it again.
+ *
+ * @param {{
+ *   statedBlocker?: unknown
+ *   checkedAt?: string | Date
+ * }} candidate
+ * @param {{ reason: string, evidence?: string }} verdict
+ * @returns {string}
+ */
+export function formatReprobeNote(candidate = {}, verdict) {
+  const checkedAt =
+    candidate.checkedAt instanceof Date
+      ? candidate.checkedAt.toISOString()
+      : trimmedString(candidate.checkedAt) || new Date().toISOString();
+  const lines = [
+    "**Blocker re-check**",
+    "",
+    `- What has to be true: ${trimmedString(candidate.statedBlocker) || "(none written on this item)"}`,
+    `- What we found: ${REASON_COPY[verdict.reason] ?? verdict.reason}`,
+  ];
+  const evidence = trimmedString(verdict.evidence);
+  if (evidence.length > 0) {
+    lines.push(`- Proof: ${evidence}`);
+  }
+  lines.push(`- Checked at: ${checkedAt}`);
+
+  return lines.join("\n");
+}

--- a/plugins/lisa/scripts/intake-prework-denominator.mjs
+++ b/plugins/lisa/scripts/intake-prework-denominator.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Pre-work denominator for build-queue intake scanners.
+ *
+ * A build-intake cycle that reports an empty lane is only as trustworthy as the
+ * set of lanes it swept. Sweeping by lane NAME (`Backlog`, `Todo`, `Ready`)
+ * omits every pre-work lane a team invented — most commonly a `Blocked` lane,
+ * which is not a distinct Linear state type at all: teams model it as
+ * `unstarted`, i.e. work that was never started. Items parked there carry a
+ * written blocker that nothing ever re-reads, so the lane reads as terminal
+ * while it is in fact a queue.
+ *
+ * This module fixes both halves: lanes are selected by TYPE, never by name, and
+ * the swept set is reported alongside the total so a wrong denominator is
+ * visible on inspection instead of silent forever.
+ */
+
+/** Lane types that hold work which has not started. Both belong to intake. */
+export const PRE_WORK_LANE_TYPES = Object.freeze(["backlog", "unstarted"]);
+
+/** Loop ids whose `nothing-needed` runs must state their denominator. */
+export const DENOMINATOR_REQUIRED_LOOP_IDS = Object.freeze(["intake-tickets"]);
+
+/**
+ * Vendor lane-type vocabularies normalized onto Linear's five-value type set.
+ * JIRA exposes the same idea as `statusCategory` (key or display name); GitHub
+ * has no type field at all, so its callers pass a type explicitly.
+ */
+const LANE_TYPE_ALIASES = Object.freeze({
+  backlog: "backlog",
+  unstarted: "unstarted",
+  started: "started",
+  completed: "completed",
+  canceled: "canceled",
+  cancelled: "canceled",
+  new: "unstarted",
+  indeterminate: "started",
+  done: "completed",
+  "to do": "unstarted",
+  "in progress": "started",
+});
+
+/**
+ * Map a vendor lane type onto the normalized vocabulary.
+ *
+ * @param {unknown} type
+ * @returns {string | null} normalized type, or null when unrecognized
+ */
+export function normalizeLaneType(type) {
+  if (typeof type !== "string") {
+    return null;
+  }
+  return LANE_TYPE_ALIASES[type.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * @param {unknown} type
+ * @returns {boolean} whether this lane holds not-yet-started work
+ */
+export function isPreWorkLaneType(type) {
+  const normalized = normalizeLaneType(type);
+  return normalized !== null && PRE_WORK_LANE_TYPES.includes(normalized);
+}
+
+/**
+ * @param {unknown} lane
+ * @returns {{ name: string, type: string | null, count: number, position: number } | null}
+ */
+function normalizeLane(lane) {
+  if (!lane || typeof lane !== "object") {
+    return null;
+  }
+  const name = String(lane.name ?? "").trim();
+  if (name.length === 0) {
+    return null;
+  }
+  const rawCount = Number(lane.count ?? 0);
+  const rawPosition = Number(lane.position ?? Number.POSITIVE_INFINITY);
+
+  return {
+    name,
+    type: normalizeLaneType(lane.type ?? lane.statusCategory),
+    count: Number.isFinite(rawCount) && rawCount > 0 ? Math.trunc(rawCount) : 0,
+    position: Number.isFinite(rawPosition)
+      ? rawPosition
+      : Number.POSITIVE_INFINITY,
+  };
+}
+
+/**
+ * @param {{ position: number, name: string }} left
+ * @param {{ position: number, name: string }} right
+ * @returns {number}
+ */
+function compareLanes(left, right) {
+  if (left.position !== right.position) {
+    return left.position - right.position;
+  }
+  return left.name.localeCompare(right.name);
+}
+
+/**
+ * Select every lane holding not-yet-started work, by type.
+ *
+ * Deliberately name-blind: a team that adds `Blocked`, `Triaged`, or `Icebox`
+ * as an `unstarted` state gets it swept without a code change, and no hardcoded
+ * roster can fall behind the board.
+ *
+ * @param {readonly unknown[]} lanes
+ * @returns {readonly {name: string, type: string, count: number, position: number}[]}
+ */
+export function selectPreWorkLanes(lanes) {
+  return (Array.isArray(lanes) ? lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null && isPreWorkLaneType(lane.type))
+    .sort(compareLanes);
+}
+
+/**
+ * Build the denominator a scanner must report with its verdict.
+ *
+ * `totalOpen` is the count of open items on the queue, independent of lanes —
+ * supplying it is what makes an omitted lane arithmetically visible.
+ *
+ * @param {{ lanes?: readonly unknown[], totalOpen?: number }} input
+ * @returns {{
+ *   swept: readonly {name: string, type: string, count: number}[]
+ *   omitted: readonly {name: string, type: string | null, count: number}[]
+ *   sweptCount: number
+ *   totalOpen: number
+ *   unsweptCount: number
+ * }}
+ */
+export function buildIntakeDenominator(input = {}) {
+  const normalized = (Array.isArray(input.lanes) ? input.lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null)
+    .sort(compareLanes);
+  const swept = normalized.filter(lane => isPreWorkLaneType(lane.type));
+  const omitted = normalized.filter(lane => !isPreWorkLaneType(lane.type));
+  const sweptCount = swept.reduce((total, lane) => total + lane.count, 0);
+  const laneTotal = normalized.reduce((total, lane) => total + lane.count, 0);
+  const rawTotalOpen = Number(input.totalOpen);
+  const totalOpen =
+    Number.isFinite(rawTotalOpen) && rawTotalOpen >= 0
+      ? Math.trunc(rawTotalOpen)
+      : laneTotal;
+
+  return {
+    swept: swept.map(({ name, type, count }) => ({ name, type, count })),
+    omitted: omitted.map(({ name, type, count }) => ({ name, type, count })),
+    sweptCount,
+    totalOpen,
+    unsweptCount: Math.max(totalOpen - sweptCount, 0),
+  };
+}
+
+/**
+ * Render the denominator for a non-technical operator.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @returns {string}
+ */
+export function formatIntakeDenominator(denominator) {
+  const lanes = denominator?.swept ?? [];
+  const listed =
+    lanes.length > 0
+      ? lanes.map(lane => `${lane.name} (${lane.count})`).join(", ")
+      : "no pre-work lanes found";
+
+  return `Looked in every lane holding work that has not started — ${listed} — ${denominator.sweptCount} items checked out of ${denominator.totalOpen} still open.`;
+}
+
+/**
+ * Render the full operator-readable one-liner for a dry build lane.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @param {{ queue?: string }} [context]
+ * @returns {string}
+ */
+export function summarizeDryLane(denominator, context = {}) {
+  const queue =
+    typeof context.queue === "string" && context.queue.trim().length > 0
+      ? ` on ${context.queue.trim()}`
+      : "";
+
+  return `Nothing ready to build${queue}. ${formatIntakeDenominator(denominator)}`;
+}
+
+/**
+ * @param {unknown} loopId
+ * @param {unknown} outcome
+ * @returns {boolean} whether this run must carry a denominator
+ */
+export function requiresDenominator(loopId, outcome) {
+  return (
+    outcome === "nothing-needed" &&
+    DENOMINATOR_REQUIRED_LOOP_IDS.includes(String(loopId ?? "").trim())
+  );
+}
+
+/**
+ * @param {unknown} denominator
+ * @returns {string | null} the reason it is unusable, or null when valid
+ */
+function findDenominatorDefect(denominator) {
+  if (!denominator || typeof denominator !== "object") {
+    return "no denominator was supplied";
+  }
+  if (!Array.isArray(denominator.swept) || denominator.swept.length === 0) {
+    return "it names no swept lanes";
+  }
+  if (!Number.isInteger(denominator.sweptCount)) {
+    return "its swept count is not a whole number";
+  }
+  if (!Number.isInteger(denominator.totalOpen)) {
+    return "its open-item total is not a whole number";
+  }
+  if (denominator.sweptCount > denominator.totalOpen) {
+    return "it claims to have swept more items than are open";
+  }
+  return null;
+}
+
+/**
+ * Refuse to record a dry build lane that does not say what it looked at.
+ *
+ * Thirty-one consecutive cycles reported an empty lane against a queue holding
+ * unswept pre-work rows. Every record was honest and every conclusion was
+ * false, because none of them stated a denominator. This turns that silent
+ * wrong answer into a loud one.
+ *
+ * @param {{ loopId?: unknown, outcome?: unknown, denominator?: unknown }} input
+ * @throws {Error} when a denominator is required and missing or malformed
+ */
+export function assertDenominatorReported(input = {}) {
+  if (!requiresDenominator(input.loopId, input.outcome)) {
+    return;
+  }
+  const defect = findDenominatorDefect(input.denominator);
+  if (defect === null) {
+    return;
+  }
+
+  throw new Error(
+    `A "nothing-needed" run for loop "${String(input.loopId).trim()}" must state the lanes it swept, and ${defect}. ` +
+      `Pass a denominator built by buildIntakeDenominator() so an omitted lane is visible instead of silent.`
+  );
+}

--- a/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-github-build-intake/SKILL.md
@@ -110,7 +110,7 @@ The only legitimate reasons to stop early:
 
 - Missing repo or required configuration. Surface the missing value and exit.
 - Label namespace not adopted (no issue carries any of `$READY` / `$CLAIMED` / `$DONE`). Surface a label-convention error and exit (this is setup, not a normal idle cycle — see "Adoption" at the bottom).
-- Empty ready set. Exit cleanly with `"No GitHub issues labeled $READY in <org>/<repo>. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -166,7 +166,57 @@ gh label list --repo <org>/<repo> --json name \
       '[.[] | .name | select(. == $r or . == $c or (. as $n | $d | index($n)))] | length'
 ```
 
-If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
+If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit.
+
+#### 2a. Sweep every pre-work lane, and state the denominator
+
+GitHub Issues has no state-type field, so labels are the only lane available here — a constraint of
+GitHub's data model, not a preference (see "Why labels" above). That makes the omission risk
+*higher*, not lower: there is no `type` to fall back on, so the pre-work set must be derived from
+**configured roles**, never from a hardcoded roster of label names. The pre-work lanes are:
+
+- the configured `$READY` label — the human-flipped lane, worked first;
+- the configured `$BLOCKED` label (`github.labels.build.blocked`) — items that were *never started*,
+  each carrying a written blocker that nothing re-read until Phase 2.5;
+- open issues carrying **no** build role label — which this scanner must see anyway in order to
+  determine and stamp their repo.
+
+Count each lane and the repo's **total open** count (`gh issue list --state open --limit 1000 --json
+number | jq length`), then build the denominator with the shared helper — GitHub callers pass the
+lane type explicitly, since there is none to read:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "$READY", type: "unstarted", count: <n>},
+                                 {name: "$BLOCKED", type: "unstarted", count: <n>},
+                                 {name: "(no role label)", type: "backlog", count: <n>},
+                                 {name: "$CLAIMED", type: "started", count: <n>}, …],
+                         totalOpen: <open issue count> })
+summarizeDryLane(denominator, { queue: "<org>/<repo>" })
+```
+
+Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all. If
+nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a bare
+"nothing to do". The run recorder rejects a dry build-intake run that does not name what it swept
+(see `automation-runbook-contract`).
+
+#### 2a.1 Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each `$BLOCKED` candidate:
+
+1. **Human gate first, and it is absolute.** An issue carrying the configured human-needed label
+   (`github.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in
+   its body is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from `scripts/intake-blocker-reprobe.mjs`. A
+   discharge with no recorded evidence is not a discharge, and neither is a candidate nothing
+   probed this cycle — the helper refuses both.
+4. **Record the result on the issue either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, relabel `$BLOCKED → $READY` with the discharging evidence in the same
+   comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 #### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
 
@@ -251,7 +301,7 @@ GitHub Issues live in one repo by definition, so the scanned repo's issues are u
    - **Container visibility is allowed.** A multi-repo Epic / Story / Spike may legitimately carry multiple `repo:<name>` labels for operator visibility. Do not split or claim it here; leave the repo markers intact and fall through to the leaf-only gate, which repairs the stale build-ready label instead of dispatching the container.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (repair containers)
 

--- a/plugins/lisa/skills/lisa-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-intake/SKILL.md
@@ -126,7 +126,7 @@ matches the mode this cycle ran in: **`intake-prd`** (PRD-side dispatch) or **`i
 
 | This cycle's exit path | Run outcome |
 |---|---|
-| Empty `Ready` set — the idle case (step 3), nothing to claim | `nothing-needed` |
+| Empty pre-work set — the idle case (step 3), nothing to claim. **Must state its denominator** (see below) | `nothing-needed` |
 | A PRD routed to `Blocked` (clarifying questions) or `Ticketed`; a build ticket claimed and dispatched | `candidate-proposed` |
 | A build cycle that shipped and verified (merged PR + evidence), or a shipped PRD moved to `verified` | `change-proved` |
 | A protected deployment (or other autonomy boundary the lifecycle hits) waiting on a human approval | `approval-requested` |
@@ -149,6 +149,22 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
   --loop-id intake-tickets --outcome candidate-proposed \
   --summary "Routed PRD #1810 to Blocked with clarifying questions; the run succeeded." \
   --runbook .lisa/automations/intake-tickets.runbook.md [--ref <item-url>]...
+```
+
+**A dry build lane must say what it looked in.** A `nothing-needed` run on `intake-tickets`
+additionally passes `--denominator` — the JSON from `buildIntakeDenominator()` in
+`scripts/intake-prework-denominator.mjs` — and the recorder **refuses the row without it**. This is
+not decoration: 31 consecutive cycles reported a dry lane against a queue holding 61 unswept
+pre-work rows, and every one of those records was honest. A missing row is noisy on inspection; a
+wrong denominator is silent forever and looks exactly like a healthy dry queue. Stating the swept
+set is what turns the silent wrong answer into an inspectable one (#2657).
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
+  --loop-id intake-tickets --outcome nothing-needed \
+  --summary "Nothing ready to build on team ENG. Looked in every lane holding work that has not started — Backlog (20), Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open." \
+  --denominator "$DENOMINATOR_JSON" \
+  --runbook .lisa/automations/intake-tickets.runbook.md
 ```
 
 If `${CLAUDE_PLUGIN_ROOT}` is unset, resolve the plugin scripts directory directly — the built copy

--- a/plugins/lisa/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-jira-build-intake/SKILL.md
@@ -85,7 +85,7 @@ The only legitimate reasons to stop early:
 
 - Missing project key / JQL or required configuration. Surface the missing value and exit.
 - Workflow misconfigured (pre-flight check finds `$CLAIMED` or `$DONE` not reachable, or `$READY` status absent). Surface and exit.
-- Empty ready set. Exit cleanly with `"No tickets with Status=$READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -130,11 +130,59 @@ JQL="${BASE_JQL} ORDER BY priority DESC, created ASC"
 
 4. Confirm the configured Atlassian site by invoking `lisa-atlassian-access` `operation: list-sites` (it enforces connection match against `.lisa.config.json`).
 
-### Phase 2 — Find ready tickets
+### Phase 2 — Sweep every pre-work status by CATEGORY
 
-Invoke `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), labels, components.
+**Sweep by `statusCategory`, never by a roster of status names.** JIRA groups statuses into three
+categories — `To Do` (`new`), `In Progress` (`indeterminate`), `Done` (`done`) — and a `Blocked`
+status is not a fourth category: a project that wants one models it under **`To Do`**, i.e. work
+that was never started. Keying the candidate set on status *names* therefore omits every pre-work
+lane a project invented, and the scanner reports an empty queue over a full one. The same defect on
+the Linear side produced 31 consecutive false "dry lane" cycles (#2657).
 
-If empty, report `"No tickets with Status=$READY. Nothing to do."` and exit. This is the common idle case.
+1. Run the ready query first: `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. This
+   is the human-flipped lane and it is worked first.
+2. Then sweep the rest of pre-work with the same base JQL, swapping the status clause for
+   `statusCategory = "To Do"`, and read the **total open** count (`statusCategory != Done`). The
+   open total is what makes an omitted lane arithmetically visible.
+3. Page to exhaustion — a single unpaged `search-issues` call is not a count.
+
+Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), status (with
+its category), labels, components.
+
+Build the denominator with the shared helper, which owns the pre-work vocabulary so no two
+scanners can disagree about what counts:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "<status>", type: "<statusCategory>", count: <rows>}, …],
+                         totalOpen: <statusCategory != Done count> })
+summarizeDryLane(denominator, { queue: "<project key>" })
+```
+
+The helper accepts JIRA's category vocabulary directly (`new` / `To Do` normalize to pre-work).
+
+**Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at
+all.** If nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a
+bare "nothing to do". The run recorder rejects a dry build-intake run that does not name what it
+swept (see `automation-runbook-contract`).
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each pre-work candidate outside `$READY`:
+
+1. **Human gate first, and it is absolute.** A ticket carrying the configured human-needed label
+   (`jira.labels.human_needed`, default `Human Needed`) or a `[lisa-human-gate]` marker in its
+   description is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from
+   `scripts/intake-blocker-reprobe.mjs`. A discharge with no recorded evidence is not a discharge,
+   and neither is a candidate nothing probed this cycle — the helper refuses both.
+4. **Record the result on the ticket either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, transition the ticket to `$READY` with the discharging evidence in the
+   same comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 ### Phase 3 — Process the first eligible ready ticket
 
@@ -149,7 +197,7 @@ A JIRA project can oversee multiple repos (`frontend` / `backend` / `infrastruct
    - **Unlabeled** → determine the target repo(s) from the ticket (description, AC, technical approach) confirmed against the code surfaces, then **stamp** `repo:<name>` via `lisa-atlassian-access` `operation: write-ticket` (add the label / set the component) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure to break it into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready tickets for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-linear-build-intake/SKILL.md
@@ -99,7 +99,7 @@ The only legitimate reasons to stop early:
 
 - Missing team key or required configuration. Surface and exit.
 - Workflow states not yet adopted (the `ready` state does not exist on the team). Surface and exit with an Adoption hint pointing at `/lisa:setup:linear`.
-- Empty ready set. Exit cleanly with `"No Linear Issues in state $READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -112,7 +112,7 @@ ready → claimed → review → done(env-keyed) (downstream)
 
 (Defaults: `Ready` / `In Progress` / `In Review` / `On Dev`/`On Stg`/`Done`.)
 
-This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done`, `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`), or `$BLOCKED` (owned by the pre-flight gate).
+This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done` or `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`). It never *sets* `$BLOCKED` either — that stays owned by the pre-flight gate — but Phase 2.5 does move an Issue **out** of a pre-work blocked lane back to `$READY` when it re-probes the Issue's own stated discharge condition and finds it no longer holds, recording the discharging evidence on the Issue.
 
 **Pre-flight check**: at start of each cycle, confirm `$READY`, `$CLAIMED`, and the relevant `$DONE` variants exist on the team via `lisa-linear-access operation: list-workflow-states`. If `$READY` is missing, stop and report adoption needed. **Unlike labels, a missing state cannot be created on demand here** — a workflow state is team configuration with a `type` and a board position, and guessing either would put an Issue somewhere a human did not sanction. Any missing state is a setup defect: report it, name the role and the expected state, and point at `/lisa:setup:linear`.
 
@@ -125,15 +125,56 @@ This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $D
    - Literal `linear` → fall back to `linear.teamKey` from config.
 2. Resolve team ID via `lisa-linear-access operation: list-teams({query: <teamKey>})`.
 
-### Phase 2 — Find ready Issues
+### Phase 2 — Sweep every pre-work lane by state TYPE
 
-Query: `lisa-linear-access operation: list-issues({team: <teamId>, state: "$READY"})`.
+**Sweep by `type`, never by a roster of state names.** Linear state types are `backlog | unstarted | started | completed | canceled`, and there is no `blocked` type — a team that wants a `Blocked` lane models it as **`unstarted`**, i.e. work that was *never started*. Selecting candidates from a hardcoded `Backlog / Todo / Ready` name list therefore omits an entire pre-work lane and reports an empty queue over a full one. Measured on one team: the name sweep saw **39 of 343 open rows**; the type sweep sees **100**, and the 61-row difference produced 31 consecutive false "dry lane" cycles (#2657).
 
-Capture each Issue's: identifier, title, type label, priority, assignee, project, state, labels, description summary.
+1. List the team's workflow states via `lisa-linear-access operation: list-workflow-states`.
+2. Keep every state whose `type` is `backlog` or `unstarted` — that is the pre-work set. `$READY` is one member of it, not the whole of it.
+3. Query each pre-work state: `lisa-linear-access operation: list-issues({team: <teamId>, state: "<state>"})`, paging to `hasNextPage=false`. Linear's GraphQL complexity ceiling silently truncates at `first: 250`, so a single unpaged call is not a count.
+4. Also read the **total open** count for the team (every state whose `type` is not `completed` / `canceled`). This number is what makes an omitted lane arithmetically visible.
+
+Capture each Issue's: identifier, title, type label, priority, assignee, project, state (with its `type`), labels, description summary.
+
+Build the denominator with the shared helper, which owns the type vocabulary so no two scanners can disagree about what counts as pre-work:
+
+```bash
+node -e '
+import("'"${CLAUDE_PLUGIN_ROOT:-plugins/src/base}"'/scripts/intake-prework-denominator.mjs").then(m => {
+  const d = m.buildIntakeDenominator({ lanes: JSON.parse(process.argv[1]), totalOpen: Number(process.argv[2]) });
+  console.log(JSON.stringify(d));
+  console.log(m.summarizeDryLane(d, { queue: process.argv[3] }));
+});' "$LANES_JSON" "$TOTAL_OPEN" "team $TEAM_KEY"
+```
+
+`$LANES_JSON` is `[{"name":"<state>","type":"<state.type>","position":<state.position>,"count":<open rows>}, …]` for **every** state on the team, pre-work and not — the helper does the selecting.
+
+**Candidate order.** Work `$READY` first (it is the human-flipped signal), then the remaining pre-work lanes oldest-first. Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all.
 
 > **No query-time repo pre-filter here (by design).** Unlike `lisa-jira-build-intake`, which narrows its JQL with `AND (labels = "repo:<current>" OR labels IS EMPTY)` (the query-time arm of `repo-scope-split`), the Linear `list_issues` label filter is an AND-of-labels and cannot express "current-repo **or** unlabeled" in one query. Adding `repo:<current>` to this query would strand unlabeled Issues the determine + stamp path must see. So the Linear scanner keeps this query broad and relies on the per-candidate 3a.0 gate below for repo scoping. (The `state` filter above is orthogonal to that — it narrows the lifecycle lane, not the repo, and is a single-valued equality so it has none of the AND-of-labels problem.)
 
-If empty, report `"No Linear Issues in state $READY. Nothing to do."` and exit. Common idle case.
+If every pre-work lane is empty, or nothing survives Phase 2.5, exit on the **denominator-stated** summary from `summarizeDryLane` — never a bare "nothing to do". See "Run outcome" below; the run recorder rejects a dry build-intake run that does not name what it swept.
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact**. It is written once and goes stale the moment its condition comes true — a dependency lands on trunk, an advisory gets patched, a package publishes. Nothing re-read one before this phase, so a discharged blocker held its Issue out of the queue indefinitely. Measured: one Issue's stated condition went true ~15 hours before anything noticed.
+
+For each pre-work candidate that is **not** in `$READY`:
+
+1. **Human gate first, and it is absolute.** An Issue carrying the configured human-needed label (`linear.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in its description is **never** auto-selected, whatever any probe says. Skip it and move on.
+2. **Extract the stated discharge condition** from the description or the most recent blocking comment — the sentence naming what has to become true.
+3. **Probe it.** Machine-testable conditions are the ones that rot fastest and are cheapest to check: a version on trunk (`git show origin/<trunk>:<manifest>`), a published package, a run history (`gh run list`), an advisory's patched status. A condition that is a human decision is not machine-testable — leave it and move on.
+4. **Classify with the shared helper** so the ordering and the evidence requirement cannot drift per vendor:
+
+```text
+classifyPreWorkCandidate({ laneType, labels, body, humanNeededLabel, statedBlocker, probe })
+  → { selectable, reason, humanGated, evidence }
+```
+
+   A discharge with **no recorded evidence is not a discharge** — the helper refuses it. So is a candidate nothing probed this cycle.
+
+5. **Record the result on the Issue either way**, via `lisa-linear-access operation: save-comment` using `formatReprobeNote(...)`, so the next cycle reads the answer rather than re-deriving it. Keep it idempotent — skip the post when an identical note already exists.
+6. **On `selectable: true`**, move the Issue to `$READY` (recording the discharging evidence in the same comment) and treat it as an ordinary candidate from Phase 3 onward. On anything else, leave the Issue exactly where it is.
 
 ### Phase 3 — Process the first eligible ready Issue
 
@@ -148,7 +189,7 @@ A Linear team can oversee multiple repos (`frontend` / `backend` / `infrastructu
    - **Unlabeled** → determine the target repo(s) from the Issue + code surfaces, then **stamp** `repo:<name>` via `lisa-linear-access operation: save-issue` (resolve/create the label via `list_issue_labels`/`create_issue_label`) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready Issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/lisa/skills/lisa-tracker-build-intake/SKILL.md
+++ b/plugins/lisa/skills/lisa-tracker-build-intake/SKILL.md
@@ -42,6 +42,30 @@ This is the claim-time arm of the rule. Its siblings are the write-time labeling
 
 The shim never needs to inspect the item itself — it forwards `$ARGUMENTS` verbatim and the resolved vendor scanner runs its Phase 3a gate before any claim.
 
+## Pre-work denominator contract (forwarded to every vendor)
+
+Also part of the build-intake API, and the reason a dry queue can be believed. Two obligations,
+uniform across `jira`, `github`, and `linear`:
+
+1. **Sweep every pre-work lane by its machine-readable category, never by a roster of lane names.**
+   No tracker has a `blocked` category: Linear models a `Blocked` state as `unstarted`, JIRA models
+   a `Blocked` status under `To Do`, and GitHub has no category at all, so its lanes come from
+   configured roles. In every case a `Blocked` lane is *pre-work* — items that were never started,
+   each carrying a written blocker. Keying selection on names omits it silently.
+2. **A `nothing-needed` run states its denominator** — which lanes were swept, how many rows each
+   held, and the total open. This is enforced, not requested: `automation-run-record.mjs` refuses a
+   `nothing-needed` row for `intake-tickets` without a `--denominator`.
+
+Shared helpers own both, so the vocabulary cannot drift per vendor:
+`scripts/intake-prework-denominator.mjs` (`buildIntakeDenominator`, `summarizeDryLane`) and
+`scripts/intake-blocker-reprobe.mjs` (`classifyPreWorkCandidate`, `formatReprobeNote`). The
+blocker re-probe carries an absolute human gate: an item carrying the configured human-needed label
+or a `[lisa-human-gate]` marker is never auto-selected, whatever a probe returns.
+
+Measured: sweeping one team by lane name saw 39 of 343 open rows; by category it sees 100. The
+61-row gap produced 31 consecutive false "dry lane" cycles, every record honest and every
+conclusion wrong (#2657).
+
 ## Repo-scope claim contract (forwarded to every vendor)
 
 Equally part of the build-intake API, and forwarded identically: when the tracker oversees multiple repos, each vendor scanner claims only tickets for the repo it is running in. Per the `repo-scope-split` rule's "Claim-time repo scoping" section, before the leaf-only gate each scanner (Phase 3a.0) resolves the current repo (`config-resolution` "Repo scoping": `repo` → `github.repo` → git remote basename), then for each ready candidate: skips a ticket labeled `repo:<other>`, determines + stamps `repo:<name>` on an unlabeled one, splits a multi-repo leaf into single-repo build-ready siblings, and claims only a single-repo leaf for the current repo. This shim does not re-implement the gate — it relies on the vendor scanner's Phase 3a.0 — but the contract is uniform across `jira`, `github`, and `linear` so behavior never drifts by tracker. It is the claim-time complement to the write-time S10 scope gate (`lisa-tracker-validate`) and `task-decomposition` step 1.5; all cite `repo-scope-split`.

--- a/plugins/src/base/rules/eager/automation-runbook-contract.md
+++ b/plugins/src/base/rules/eager/automation-runbook-contract.md
@@ -48,6 +48,8 @@ Exactly one per run:
 Health and operator action are **orthogonal** — a healthy run can still need an answer:
 
 - `nothing-needed` — the loop ran and found nothing to act on. **Healthy.** Operator action: none.
+  A queue scanner's `nothing-needed` summary must name the lanes it swept and the total open — a dry
+  queue and a wrong denominator are otherwise indistinguishable. See the reference body.
 - `candidate-proposed` — the loop proposed work (ticket, PRD, recommendation). **Healthy.** Operator
   action: review the proposed item and flip it ready when you want it built.
 - `change-proved` — the loop made a change and proved it with evidence. **Healthy.** Operator

--- a/plugins/src/base/rules/reference/automation-runbook-contract.md
+++ b/plugins/src/base/rules/reference/automation-runbook-contract.md
@@ -120,6 +120,25 @@ recovery-required   Lost access to the tracker; filed #1812 with the one decisio
 policy-obsolete     No work has reached this queue in 30 days; proposed teardown in #1813.
 ```
 
+### `nothing-needed` states its denominator
+
+A queue-scanning loop that reports nothing is only as trustworthy as the set it looked at, and a
+summary of the form "scanned N items" hides the one thing worth checking: **which lanes N came
+from.** So a `nothing-needed` summary from a queue scanner names the lanes it swept, the count in
+each, and the total open — `Looked in every lane holding work that has not started — Backlog (20),
+Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open.`
+
+This is a measured requirement, not a style preference. One build lane reported 31 consecutive dry
+cycles over a queue holding 61 unswept rows, at least one of them buildable for ~15 hours. Every
+one of the 31 records was honest and every conclusion was false, because the scanner never said
+what its denominator was. **A missing run record is noisy on inspection; a wrong denominator is
+silent forever and looks exactly like a healthy dry queue.** Stating the swept set is what makes
+the second failure mode visible at all.
+
+The build-intake loop enforces this rather than requesting it: `automation-run-record.mjs` refuses
+a `nothing-needed` row for `intake-tickets` unless the call carries a `--denominator` built by
+`scripts/intake-prework-denominator.mjs`.
+
 **No silent exit.** Every run posts its outcome and its one-line summary before stopping —
 including the trivial early terminations (empty queue, nothing eligible, already-claimed) — so
 there is no silent exit for an operator to misread as health. A run that ends without a

--- a/plugins/src/base/scripts/automation-run-record.mjs
+++ b/plugins/src/base/scripts/automation-run-record.mjs
@@ -11,6 +11,8 @@ import path from "node:path";
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
+import { assertDenominatorReported } from "./intake-prework-denominator.mjs";
+
 export const AUTOMATION_RUN_OUTCOMES = [
   "nothing-needed",
   "candidate-proposed",
@@ -55,6 +57,15 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  * @returns {Promise<{ readonly path: string, readonly record: AutomationRunRecord, readonly records: readonly AutomationRunRecord[], readonly appended: boolean, readonly skippedCorruptLines: number, readonly maxEntries: number }>}
  */
 export async function recordAutomationRun(input) {
+  // Write path only. Stored rows are re-validated on read through
+  // `validateStoredRecord`, and a history written before this contract existed
+  // must stay readable — so the denominator gate lives here, where a NEW row is
+  // minted, and never on the read path.
+  assertDenominatorReported({
+    loopId: input.loopId,
+    outcome: input.outcome,
+    denominator: input.extras?.denominator,
+  });
   const projectRoot = path.resolve(input.projectRoot ?? process.cwd());
   const maxEntries =
     input.maxEntries ??
@@ -303,14 +314,19 @@ async function writeJsonlAtomically(filePath, records) {
 const CLI_USAGE = `Usage: node automation-run-record.mjs \\
   --loop-id <slug> --outcome <${AUTOMATION_RUN_OUTCOMES.join("|")}> \\
   --summary "<operator-readable one-liner>" --runbook <path> \\
-  [--ref <url>]... [--run-id <id>] [--project-root <dir>]`;
+  [--ref <url>]... [--run-id <id>] [--project-root <dir>] \\
+  [--denominator '<json from buildIntakeDenominator()>']
+
+--denominator is REQUIRED for a "nothing-needed" run on a build-intake loop: a
+dry lane that does not say which lanes it looked in cannot be checked.`;
 
 /**
  * Translate a repeatable-flag argv into a {@link RecordAutomationRunInput}.
  *
  * Every flag takes a following value; `--ref` may repeat and accumulates into
- * `refs`. Unknown flags and value-less flags throw so a typo never silently
- * records the wrong thing.
+ * `refs`, and `--denominator` carries the swept-lane JSON into `extras`.
+ * Unknown flags and value-less flags throw so a typo never silently records the
+ * wrong thing.
  *
  * @param {readonly string[]} argv
  * @returns {RecordAutomationRunInput}
@@ -320,6 +336,8 @@ function parseAutomationRunRecordArgv(argv) {
   const single = {};
   /** @type {string[]} */
   const refs = [];
+  /** @type {Record<string, unknown>} */
+  const extras = {};
   const flags = {
     "--loop-id": "loopId",
     "--outcome": "outcome",
@@ -349,6 +367,10 @@ function parseAutomationRunRecordArgv(argv) {
       refs.push(takeValue());
       continue;
     }
+    if (flag === "--denominator") {
+      extras.denominator = parseDenominatorFlag(takeValue());
+      continue;
+    }
     const key = flags[flag];
     if (!key) {
       throw new Error(`Unknown flag "${flag}".`);
@@ -356,7 +378,21 @@ function parseAutomationRunRecordArgv(argv) {
     single[key] = takeValue();
   }
 
-  return { ...single, refs };
+  return { ...single, refs, extras };
+}
+
+/**
+ * @param {string} value
+ * @returns {unknown}
+ */
+function parseDenominatorFlag(value) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(
+      "--denominator must be JSON produced by buildIntakeDenominator()."
+    );
+  }
 }
 
 /**

--- a/plugins/src/base/scripts/intake-blocker-reprobe.mjs
+++ b/plugins/src/base/scripts/intake-blocker-reprobe.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * Blocker re-probe gate for pre-work build-intake candidates.
+ *
+ * A blocker is a claim with a timestamp, not a fact. It is written once, and it
+ * decays the moment its condition goes true — a dependency lands on trunk, a
+ * CVE gets patched, a package publishes. Nothing in the old intake loop ever
+ * re-read one, so a discharged blocker held its item out of the queue forever.
+ *
+ * This module decides, per candidate, whether intake may select it. It never
+ * probes anything itself: the caller runs the probe and hands back the result,
+ * which keeps the decision auditable and testable apart from the network.
+ */
+
+import { isPreWorkLaneType } from "./intake-prework-denominator.mjs";
+
+/** Marker a writer stamps on an item a human deliberately parked. */
+export const HUMAN_GATE_MARKER = "[lisa-human-gate]";
+
+/** Default label naming a block only a human can clear. */
+export const DEFAULT_HUMAN_NEEDED_LABEL = "human-needed";
+
+/**
+ * @param {unknown} labels
+ * @returns {readonly string[]}
+ */
+function normalizeLabels(labels) {
+  return (Array.isArray(labels) ? labels : [])
+    .map(label =>
+      typeof label === "string"
+        ? label
+        : typeof label?.name === "string"
+          ? label.name
+          : ""
+    )
+    .map(label => label.trim().toLowerCase())
+    .filter(label => label.length > 0);
+}
+
+/**
+ * @param {{ labels?: unknown, body?: unknown, humanNeededLabel?: unknown }} input
+ * @returns {boolean}
+ */
+function isHumanGated(input) {
+  const configured = String(
+    input.humanNeededLabel ?? DEFAULT_HUMAN_NEEDED_LABEL
+  )
+    .trim()
+    .toLowerCase();
+  if (
+    configured.length > 0 &&
+    normalizeLabels(input.labels).includes(configured)
+  ) {
+    return true;
+  }
+
+  return String(input.body ?? "").includes(HUMAN_GATE_MARKER);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string}
+ */
+function trimmedString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * @param {{ discharged?: unknown, evidence?: unknown }} probe
+ * @returns {{ selectable: boolean, reason: string, evidence: string }}
+ */
+function judgeProbe(probe) {
+  const evidence = trimmedString(probe.evidence);
+
+  if (probe.discharged !== true) {
+    return {
+      selectable: false,
+      reason: "blocker-holds",
+      evidence,
+    };
+  }
+  if (evidence.length === 0) {
+    return {
+      selectable: false,
+      reason: "blocker-discharge-unevidenced",
+      evidence,
+    };
+  }
+
+  return { selectable: true, reason: "blocker-discharged", evidence };
+}
+
+/**
+ * Decide whether a pre-work item may be selected as a build candidate.
+ *
+ * Order is load-bearing. The human gate is checked before anything else, so no
+ * probe result — however conclusive — can promote an item a human parked.
+ *
+ * @param {{
+ *   laneType?: unknown
+ *   labels?: unknown
+ *   body?: unknown
+ *   humanNeededLabel?: unknown
+ *   statedBlocker?: unknown
+ *   probe?: { discharged?: unknown, evidence?: unknown } | null
+ * }} input
+ * @returns {{ selectable: boolean, reason: string, humanGated: boolean, evidence: string }}
+ */
+export function classifyPreWorkCandidate(input = {}) {
+  if (isHumanGated(input)) {
+    return {
+      selectable: false,
+      reason: "human-gate",
+      humanGated: true,
+      evidence: "",
+    };
+  }
+  if (!isPreWorkLaneType(input.laneType)) {
+    return {
+      selectable: false,
+      reason: "not-pre-work",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (trimmedString(input.statedBlocker).length === 0) {
+    return {
+      selectable: true,
+      reason: "no-blocker",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+  if (!input.probe || typeof input.probe !== "object") {
+    return {
+      selectable: false,
+      reason: "blocker-unprobed",
+      humanGated: false,
+      evidence: "",
+    };
+  }
+
+  return { ...judgeProbe(input.probe), humanGated: false };
+}
+
+/** Plain-English wording for each verdict, for the note left on the item. */
+const REASON_COPY = Object.freeze({
+  "human-gate": "A person parked this one on purpose, so intake left it alone.",
+  "not-pre-work": "This item is not sitting in a not-yet-started lane.",
+  "no-blocker": "No blocker was written on this item, so it is buildable.",
+  "blocker-unprobed":
+    "This item states a blocker that was not re-checked this cycle, so it stays put.",
+  "blocker-holds":
+    "The blocker was re-checked and still holds, so it stays put.",
+  "blocker-discharge-unevidenced":
+    "The blocker looked clear but no proof was recorded, so it stays put.",
+  "blocker-discharged":
+    "The blocker was re-checked and no longer applies, so this item is buildable again.",
+});
+
+/**
+ * Render the re-probe result to leave on the item, so the next cycle reads the
+ * answer instead of deriving it again.
+ *
+ * @param {{
+ *   statedBlocker?: unknown
+ *   checkedAt?: string | Date
+ * }} candidate
+ * @param {{ reason: string, evidence?: string }} verdict
+ * @returns {string}
+ */
+export function formatReprobeNote(candidate = {}, verdict) {
+  const checkedAt =
+    candidate.checkedAt instanceof Date
+      ? candidate.checkedAt.toISOString()
+      : trimmedString(candidate.checkedAt) || new Date().toISOString();
+  const lines = [
+    "**Blocker re-check**",
+    "",
+    `- What has to be true: ${trimmedString(candidate.statedBlocker) || "(none written on this item)"}`,
+    `- What we found: ${REASON_COPY[verdict.reason] ?? verdict.reason}`,
+  ];
+  const evidence = trimmedString(verdict.evidence);
+  if (evidence.length > 0) {
+    lines.push(`- Proof: ${evidence}`);
+  }
+  lines.push(`- Checked at: ${checkedAt}`);
+
+  return lines.join("\n");
+}

--- a/plugins/src/base/scripts/intake-prework-denominator.mjs
+++ b/plugins/src/base/scripts/intake-prework-denominator.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Pre-work denominator for build-queue intake scanners.
+ *
+ * A build-intake cycle that reports an empty lane is only as trustworthy as the
+ * set of lanes it swept. Sweeping by lane NAME (`Backlog`, `Todo`, `Ready`)
+ * omits every pre-work lane a team invented — most commonly a `Blocked` lane,
+ * which is not a distinct Linear state type at all: teams model it as
+ * `unstarted`, i.e. work that was never started. Items parked there carry a
+ * written blocker that nothing ever re-reads, so the lane reads as terminal
+ * while it is in fact a queue.
+ *
+ * This module fixes both halves: lanes are selected by TYPE, never by name, and
+ * the swept set is reported alongside the total so a wrong denominator is
+ * visible on inspection instead of silent forever.
+ */
+
+/** Lane types that hold work which has not started. Both belong to intake. */
+export const PRE_WORK_LANE_TYPES = Object.freeze(["backlog", "unstarted"]);
+
+/** Loop ids whose `nothing-needed` runs must state their denominator. */
+export const DENOMINATOR_REQUIRED_LOOP_IDS = Object.freeze(["intake-tickets"]);
+
+/**
+ * Vendor lane-type vocabularies normalized onto Linear's five-value type set.
+ * JIRA exposes the same idea as `statusCategory` (key or display name); GitHub
+ * has no type field at all, so its callers pass a type explicitly.
+ */
+const LANE_TYPE_ALIASES = Object.freeze({
+  backlog: "backlog",
+  unstarted: "unstarted",
+  started: "started",
+  completed: "completed",
+  canceled: "canceled",
+  cancelled: "canceled",
+  new: "unstarted",
+  indeterminate: "started",
+  done: "completed",
+  "to do": "unstarted",
+  "in progress": "started",
+});
+
+/**
+ * Map a vendor lane type onto the normalized vocabulary.
+ *
+ * @param {unknown} type
+ * @returns {string | null} normalized type, or null when unrecognized
+ */
+export function normalizeLaneType(type) {
+  if (typeof type !== "string") {
+    return null;
+  }
+  return LANE_TYPE_ALIASES[type.trim().toLowerCase()] ?? null;
+}
+
+/**
+ * @param {unknown} type
+ * @returns {boolean} whether this lane holds not-yet-started work
+ */
+export function isPreWorkLaneType(type) {
+  const normalized = normalizeLaneType(type);
+  return normalized !== null && PRE_WORK_LANE_TYPES.includes(normalized);
+}
+
+/**
+ * @param {unknown} lane
+ * @returns {{ name: string, type: string | null, count: number, position: number } | null}
+ */
+function normalizeLane(lane) {
+  if (!lane || typeof lane !== "object") {
+    return null;
+  }
+  const name = String(lane.name ?? "").trim();
+  if (name.length === 0) {
+    return null;
+  }
+  const rawCount = Number(lane.count ?? 0);
+  const rawPosition = Number(lane.position ?? Number.POSITIVE_INFINITY);
+
+  return {
+    name,
+    type: normalizeLaneType(lane.type ?? lane.statusCategory),
+    count: Number.isFinite(rawCount) && rawCount > 0 ? Math.trunc(rawCount) : 0,
+    position: Number.isFinite(rawPosition)
+      ? rawPosition
+      : Number.POSITIVE_INFINITY,
+  };
+}
+
+/**
+ * @param {{ position: number, name: string }} left
+ * @param {{ position: number, name: string }} right
+ * @returns {number}
+ */
+function compareLanes(left, right) {
+  if (left.position !== right.position) {
+    return left.position - right.position;
+  }
+  return left.name.localeCompare(right.name);
+}
+
+/**
+ * Select every lane holding not-yet-started work, by type.
+ *
+ * Deliberately name-blind: a team that adds `Blocked`, `Triaged`, or `Icebox`
+ * as an `unstarted` state gets it swept without a code change, and no hardcoded
+ * roster can fall behind the board.
+ *
+ * @param {readonly unknown[]} lanes
+ * @returns {readonly {name: string, type: string, count: number, position: number}[]}
+ */
+export function selectPreWorkLanes(lanes) {
+  return (Array.isArray(lanes) ? lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null && isPreWorkLaneType(lane.type))
+    .sort(compareLanes);
+}
+
+/**
+ * Build the denominator a scanner must report with its verdict.
+ *
+ * `totalOpen` is the count of open items on the queue, independent of lanes —
+ * supplying it is what makes an omitted lane arithmetically visible.
+ *
+ * @param {{ lanes?: readonly unknown[], totalOpen?: number }} input
+ * @returns {{
+ *   swept: readonly {name: string, type: string, count: number}[]
+ *   omitted: readonly {name: string, type: string | null, count: number}[]
+ *   sweptCount: number
+ *   totalOpen: number
+ *   unsweptCount: number
+ * }}
+ */
+export function buildIntakeDenominator(input = {}) {
+  const normalized = (Array.isArray(input.lanes) ? input.lanes : [])
+    .map(normalizeLane)
+    .filter(lane => lane !== null)
+    .sort(compareLanes);
+  const swept = normalized.filter(lane => isPreWorkLaneType(lane.type));
+  const omitted = normalized.filter(lane => !isPreWorkLaneType(lane.type));
+  const sweptCount = swept.reduce((total, lane) => total + lane.count, 0);
+  const laneTotal = normalized.reduce((total, lane) => total + lane.count, 0);
+  const rawTotalOpen = Number(input.totalOpen);
+  const totalOpen =
+    Number.isFinite(rawTotalOpen) && rawTotalOpen >= 0
+      ? Math.trunc(rawTotalOpen)
+      : laneTotal;
+
+  return {
+    swept: swept.map(({ name, type, count }) => ({ name, type, count })),
+    omitted: omitted.map(({ name, type, count }) => ({ name, type, count })),
+    sweptCount,
+    totalOpen,
+    unsweptCount: Math.max(totalOpen - sweptCount, 0),
+  };
+}
+
+/**
+ * Render the denominator for a non-technical operator.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @returns {string}
+ */
+export function formatIntakeDenominator(denominator) {
+  const lanes = denominator?.swept ?? [];
+  const listed =
+    lanes.length > 0
+      ? lanes.map(lane => `${lane.name} (${lane.count})`).join(", ")
+      : "no pre-work lanes found";
+
+  return `Looked in every lane holding work that has not started — ${listed} — ${denominator.sweptCount} items checked out of ${denominator.totalOpen} still open.`;
+}
+
+/**
+ * Render the full operator-readable one-liner for a dry build lane.
+ *
+ * @param {ReturnType<typeof buildIntakeDenominator>} denominator
+ * @param {{ queue?: string }} [context]
+ * @returns {string}
+ */
+export function summarizeDryLane(denominator, context = {}) {
+  const queue =
+    typeof context.queue === "string" && context.queue.trim().length > 0
+      ? ` on ${context.queue.trim()}`
+      : "";
+
+  return `Nothing ready to build${queue}. ${formatIntakeDenominator(denominator)}`;
+}
+
+/**
+ * @param {unknown} loopId
+ * @param {unknown} outcome
+ * @returns {boolean} whether this run must carry a denominator
+ */
+export function requiresDenominator(loopId, outcome) {
+  return (
+    outcome === "nothing-needed" &&
+    DENOMINATOR_REQUIRED_LOOP_IDS.includes(String(loopId ?? "").trim())
+  );
+}
+
+/**
+ * @param {unknown} denominator
+ * @returns {string | null} the reason it is unusable, or null when valid
+ */
+function findDenominatorDefect(denominator) {
+  if (!denominator || typeof denominator !== "object") {
+    return "no denominator was supplied";
+  }
+  if (!Array.isArray(denominator.swept) || denominator.swept.length === 0) {
+    return "it names no swept lanes";
+  }
+  if (!Number.isInteger(denominator.sweptCount)) {
+    return "its swept count is not a whole number";
+  }
+  if (!Number.isInteger(denominator.totalOpen)) {
+    return "its open-item total is not a whole number";
+  }
+  if (denominator.sweptCount > denominator.totalOpen) {
+    return "it claims to have swept more items than are open";
+  }
+  return null;
+}
+
+/**
+ * Refuse to record a dry build lane that does not say what it looked at.
+ *
+ * Thirty-one consecutive cycles reported an empty lane against a queue holding
+ * unswept pre-work rows. Every record was honest and every conclusion was
+ * false, because none of them stated a denominator. This turns that silent
+ * wrong answer into a loud one.
+ *
+ * @param {{ loopId?: unknown, outcome?: unknown, denominator?: unknown }} input
+ * @throws {Error} when a denominator is required and missing or malformed
+ */
+export function assertDenominatorReported(input = {}) {
+  if (!requiresDenominator(input.loopId, input.outcome)) {
+    return;
+  }
+  const defect = findDenominatorDefect(input.denominator);
+  if (defect === null) {
+    return;
+  }
+
+  throw new Error(
+    `A "nothing-needed" run for loop "${String(input.loopId).trim()}" must state the lanes it swept, and ${defect}. ` +
+      `Pass a denominator built by buildIntakeDenominator() so an omitted lane is visible instead of silent.`
+  );
+}

--- a/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-github-build-intake/SKILL.md
@@ -110,7 +110,7 @@ The only legitimate reasons to stop early:
 
 - Missing repo or required configuration. Surface the missing value and exit.
 - Label namespace not adopted (no issue carries any of `$READY` / `$CLAIMED` / `$DONE`). Surface a label-convention error and exit (this is setup, not a normal idle cycle — see "Adoption" at the bottom).
-- Empty ready set. Exit cleanly with `"No GitHub issues labeled $READY in <org>/<repo>. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -166,7 +166,57 @@ gh label list --repo <org>/<repo> --json name \
       '[.[] | .name | select(. == $r or . == $c or (. as $n | $d | index($n)))] | length'
 ```
 
-If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit. If the role labels exist but none are `$READY` on any open issue matching the resolved assignee filter (or any open issue when the filter is empty) → genuinely empty queue, exit cleanly with `"No GitHub issues labeled $READY. Nothing to do."`
+If none of the configured role labels exist on the repo → label convention not adopted, surface a setup error and exit.
+
+#### 2a. Sweep every pre-work lane, and state the denominator
+
+GitHub Issues has no state-type field, so labels are the only lane available here — a constraint of
+GitHub's data model, not a preference (see "Why labels" above). That makes the omission risk
+*higher*, not lower: there is no `type` to fall back on, so the pre-work set must be derived from
+**configured roles**, never from a hardcoded roster of label names. The pre-work lanes are:
+
+- the configured `$READY` label — the human-flipped lane, worked first;
+- the configured `$BLOCKED` label (`github.labels.build.blocked`) — items that were *never started*,
+  each carrying a written blocker that nothing re-read until Phase 2.5;
+- open issues carrying **no** build role label — which this scanner must see anyway in order to
+  determine and stamp their repo.
+
+Count each lane and the repo's **total open** count (`gh issue list --state open --limit 1000 --json
+number | jq length`), then build the denominator with the shared helper — GitHub callers pass the
+lane type explicitly, since there is none to read:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "$READY", type: "unstarted", count: <n>},
+                                 {name: "$BLOCKED", type: "unstarted", count: <n>},
+                                 {name: "(no role label)", type: "backlog", count: <n>},
+                                 {name: "$CLAIMED", type: "started", count: <n>}, …],
+                         totalOpen: <open issue count> })
+summarizeDryLane(denominator, { queue: "<org>/<repo>" })
+```
+
+Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all. If
+nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a bare
+"nothing to do". The run recorder rejects a dry build-intake run that does not name what it swept
+(see `automation-runbook-contract`).
+
+#### 2a.1 Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each `$BLOCKED` candidate:
+
+1. **Human gate first, and it is absolute.** An issue carrying the configured human-needed label
+   (`github.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in
+   its body is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from `scripts/intake-blocker-reprobe.mjs`. A
+   discharge with no recorded evidence is not a discharge, and neither is a candidate nothing
+   probed this cycle — the helper refuses both.
+4. **Record the result on the issue either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, relabel `$BLOCKED → $READY` with the discharging evidence in the same
+   comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 #### 2b. Lifecycle-label trust resolution (bot-authored labels are not signals)
 
@@ -251,7 +301,7 @@ GitHub Issues live in one repo by definition, so the scanned repo's issues are u
    - **Container visibility is allowed.** A multi-repo Epic / Story / Spike may legitimately carry multiple `repo:<name>` labels for operator visibility. Do not split or claim it here; leave the repo markers intact and fall through to the leaf-only gate, which repairs the stale build-ready label instead of dispatching the container.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (repair containers)
 

--- a/plugins/src/base/skills/lisa-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-intake/SKILL.md
@@ -126,7 +126,7 @@ matches the mode this cycle ran in: **`intake-prd`** (PRD-side dispatch) or **`i
 
 | This cycle's exit path | Run outcome |
 |---|---|
-| Empty `Ready` set — the idle case (step 3), nothing to claim | `nothing-needed` |
+| Empty pre-work set — the idle case (step 3), nothing to claim. **Must state its denominator** (see below) | `nothing-needed` |
 | A PRD routed to `Blocked` (clarifying questions) or `Ticketed`; a build ticket claimed and dispatched | `candidate-proposed` |
 | A build cycle that shipped and verified (merged PR + evidence), or a shipped PRD moved to `verified` | `change-proved` |
 | A protected deployment (or other autonomy boundary the lifecycle hits) waiting on a human approval | `approval-requested` |
@@ -149,6 +149,22 @@ node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
   --loop-id intake-tickets --outcome candidate-proposed \
   --summary "Routed PRD #1810 to Blocked with clarifying questions; the run succeeded." \
   --runbook .lisa/automations/intake-tickets.runbook.md [--ref <item-url>]...
+```
+
+**A dry build lane must say what it looked in.** A `nothing-needed` run on `intake-tickets`
+additionally passes `--denominator` — the JSON from `buildIntakeDenominator()` in
+`scripts/intake-prework-denominator.mjs` — and the recorder **refuses the row without it**. This is
+not decoration: 31 consecutive cycles reported a dry lane against a queue holding 61 unswept
+pre-work rows, and every one of those records was honest. A missing row is noisy on inspection; a
+wrong denominator is silent forever and looks exactly like a healthy dry queue. Stating the swept
+set is what turns the silent wrong answer into an inspectable one (#2657).
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/automation-run-record.mjs" \
+  --loop-id intake-tickets --outcome nothing-needed \
+  --summary "Nothing ready to build on team ENG. Looked in every lane holding work that has not started — Backlog (20), Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open." \
+  --denominator "$DENOMINATOR_JSON" \
+  --runbook .lisa/automations/intake-tickets.runbook.md
 ```
 
 If `${CLAUDE_PLUGIN_ROOT}` is unset, resolve the plugin scripts directory directly — the built copy

--- a/plugins/src/base/skills/lisa-jira-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-jira-build-intake/SKILL.md
@@ -85,7 +85,7 @@ The only legitimate reasons to stop early:
 
 - Missing project key / JQL or required configuration. Surface the missing value and exit.
 - Workflow misconfigured (pre-flight check finds `$CLAIMED` or `$DONE` not reachable, or `$READY` status absent). Surface and exit.
-- Empty ready set. Exit cleanly with `"No tickets with Status=$READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -130,11 +130,59 @@ JQL="${BASE_JQL} ORDER BY priority DESC, created ASC"
 
 4. Confirm the configured Atlassian site by invoking `lisa-atlassian-access` `operation: list-sites` (it enforces connection match against `.lisa.config.json`).
 
-### Phase 2 — Find ready tickets
+### Phase 2 — Sweep every pre-work status by CATEGORY
 
-Invoke `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), labels, components.
+**Sweep by `statusCategory`, never by a roster of status names.** JIRA groups statuses into three
+categories — `To Do` (`new`), `In Progress` (`indeterminate`), `Done` (`done`) — and a `Blocked`
+status is not a fourth category: a project that wants one models it under **`To Do`**, i.e. work
+that was never started. Keying the candidate set on status *names* therefore omits every pre-work
+lane a project invented, and the scanner reports an empty queue over a full one. The same defect on
+the Linear side produced 31 consecutive false "dry lane" cycles (#2657).
 
-If empty, report `"No tickets with Status=$READY. Nothing to do."` and exit. This is the common idle case.
+1. Run the ready query first: `lisa-atlassian-access` `operation: search-issues jql: "<JQL>"`. This
+   is the human-flipped lane and it is worked first.
+2. Then sweep the rest of pre-work with the same base JQL, swapping the status clause for
+   `statusCategory = "To Do"`, and read the **total open** count (`statusCategory != Done`). The
+   open total is what makes an omitted lane arithmetically visible.
+3. Page to exhaustion — a single unpaged `search-issues` call is not a count.
+
+Capture each ticket's: key, summary, issue type, priority, assignee, parent (epic), status (with
+its category), labels, components.
+
+Build the denominator with the shared helper, which owns the pre-work vocabulary so no two
+scanners can disagree about what counts:
+
+```text
+buildIntakeDenominator({ lanes: [{name: "<status>", type: "<statusCategory>", count: <rows>}, …],
+                         totalOpen: <statusCategory != Done count> })
+summarizeDryLane(denominator, { queue: "<project key>" })
+```
+
+The helper accepts JIRA's category vocabulary directly (`new` / `To Do` normalize to pre-work).
+
+**Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at
+all.** If nothing survives, exit on the denominator-stated summary from `summarizeDryLane` — never a
+bare "nothing to do". The run recorder rejects a dry build-intake run that does not name what it
+swept (see `automation-runbook-contract`).
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact** — it goes stale the moment its condition comes
+true, and nothing re-read one before this phase. For each pre-work candidate outside `$READY`:
+
+1. **Human gate first, and it is absolute.** A ticket carrying the configured human-needed label
+   (`jira.labels.human_needed`, default `Human Needed`) or a `[lisa-human-gate]` marker in its
+   description is **never** auto-selected, whatever any probe says.
+2. **Extract the stated discharge condition**, then **probe it**. Machine-testable conditions — a
+   version on trunk, a published package, a CI run history, an advisory's patched status — rot
+   fastest and are cheapest to check. A human decision is not machine-testable; leave it.
+3. **Classify with `classifyPreWorkCandidate(...)`** from
+   `scripts/intake-blocker-reprobe.mjs`. A discharge with no recorded evidence is not a discharge,
+   and neither is a candidate nothing probed this cycle — the helper refuses both.
+4. **Record the result on the ticket either way** via `formatReprobeNote(...)` as a comment, so the
+   next cycle reads the answer rather than re-deriving it. Keep it idempotent.
+5. **On `selectable: true`**, transition the ticket to `$READY` with the discharging evidence in the
+   same comment, and treat it as an ordinary candidate. On anything else, leave it where it is.
 
 ### Phase 3 — Process the first eligible ready ticket
 
@@ -149,7 +197,7 @@ A JIRA project can oversee multiple repos (`frontend` / `backend` / `infrastruct
    - **Unlabeled** → determine the target repo(s) from the ticket (description, AC, technical approach) confirmed against the code surfaces, then **stamp** `repo:<name>` via `lisa-atlassian-access` `operation: write-ticket` (add the label / set the component) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure to break it into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready tickets for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/src/base/skills/lisa-linear-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-linear-build-intake/SKILL.md
@@ -99,7 +99,7 @@ The only legitimate reasons to stop early:
 
 - Missing team key or required configuration. Surface and exit.
 - Workflow states not yet adopted (the `ready` state does not exist on the team). Surface and exit with an Adoption hint pointing at `/lisa:setup:linear`.
-- Empty ready set. Exit cleanly with `"No Linear Issues in state $READY. Nothing to do."`
+- Empty pre-work set. Exit cleanly on the denominator-stated summary from `summarizeDryLane` — which names every lane swept, its count, and the open total. A bare "nothing to do" is not an acceptable exit: it is indistinguishable from a wrong denominator (#2657).
 
 ## Lifecycle assumed
 
@@ -112,7 +112,7 @@ ready → claimed → review → done(env-keyed) (downstream)
 
 (Defaults: `Ready` / `In Progress` / `In Review` / `On Dev`/`On Stg`/`Done`.)
 
-This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done`, `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`), or `$BLOCKED` (owned by the pre-flight gate).
+This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $DONE` on completion. It never touches the terminal production `done` or `$REVIEW` (owned by the lifecycle / `lisa-linear-evidence`). It never *sets* `$BLOCKED` either — that stays owned by the pre-flight gate — but Phase 2.5 does move an Issue **out** of a pre-work blocked lane back to `$READY` when it re-probes the Issue's own stated discharge condition and finds it no longer holds, recording the discharging evidence on the Issue.
 
 **Pre-flight check**: at start of each cycle, confirm `$READY`, `$CLAIMED`, and the relevant `$DONE` variants exist on the team via `lisa-linear-access operation: list-workflow-states`. If `$READY` is missing, stop and report adoption needed. **Unlike labels, a missing state cannot be created on demand here** — a workflow state is team configuration with a `type` and a board position, and guessing either would put an Issue somewhere a human did not sanction. Any missing state is a setup defect: report it, name the role and the expected state, and point at `/lisa:setup:linear`.
 
@@ -125,15 +125,56 @@ This skill ONLY transitions `$READY → $CLAIMED` on claim, and `$CLAIMED → $D
    - Literal `linear` → fall back to `linear.teamKey` from config.
 2. Resolve team ID via `lisa-linear-access operation: list-teams({query: <teamKey>})`.
 
-### Phase 2 — Find ready Issues
+### Phase 2 — Sweep every pre-work lane by state TYPE
 
-Query: `lisa-linear-access operation: list-issues({team: <teamId>, state: "$READY"})`.
+**Sweep by `type`, never by a roster of state names.** Linear state types are `backlog | unstarted | started | completed | canceled`, and there is no `blocked` type — a team that wants a `Blocked` lane models it as **`unstarted`**, i.e. work that was *never started*. Selecting candidates from a hardcoded `Backlog / Todo / Ready` name list therefore omits an entire pre-work lane and reports an empty queue over a full one. Measured on one team: the name sweep saw **39 of 343 open rows**; the type sweep sees **100**, and the 61-row difference produced 31 consecutive false "dry lane" cycles (#2657).
 
-Capture each Issue's: identifier, title, type label, priority, assignee, project, state, labels, description summary.
+1. List the team's workflow states via `lisa-linear-access operation: list-workflow-states`.
+2. Keep every state whose `type` is `backlog` or `unstarted` — that is the pre-work set. `$READY` is one member of it, not the whole of it.
+3. Query each pre-work state: `lisa-linear-access operation: list-issues({team: <teamId>, state: "<state>"})`, paging to `hasNextPage=false`. Linear's GraphQL complexity ceiling silently truncates at `first: 250`, so a single unpaged call is not a count.
+4. Also read the **total open** count for the team (every state whose `type` is not `completed` / `canceled`). This number is what makes an omitted lane arithmetically visible.
+
+Capture each Issue's: identifier, title, type label, priority, assignee, project, state (with its `type`), labels, description summary.
+
+Build the denominator with the shared helper, which owns the type vocabulary so no two scanners can disagree about what counts as pre-work:
+
+```bash
+node -e '
+import("'"${CLAUDE_PLUGIN_ROOT:-plugins/src/base}"'/scripts/intake-prework-denominator.mjs").then(m => {
+  const d = m.buildIntakeDenominator({ lanes: JSON.parse(process.argv[1]), totalOpen: Number(process.argv[2]) });
+  console.log(JSON.stringify(d));
+  console.log(m.summarizeDryLane(d, { queue: process.argv[3] }));
+});' "$LANES_JSON" "$TOTAL_OPEN" "team $TEAM_KEY"
+```
+
+`$LANES_JSON` is `[{"name":"<state>","type":"<state.type>","position":<state.position>,"count":<open rows>}, …]` for **every** state on the team, pre-work and not — the helper does the selecting.
+
+**Candidate order.** Work `$READY` first (it is the human-flipped signal), then the remaining pre-work lanes oldest-first. Every candidate outside `$READY` must clear Phase 2.5 before it is treated as a candidate at all.
 
 > **No query-time repo pre-filter here (by design).** Unlike `lisa-jira-build-intake`, which narrows its JQL with `AND (labels = "repo:<current>" OR labels IS EMPTY)` (the query-time arm of `repo-scope-split`), the Linear `list_issues` label filter is an AND-of-labels and cannot express "current-repo **or** unlabeled" in one query. Adding `repo:<current>` to this query would strand unlabeled Issues the determine + stamp path must see. So the Linear scanner keeps this query broad and relies on the per-candidate 3a.0 gate below for repo scoping. (The `state` filter above is orthogonal to that — it narrows the lifecycle lane, not the repo, and is a single-valued equality so it has none of the AND-of-labels problem.)
 
-If empty, report `"No Linear Issues in state $READY. Nothing to do."` and exit. Common idle case.
+If every pre-work lane is empty, or nothing survives Phase 2.5, exit on the **denominator-stated** summary from `summarizeDryLane` — never a bare "nothing to do". See "Run outcome" below; the run recorder rejects a dry build-intake run that does not name what it swept.
+
+### Phase 2.5 — Re-probe the blockers instead of inheriting them
+
+A blocker is a **claim with a timestamp, not a fact**. It is written once and goes stale the moment its condition comes true — a dependency lands on trunk, an advisory gets patched, a package publishes. Nothing re-read one before this phase, so a discharged blocker held its Issue out of the queue indefinitely. Measured: one Issue's stated condition went true ~15 hours before anything noticed.
+
+For each pre-work candidate that is **not** in `$READY`:
+
+1. **Human gate first, and it is absolute.** An Issue carrying the configured human-needed label (`linear.labels.build.human_needed`, default `human-needed`) or a `[lisa-human-gate]` marker in its description is **never** auto-selected, whatever any probe says. Skip it and move on.
+2. **Extract the stated discharge condition** from the description or the most recent blocking comment — the sentence naming what has to become true.
+3. **Probe it.** Machine-testable conditions are the ones that rot fastest and are cheapest to check: a version on trunk (`git show origin/<trunk>:<manifest>`), a published package, a run history (`gh run list`), an advisory's patched status. A condition that is a human decision is not machine-testable — leave it and move on.
+4. **Classify with the shared helper** so the ordering and the evidence requirement cannot drift per vendor:
+
+```text
+classifyPreWorkCandidate({ laneType, labels, body, humanNeededLabel, statedBlocker, probe })
+  → { selectable, reason, humanGated, evidence }
+```
+
+   A discharge with **no recorded evidence is not a discharge** — the helper refuses it. So is a candidate nothing probed this cycle.
+
+5. **Record the result on the Issue either way**, via `lisa-linear-access operation: save-comment` using `formatReprobeNote(...)`, so the next cycle reads the answer rather than re-deriving it. Keep it idempotent — skip the post when an identical note already exists.
+6. **On `selectable: true`**, move the Issue to `$READY` (recording the discharging evidence in the same comment) and treat it as an ordinary candidate from Phase 3 onward. On anything else, leave the Issue exactly where it is.
 
 ### Phase 3 — Process the first eligible ready Issue
 
@@ -148,7 +189,7 @@ A Linear team can oversee multiple repos (`frontend` / `backend` / `infrastructu
    - **Unlabeled** → determine the target repo(s) from the Issue + code surfaces, then **stamp** `repo:<name>` via `lisa-linear-access operation: save-issue` (resolve/create the label via `list_issue_labels`/`create_issue_label`) so later cycles filter cheaply; re-apply with the now-known repo.
    - **Multi-repo leaf → split, never claim.** Run the `repo-scope-split` work-time procedure into single-repo siblings, each created **build-ready** (`build_ready: true`) and stamped with its own `repo:<name>`; the current repo's sibling becomes a normal candidate.
    - **Single-repo leaf for the current repo** → fall through to 3a (leaf-only gate) and 3b (claim).
-4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the ready set is exhausted — exit cleanly with `"No ready Issues for repo <current>. Nothing to do."`.
+4. Continue until a claimable current-repo leaf is found (claim it; one per cycle) or the candidate set is exhausted — exit cleanly on the denominator-stated summary, naming the current repo alongside the swept lanes.
 
 #### 3a. Leaf-only claim gate (skip / safe-block containers)
 

--- a/plugins/src/base/skills/lisa-tracker-build-intake/SKILL.md
+++ b/plugins/src/base/skills/lisa-tracker-build-intake/SKILL.md
@@ -42,6 +42,30 @@ This is the claim-time arm of the rule. Its siblings are the write-time labeling
 
 The shim never needs to inspect the item itself — it forwards `$ARGUMENTS` verbatim and the resolved vendor scanner runs its Phase 3a gate before any claim.
 
+## Pre-work denominator contract (forwarded to every vendor)
+
+Also part of the build-intake API, and the reason a dry queue can be believed. Two obligations,
+uniform across `jira`, `github`, and `linear`:
+
+1. **Sweep every pre-work lane by its machine-readable category, never by a roster of lane names.**
+   No tracker has a `blocked` category: Linear models a `Blocked` state as `unstarted`, JIRA models
+   a `Blocked` status under `To Do`, and GitHub has no category at all, so its lanes come from
+   configured roles. In every case a `Blocked` lane is *pre-work* — items that were never started,
+   each carrying a written blocker. Keying selection on names omits it silently.
+2. **A `nothing-needed` run states its denominator** — which lanes were swept, how many rows each
+   held, and the total open. This is enforced, not requested: `automation-run-record.mjs` refuses a
+   `nothing-needed` row for `intake-tickets` without a `--denominator`.
+
+Shared helpers own both, so the vocabulary cannot drift per vendor:
+`scripts/intake-prework-denominator.mjs` (`buildIntakeDenominator`, `summarizeDryLane`) and
+`scripts/intake-blocker-reprobe.mjs` (`classifyPreWorkCandidate`, `formatReprobeNote`). The
+blocker re-probe carries an absolute human gate: an item carrying the configured human-needed label
+or a `[lisa-human-gate]` marker is never auto-selected, whatever a probe returns.
+
+Measured: sweeping one team by lane name saw 39 of 343 open rows; by category it sees 100. The
+61-row gap produced 31 consecutive false "dry lane" cycles, every record honest and every
+conclusion wrong (#2657).
+
 ## Repo-scope claim contract (forwarded to every vendor)
 
 Equally part of the build-intake API, and forwarded identically: when the tracker oversees multiple repos, each vendor scanner claims only tickets for the repo it is running in. Per the `repo-scope-split` rule's "Claim-time repo scoping" section, before the leaf-only gate each scanner (Phase 3a.0) resolves the current repo (`config-resolution` "Repo scoping": `repo` → `github.repo` → git remote basename), then for each ready candidate: skips a ticket labeled `repo:<other>`, determines + stamps `repo:<name>` on an unlabeled one, splits a multi-repo leaf into single-repo build-ready siblings, and claims only a single-repo leaf for the current repo. This shim does not re-implement the gate — it relies on the vendor scanner's Phase 3a.0 — but the contract is uniform across `jira`, `github`, and `linear` so behavior never drifts by tracker. It is the claim-time complement to the write-time S10 scope gate (`lisa-tracker-validate`) and `task-decomposition` step 1.5; all cite `repo-scope-split`.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -729,7 +729,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/track-plan-sessions.sh":
       "8bc47dcad3aed628df0c9efbe7b6f3df87635b94b0c54c71e0bd52eceace563a",
     "plugins/src/base/rules/eager/automation-runbook-contract.md":
-      "3d082e2f9a980ccf1dd6b51cc7251dfb171a53f8dcc36c11b4d9fd1f3d89dec7",
+      "0442c478cac32b2522534309bda96a30e1cd268b9041d2b6a7a63d08a5c49920",
     "plugins/src/base/rules/eager/base-rules.md":
       "d3a4bd518acf2c6f4e866042542f9155fdbf5b2fdad5747e1afd097bdef15351",
     "plugins/src/base/rules/eager/bdd-e2e-coverage.md":
@@ -829,7 +829,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/eager/work-item-definition-of-ready.md":
       "4285953f749aabee90dd44d7bff7e28a50e0a8c910917a96ebf81abfa425d836",
     "plugins/src/base/rules/reference/automation-runbook-contract.md":
-      "2074badf010c15dce80ce17be0d0c714baf700d09e87ca1f9d4628108e6f231c",
+      "427be7bddf9a581dbb1c1fdbe07c02d4a1ff4ec96f4d91f409651b6ac4ff8a45",
     "plugins/src/base/rules/reference/base-rules.md":
       "487ea1764c4b636ca4a33b78a90e925f028bb9a54182c0795cd1bbdc437a262d",
     "plugins/src/base/rules/reference/bdd-e2e-coverage.md":
@@ -929,7 +929,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/work-item-definition-of-ready.md":
       "ebcfe89f5a33a8008c4a54c1c2f4a092952df3263adc8f537a4c0b6ad8dbe18d",
     "plugins/src/base/scripts/automation-run-record.mjs":
-      "77ea269502b97300c400916ee851dc85082a9237ce3d4468688455084d96413a",
+      "7ec6370d15aa4db9fb866cfc83621a7bc58c83f4c24fc15eeddd2bda91f66bc0",
     "plugins/src/base/scripts/automation-status-claude-adapter.mjs":
       "1f77b28fd59986ac3f76a55296b70d8c45385bbdb759e97691e49db121725ee2",
     "plugins/src/base/scripts/automation-status-codex-adapter.mjs":
@@ -952,6 +952,10 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "f183e62848ac539da56a525fe2105fc6251a49e555a01dd1bba10d9227b1a6bf",
     "plugins/src/base/scripts/install-remote-agent-aws.mjs":
       "5ef1c323d7cbfda8976f6fb0c24f7a8e5f5757475fd1d71c6e5bec91023cebe3",
+    "plugins/src/base/scripts/intake-blocker-reprobe.mjs":
+      "135a9b5a0894f70562b54d2071caff1e679c0fe542a606caca39e9e6a5b65f24",
+    "plugins/src/base/scripts/intake-prework-denominator.mjs":
+      "0a40cb91ab1c0e810f42d035d9652af3033e97c692b93b911de851991c12eca1",
     "plugins/src/base/scripts/lifecycle-label-trust.mjs":
       "0a9892890da6011733bf9b1186fbe936253c2796c4ac448f1a55f63b8daaa154",
     "plugins/src/base/scripts/plugin-sync-explain.mjs":
@@ -1035,7 +1039,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-github-add-journey/SKILL.md":
       "6b3bbe8ff85c7cb20412dcfcab3d7506a3efc67907cb749622c329fb4130baf4",
     "plugins/src/base/skills/lisa-github-build-intake/SKILL.md":
-      "ad703d7e7a9f13de6e708fc31fa321b329295b0cc8b31de8804c2fdc3b2fa7fa",
+      "f956b8ba5148a76a157f8c6089f1d94de5eeea699c9a37570b71b80ad9ec6015",
     "plugins/src/base/skills/lisa-github-claim/SKILL.md":
       "71301c6d45d7eb5523e74aa7f070bb2becf57ca68fb8bde9e02ee937b78815f7",
     "plugins/src/base/skills/lisa-github-create/SKILL.md":
@@ -1083,13 +1087,13 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-intake-explain/SKILL.md":
       "353ffde220de23a06cd88fea0fffc8ff690fc6bcf553f99988a8367138404eba",
     "plugins/src/base/skills/lisa-intake/SKILL.md":
-      "5ca35517fec4483c000466a4a2e7487b0f75ccec17053ad0b06ec4848027d1a1",
+      "ad78305053ac69451e35ba3011895fe0220d5aa7306e38260a45b23a9683140f",
     "plugins/src/base/skills/lisa-jam-access/SKILL.md":
       "eb7255578a3ada2278a0437c4300fed3f28b9b1a4ef2fd4ceed63f3d9ab81ed3",
     "plugins/src/base/skills/lisa-jira-add-journey/SKILL.md":
       "92bc77aac50426b37f954ed24d95bd600ae1a429c2fecd6bbd4317053136bb03",
     "plugins/src/base/skills/lisa-jira-build-intake/SKILL.md":
-      "6a31ad5193281b0b7ac6ba8d774fc5e1e357f320d44f151f8e715f1dee4c2f64",
+      "dafbb30c38b0da961a38064fecbdb0f3eeb26886369c4040ed9c42570ab2272d",
     "plugins/src/base/skills/lisa-jira-claim/SKILL.md":
       "9c4935441a4e6b55df0949178f96e927184c4909bffff8929b39a304bc5ac00a",
     "plugins/src/base/skills/lisa-jira-create/SKILL.md":
@@ -1127,7 +1131,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-linear-add-journey/SKILL.md":
       "0a9f2bd0e19fbaa4794537e436c22748c7621644253a91923d84bc77ca43f793",
     "plugins/src/base/skills/lisa-linear-build-intake/SKILL.md":
-      "0996feb0f8f0df41372a35682ef39f1b6c8e213402a39bc8dca864d9ee0724f6",
+      "06cae5e0675bb03fe45c5efdaf3c79168c932cdae757c40446c54f8aa451a644",
     "plugins/src/base/skills/lisa-linear-claim/SKILL.md":
       "d3fee9a0435e93402be53769313f971c77b847521826fbaee0d19a0bdbc34b93",
     "plugins/src/base/skills/lisa-linear-create/SKILL.md":
@@ -1367,7 +1371,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-tracker-add-journey/SKILL.md":
       "a3da2e0350bcdebcdcc05f2d7931af868382638d3a28d09d4718f2f458d4be0a",
     "plugins/src/base/skills/lisa-tracker-build-intake/SKILL.md":
-      "df50fb88f29eadc66c250e1d7f841472df43ba865930fbbc0bea36bba3380ec3",
+      "db392f3342cac926bbf65025427dac303c937fe3d6f59bb3feb50c8e0f75fa3b",
     "plugins/src/base/skills/lisa-tracker-claim/SKILL.md":
       "481922dba26c4e62ae36193a2e1565860aecf7e344bf5c37b3a0759f42676846",
     "plugins/src/base/skills/lisa-tracker-create/SKILL.md":
@@ -3367,6 +3371,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-agy/scripts/design-source-gate.mjs": true,
     "plugins/lisa-agy/scripts/doctor-report.mjs": true,
     "plugins/lisa-agy/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/lisa-agy/scripts/intake-blocker-reprobe.mjs": true,
+    "plugins/lisa-agy/scripts/intake-prework-denominator.mjs": true,
     "plugins/lisa-agy/scripts/lifecycle-label-trust.mjs": true,
     "plugins/lisa-agy/scripts/plugin-sync-explain.mjs": true,
     "plugins/lisa-agy/scripts/project-ideation-idempotency-harness.mjs": true,
@@ -3840,6 +3846,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-copilot/scripts/design-source-gate.mjs": true,
     "plugins/lisa-copilot/scripts/doctor-report.mjs": true,
     "plugins/lisa-copilot/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/lisa-copilot/scripts/intake-blocker-reprobe.mjs": true,
+    "plugins/lisa-copilot/scripts/intake-prework-denominator.mjs": true,
     "plugins/lisa-copilot/scripts/lifecycle-label-trust.mjs": true,
     "plugins/lisa-copilot/scripts/plugin-sync-explain.mjs": true,
     "plugins/lisa-copilot/scripts/project-ideation-idempotency-harness.mjs": true,
@@ -4299,6 +4307,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa-cursor/scripts/design-source-gate.mjs": true,
     "plugins/lisa-cursor/scripts/doctor-report.mjs": true,
     "plugins/lisa-cursor/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/lisa-cursor/scripts/intake-blocker-reprobe.mjs": true,
+    "plugins/lisa-cursor/scripts/intake-prework-denominator.mjs": true,
     "plugins/lisa-cursor/scripts/lifecycle-label-trust.mjs": true,
     "plugins/lisa-cursor/scripts/plugin-sync-explain.mjs": true,
     "plugins/lisa-cursor/scripts/project-ideation-idempotency-harness.mjs": true,
@@ -6857,6 +6867,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/lisa/scripts/design-source-gate.mjs": true,
     "plugins/lisa/scripts/doctor-report.mjs": true,
     "plugins/lisa/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/lisa/scripts/intake-blocker-reprobe.mjs": true,
+    "plugins/lisa/scripts/intake-prework-denominator.mjs": true,
     "plugins/lisa/scripts/lifecycle-label-trust.mjs": true,
     "plugins/lisa/scripts/plugin-sync-explain.mjs": true,
     "plugins/lisa/scripts/project-ideation-idempotency-harness.mjs": true,
@@ -7498,6 +7510,8 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "plugins/src/base/scripts/design-source-gate.mjs": true,
     "plugins/src/base/scripts/doctor-report.mjs": true,
     "plugins/src/base/scripts/install-remote-agent-aws.mjs": true,
+    "plugins/src/base/scripts/intake-blocker-reprobe.mjs": true,
+    "plugins/src/base/scripts/intake-prework-denominator.mjs": true,
     "plugins/src/base/scripts/lifecycle-label-trust.mjs": true,
     "plugins/src/base/scripts/plugin-sync-explain.mjs": true,
     "plugins/src/base/scripts/project-ideation-idempotency-harness.mjs": true,
@@ -8602,6 +8616,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/fixtures/harness-parity-council/probe-auth-missing.json": true,
     "tests/fixtures/harness-parity-council/probe-command-missing.json": true,
     "tests/fixtures/harness-parity-council/probe-success.json": true,
+    "tests/fixtures/intake-prework-denominator/linear-team-lanes.json": true,
     "tests/fixtures/queue-status-build-readers/github-umbrella.json": true,
     "tests/fixtures/queue-status-build-readers/github.json": true,
     "tests/fixtures/queue-status-build-readers/jira.json": true,
@@ -9285,6 +9300,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/intake-explain-published-docs.test.ts": true,
     "tests/unit/strategies/intake-explain-scaffold.test.ts": true,
     "tests/unit/strategies/intake-explain-smoke-fixtures.test.ts": true,
+    "tests/unit/strategies/intake-prework-denominator.test.ts": true,
     "tests/unit/strategies/jira-description-adf.test.ts": true,
     "tests/unit/strategies/jira-evidence-config-bound-status.test.ts": true,
     "tests/unit/strategies/ladder-router-contract.test.ts": true,

--- a/tests/fixtures/intake-prework-denominator/linear-team-lanes.json
+++ b/tests/fixtures/intake-prework-denominator/linear-team-lanes.json
@@ -1,0 +1,15 @@
+{
+  "note": "Workflow states and open-issue counts for one team, recorded 2026-08-17. Reproduces the reported shape: a `Blocked` lane typed `unstarted` sorting after `Ready`.",
+  "totalOpen": 343,
+  "preFixSweptLaneNames": ["Backlog", "Todo", "Ready"],
+  "lanes": [
+    { "name": "Backlog", "type": "backlog", "position": 0, "count": 20 },
+    { "name": "Todo", "type": "unstarted", "position": 1, "count": 17 },
+    { "name": "Ready", "type": "unstarted", "position": 439.06, "count": 2 },
+    { "name": "Blocked", "type": "unstarted", "position": 877.13, "count": 61 },
+    { "name": "In Progress", "type": "started", "position": 2, "count": 21 },
+    { "name": "On Dev", "type": "started", "position": 3, "count": 221 },
+    { "name": "Done", "type": "completed", "position": 4, "count": 0 },
+    { "name": "Canceled", "type": "canceled", "position": 5, "count": 0 }
+  ]
+}

--- a/tests/unit/strategies/automation-run-record-cli.test.ts
+++ b/tests/unit/strategies/automation-run-record-cli.test.ts
@@ -35,6 +35,17 @@ const F_OUTCOME = "--outcome";
 const F_SUMMARY = "--summary";
 const F_RUNBOOK = "--runbook";
 const F_RUN_ID = "--run-id";
+const F_DENOMINATOR = "--denominator";
+const DENOMINATOR = JSON.stringify({
+  swept: [
+    { name: "Todo", type: "unstarted", count: 0 },
+    { name: "Ready", type: "unstarted", count: 0 },
+  ],
+  omitted: [],
+  sweptCount: 0,
+  totalOpen: 0,
+  unsweptCount: 0,
+});
 
 let root: string;
 
@@ -76,6 +87,8 @@ describe("automation run record CLI (#1798)", () => {
       RUNBOOK,
       "--ref",
       "https://github.com/CodySwannGT/lisa/issues/1798",
+      F_DENOMINATOR,
+      DENOMINATOR,
       F_RUN_ID,
       "cli-run-1",
     ]);
@@ -153,6 +166,68 @@ describe("automation run record CLI (#1798)", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain("--bogus");
+  });
+
+  it("refuses a dry build-intake run that states no denominator (#2657)", () => {
+    const result = runCli([
+      F_LOOP,
+      LOOP,
+      F_OUTCOME,
+      NOTHING_NEEDED,
+      F_SUMMARY,
+      NOTHING_SUMMARY,
+      F_RUNBOOK,
+      RUNBOOK,
+      F_RUN_ID,
+      "cli-no-denominator-1",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must state the lanes it swept");
+    expect(existsSync(path.join(root, RECORDS))).toBe(false);
+  });
+
+  it("keeps the swept lanes on the recorded row (#2657)", () => {
+    const result = runCli([
+      F_LOOP,
+      LOOP,
+      F_OUTCOME,
+      NOTHING_NEEDED,
+      F_SUMMARY,
+      NOTHING_SUMMARY,
+      F_RUNBOOK,
+      RUNBOOK,
+      F_DENOMINATOR,
+      DENOMINATOR,
+      F_RUN_ID,
+      "cli-denominator-1",
+    ]);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(readLines(RECORDS)[0])).toMatchObject({
+      denominator: { sweptCount: 0, totalOpen: 0 },
+    });
+  });
+
+  it("rejects a --denominator that is not JSON (#2657)", () => {
+    const result = runCli([
+      F_LOOP,
+      LOOP,
+      F_OUTCOME,
+      NOTHING_NEEDED,
+      F_SUMMARY,
+      NOTHING_SUMMARY,
+      F_RUNBOOK,
+      RUNBOOK,
+      F_DENOMINATOR,
+      "Backlog(20)+Todo(17)",
+      F_RUN_ID,
+      "cli-bad-denominator-1",
+    ]);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("must be JSON");
+    expect(existsSync(path.join(root, RECORDS))).toBe(false);
   });
 
   it("suppresses a duplicate re-append for the same run_id", () => {

--- a/tests/unit/strategies/intake-prework-denominator.test.ts
+++ b/tests/unit/strategies/intake-prework-denominator.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Regression coverage for the build-intake pre-work denominator (#2657).
+ *
+ * Build-intake swept its candidate lanes by state NAME, so a `Blocked` lane —
+ * which trackers model as a not-yet-started type, never as a distinct one —
+ * fell out of the denominator entirely. Thirty-one consecutive cycles reported
+ * a dry lane against a queue that was not dry, and every one of those records
+ * was honest. The fix sweeps by TYPE and makes the denominator part of the
+ * verdict.
+ * @module tests/unit/strategies/intake-prework-denominator
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyPreWorkCandidate,
+  formatReprobeNote,
+} from "../../../plugins/src/base/scripts/intake-blocker-reprobe.mjs";
+import {
+  assertDenominatorReported,
+  buildIntakeDenominator,
+  formatIntakeDenominator,
+  isPreWorkLaneType,
+  requiresDenominator,
+  selectPreWorkLanes,
+  summarizeDryLane,
+} from "../../../plugins/src/base/scripts/intake-prework-denominator.mjs";
+
+const ANY_EVIDENCE = "any evidence at all";
+const LOOP_ID = "intake-tickets";
+const NOTHING_NEEDED = "nothing-needed";
+
+const FIXTURE = JSON.parse(
+  readFileSync(
+    path.join(
+      __dirname,
+      "../../fixtures/intake-prework-denominator/linear-team-lanes.json"
+    ),
+    "utf8"
+  )
+) as {
+  readonly totalOpen: number;
+  readonly preFixSweptLaneNames: readonly string[];
+  readonly lanes: readonly {
+    name: string;
+    type: string;
+    position: number;
+    count: number;
+  }[];
+};
+
+/**
+ * The pre-fix selection: a hardcoded roster of lane NAMES.
+ *
+ * @returns the row count that sweep saw
+ */
+function sweepByHardcodedNames(): number {
+  const names = new Set(FIXTURE.preFixSweptLaneNames);
+  return FIXTURE.lanes
+    .filter(lane => names.has(lane.name))
+    .reduce((total, lane) => total + lane.count, 0);
+}
+
+describe("pre-work lanes are swept by state type, not by state name (#2657)", () => {
+  it("sweeps every not-yet-started lane including a Blocked lane typed unstarted", () => {
+    expect(selectPreWorkLanes(FIXTURE.lanes).map(lane => lane.name)).toEqual([
+      "Backlog",
+      "Todo",
+      "Ready",
+      "Blocked",
+    ]);
+  });
+
+  it("counts 61 more rows than the hardcoded-name sweep it replaces", () => {
+    const denominator = buildIntakeDenominator({
+      lanes: FIXTURE.lanes,
+      totalOpen: FIXTURE.totalOpen,
+    });
+
+    expect(sweepByHardcodedNames()).toBe(39);
+    expect(denominator.sweptCount).toBe(100);
+    expect(denominator.totalOpen).toBe(343);
+  });
+
+  it("sweeps a custom pre-work lane no roster could have listed", () => {
+    expect(
+      selectPreWorkLanes([
+        { name: "Icebox", type: "unstarted", position: 9, count: 4 },
+        { name: "Shipping", type: "started", position: 1, count: 7 },
+      ]).map(lane => lane.name)
+    ).toEqual(["Icebox"]);
+  });
+
+  it("accepts a tracker that names lane types differently", () => {
+    expect(isPreWorkLaneType("new")).toBe(true);
+    expect(isPreWorkLaneType("To Do")).toBe(true);
+    expect(isPreWorkLaneType("indeterminate")).toBe(false);
+    expect(isPreWorkLaneType("done")).toBe(false);
+    expect(isPreWorkLaneType("invented-by-nobody")).toBe(false);
+  });
+
+  it("keeps started and finished lanes out of the denominator", () => {
+    const denominator = buildIntakeDenominator({
+      lanes: FIXTURE.lanes,
+      totalOpen: FIXTURE.totalOpen,
+    });
+
+    expect(denominator.omitted.map(lane => lane.name)).toEqual([
+      "In Progress",
+      "On Dev",
+      "Done",
+      "Canceled",
+    ]);
+    expect(denominator.unsweptCount).toBe(243);
+  });
+});
+
+describe("a blocked item is re-probed rather than inherited (#2657)", () => {
+  const blockedLeaf = {
+    laneType: "unstarted",
+    labels: ["repo:frontend", "type:Bug"],
+    body: "Blocked until the shared package on trunk reaches 3.23.1.",
+    statedBlocker: "shared package on trunk >= 3.23.1",
+  };
+
+  it("surfaces an item whose discharge condition went true, with the evidence", () => {
+    expect(
+      classifyPreWorkCandidate({
+        ...blockedLeaf,
+        probe: {
+          discharged: true,
+          evidence: "trunk manifest reads 3.27.0",
+        },
+      })
+    ).toEqual({
+      selectable: true,
+      reason: "blocker-discharged",
+      humanGated: false,
+      evidence: "trunk manifest reads 3.27.0",
+    });
+  });
+
+  it("leaves an item whose condition still holds, and records why", () => {
+    const verdict = classifyPreWorkCandidate({
+      ...blockedLeaf,
+      probe: { discharged: false, evidence: "trunk manifest reads 3.21.0" },
+    });
+
+    expect(verdict.selectable).toBe(false);
+    expect(verdict.reason).toBe("blocker-holds");
+    expect(
+      formatReprobeNote(
+        { ...blockedLeaf, checkedAt: "2026-08-17T18:31:00.000Z" },
+        verdict
+      )
+    ).toContain("The blocker was re-checked and still holds");
+  });
+
+  it("refuses to select on an unevidenced discharge", () => {
+    expect(
+      classifyPreWorkCandidate({ ...blockedLeaf, probe: { discharged: true } })
+    ).toMatchObject({
+      selectable: false,
+      reason: "blocker-discharge-unevidenced",
+    });
+  });
+
+  it("refuses to select an item nothing re-probed this cycle", () => {
+    expect(
+      classifyPreWorkCandidate({ ...blockedLeaf, probe: null })
+    ).toMatchObject({ selectable: false, reason: "blocker-unprobed" });
+  });
+
+  it("selects a pre-work item that states no blocker at all", () => {
+    expect(
+      classifyPreWorkCandidate({ laneType: "unstarted", labels: [] })
+    ).toMatchObject({ selectable: true, reason: "no-blocker" });
+  });
+
+  it("writes the re-probe note in plain words an operator can read", () => {
+    const note = formatReprobeNote(
+      {
+        statedBlocker: "two advisories patched",
+        checkedAt: "2026-08-17T00:00:00.000Z",
+      },
+      {
+        reason: "blocker-discharged",
+        evidence: "both advisories now carry a fix",
+      }
+    );
+
+    expect(note).toContain("What has to be true: two advisories patched");
+    expect(note).toContain(
+      "no longer applies, so this item is buildable again"
+    );
+    expect(note).toContain("Proof: both advisories now carry a fix");
+    expect(note).toContain("Checked at: 2026-08-17T00:00:00.000Z");
+  });
+});
+
+describe("a human-gated item is never auto-selected (#2657)", () => {
+  it("refuses an item carrying the human-needed label even when the blocker cleared", () => {
+    expect(
+      classifyPreWorkCandidate({
+        laneType: "unstarted",
+        labels: ["repo:frontend", "human-needed"],
+        statedBlocker: "founder scope decision",
+        probe: { discharged: true, evidence: ANY_EVIDENCE },
+      })
+    ).toMatchObject({
+      selectable: false,
+      reason: "human-gate",
+      humanGated: true,
+    });
+  });
+
+  it("refuses an item carrying the human-gate marker in its body", () => {
+    expect(
+      classifyPreWorkCandidate({
+        laneType: "unstarted",
+        labels: [],
+        body: "<!-- [lisa-human-gate] reason=product-call -->",
+        probe: { discharged: true, evidence: ANY_EVIDENCE },
+      })
+    ).toMatchObject({ selectable: false, humanGated: true });
+  });
+
+  it("honours a project-configured human-gate label name", () => {
+    expect(
+      classifyPreWorkCandidate({
+        laneType: "unstarted",
+        labels: ["Human Needed"],
+        humanNeededLabel: "Human Needed",
+        probe: { discharged: true, evidence: ANY_EVIDENCE },
+      })
+    ).toMatchObject({ selectable: false, humanGated: true });
+  });
+});
+
+describe("a dry lane states its denominator (#2657)", () => {
+  const denominator = buildIntakeDenominator({
+    lanes: FIXTURE.lanes,
+    totalOpen: FIXTURE.totalOpen,
+  });
+
+  it("names every swept lane, its count, and the open total", () => {
+    const summary = summarizeDryLane(denominator, { queue: "team TUN" });
+
+    expect(summary).toContain("Nothing ready to build on team TUN.");
+    expect(summary).toContain("Backlog (20)");
+    expect(summary).toContain("Todo (17)");
+    expect(summary).toContain("Ready (2)");
+    expect(summary).toContain("Blocked (61)");
+    expect(summary).toContain("100 items checked out of 343 still open");
+  });
+
+  it("uses no jargon a non-technical operator would have to decode", () => {
+    const summary = formatIntakeDenominator(denominator);
+
+    for (const jargon of [
+      "unstarted",
+      "backlog type",
+      "denominator",
+      "GraphQL",
+      "state type",
+    ]) {
+      expect(summary).not.toContain(jargon);
+    }
+  });
+
+  it("requires a denominator only for a dry build-intake run", () => {
+    expect(requiresDenominator(LOOP_ID, NOTHING_NEEDED)).toBe(true);
+    expect(requiresDenominator(LOOP_ID, "candidate-proposed")).toBe(false);
+    expect(requiresDenominator("monitor", NOTHING_NEEDED)).toBe(false);
+  });
+
+  it("rejects a dry build-intake run that states no denominator", () => {
+    expect(() =>
+      assertDenominatorReported({
+        loopId: LOOP_ID,
+        outcome: NOTHING_NEEDED,
+      })
+    ).toThrow(/must state the lanes it swept, and no denominator was supplied/);
+  });
+
+  it("rejects a denominator that names no lanes", () => {
+    expect(() =>
+      assertDenominatorReported({
+        loopId: LOOP_ID,
+        outcome: NOTHING_NEEDED,
+        denominator: { swept: [], sweptCount: 0, totalOpen: 343 },
+      })
+    ).toThrow(/it names no swept lanes/);
+  });
+
+  it("rejects a denominator claiming more swept rows than are open", () => {
+    expect(() =>
+      assertDenominatorReported({
+        loopId: LOOP_ID,
+        outcome: NOTHING_NEEDED,
+        denominator: {
+          swept: [{ name: "Ready", type: "unstarted", count: 400 }],
+          sweptCount: 400,
+          totalOpen: 343,
+        },
+      })
+    ).toThrow(/more items than are open/);
+  });
+
+  it("accepts a well-formed denominator", () => {
+    expect(() =>
+      assertDenominatorReported({
+        loopId: LOOP_ID,
+        outcome: NOTHING_NEEDED,
+        denominator,
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## What was wrong

`lisa-*-build-intake` picked its candidates from a hardcoded roster of lane **names**. No tracker has a `blocked` lane type — Linear models a `Blocked` state as `unstarted`, JIRA models a `Blocked` status under the `To Do` category, and GitHub has no type field at all. So a `Blocked` lane is **pre-work**: items that were *never started*, each carrying a written blocker that nothing ever re-read. A name roster omits that lane silently, and the scanner then reports an empty queue over a full one.

## The two denominators, measured

Computed on the new fixture (`tests/fixtures/intake-prework-denominator/linear-team-lanes.json`), which reproduces the reported lane shape:

```
PRE-FIX  (sweep by state NAME): Backlog(20)+Todo(17)+Ready(2)             =  39 of 343 open
POST-FIX (sweep by state TYPE): Backlog(20)+Todo(17)+Ready(2)+Blocked(61) = 100 of 343 open
Rows the pre-fix denominator never selected: 61
```

61 rows were never selectable. That produced 31 consecutive "dry lane" cycles over a queue that was not dry — every run record honest, every conclusion false.

## What changed

Three executable controls, not prose:

1. **`plugins/src/base/scripts/intake-prework-denominator.mjs`** — selects lanes by *normalized type* (`backlog` / `unstarted`, with JIRA's `new` / `To Do` category vocabulary mapped in) and builds the swept-set report. A team that adds `Icebox` as an unstarted state gets it swept with no code change.
2. **`plugins/src/base/scripts/intake-blocker-reprobe.mjs`** — treats a blocker as a claim with a timestamp, not a fact. The **human gate is checked first and is absolute**: no probe, however conclusive, can promote an item a person parked. A discharge with no recorded evidence is not a discharge, and neither is a candidate nothing probed this cycle.
3. **`automation-run-record.mjs` refuses a `nothing-needed` row for `intake-tickets` without `--denominator`.** A missing run record is noisy on inspection; a wrong denominator is silent forever and looks exactly like a healthy dry queue. This is the half that would have caught the defect on cycle 2 rather than cycle 32.

Wired into all three vendor scanners (`linear` / `jira` / `github`) plus the vendor-neutral `lisa-tracker-build-intake` shim and the `automation-runbook-contract` rule, so the pre-work vocabulary cannot drift per tracker. Fanned out to every agent plugin by `build:plugins`.

## Operator-facing wording

The dry-lane summary is written for a non-technical reader — no lane types, no jargon, and a test asserts the absence of each term:

> Nothing ready to build on team ENG. Looked in every lane holding work that has not started — Backlog (20), Todo (17), Ready (2), Blocked (61) — 100 items checked out of 343 still open.

## Bite control (each guard proven RED before the fix)

| Guard broken | Named tests observed RED |
|---|---|
| `selectPreWorkLanes` reverted to the pre-fix `["Backlog","Todo","Ready"]` name roster | 5 failed, incl. *"sweeps every not-yet-started lane including a Blocked lane typed unstarted"* and *"counts 61 more rows than the hardcoded-name sweep it replaces"* |
| `assertDenominatorReported` call removed from `recordAutomationRun` | 1 failed: *"refuses a dry build-intake run that states no denominator (#2657)"* |
| Human gate moved to run *after* the probe instead of first | 3 failed, incl. *"refuses an item carrying the human-needed label even when the blocker cleared"* |

Each was restored and re-run GREEN.

## Verification

- `bun run test:cov` — **734 files / 13269 tests, all passing** on this branch; the `origin/main` baseline under the same command is 733 / 13245.
- `bun run lint`, `bun run typecheck`, `bun run check:artifacts` — clean. Derived artifacts regenerated after `git add` and staged.

## Not covered

- No live tracker run. Every number here comes from the fixture and the unit suite; the scanners themselves are agent-executed prose that now cites the shared helpers.
- Phase 2.5 does not itself run probes — it classifies a probe result the scanner supplies. That keeps the human-gate ordering and the evidence requirement testable apart from the network, but the *quality* of a probe is still the scanner's judgment.

Work-Item: CodySwannGT/lisa#2657
