### PR TITLE
fix(gates): declare the .mjs gate off, and stop that off from rotting

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -491,7 +491,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -595,7 +595,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -680,7 +680,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -809,7 +809,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -1221,7 +1221,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -1444,7 +1444,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -1559,7 +1559,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -2174,7 +2174,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -2259,7 +2259,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -2720,7 +2720,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -2936,7 +2936,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -3071,7 +3071,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -3166,7 +3166,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -3261,7 +3261,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -3357,7 +3357,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi
@@ -3585,7 +3585,7 @@ jobs:
         run: |
           set -euo pipefail
           RESOLVER=""
-          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs"; do
+          for candidate in "node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-gates.mjs" "scripts/lisa-gates.mjs" "all/copy-overwrite/scripts/lisa-gates.mjs"; do
             if [ -f "$candidate" ]; then RESOLVER="$candidate"; break; fi
           done
           if [ -z "$RESOLVER" ]; then echo "configured=false" >> "$GITHUB_OUTPUT"; exit 0; fi

--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -140,6 +140,10 @@
     },
     "version-duplication": {
       "pull-request": "optional"
+    },
+    "test-node-suites": {
+      "push": "off",
+      "pull-request": "off"
     }
   },
   "policy": {

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8841,6 +8841,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/jest-base.test.ts": true,
     "tests/unit/config/jest-expo.test.ts": true,
     "tests/unit/config/js-yaml-security-floor.test.ts": true,
+    "tests/unit/config/mjs-gate-off-stays-honest.test.ts": true,
     "tests/unit/config/oxlint-expo.test.ts": true,
     "tests/unit/config/oxlint-jsdoc-parity.test.ts": true,
     "tests/unit/config/oxlint-typescript.test.ts": true,

--- a/tests/unit/config/mjs-gate-off-stays-honest.test.ts
+++ b/tests/unit/config/mjs-gate-off-stays-honest.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Keeps `test-node-suites: off` honest about why it is off.
+ *
+ * This repository declares the gate `off` because it genuinely has no
+ * `*.test.mjs` suites — the plugin suites are collected by vitest, and the
+ * `.mjs` runner it ships resolves for CONSUMERS through their installed
+ * package, never for the repository that ships it. `off` was the remedy the
+ * gate's own error message prescribed, and it is the honest one: it drops the
+ * required context instead of satisfying it vacuously.
+ *
+ * What `off` cannot do is stay correct on its own. The first `*.test.mjs`
+ * added here would go unrun with the gate reporting nothing at all — not a
+ * red, not a warning, silence. That is the same shape as every defect this
+ * gate exists to catch, arriving through the remedy rather than the bug.
+ *
+ * So the declaration and the fact it rests on are checked against each other.
+ * Adding a `.mjs` suite while the gate is `off` fails here and names the
+ * contradiction; the fix is to stop declaring `off`, not to edit this test.
+ * @module tests/unit/config/mjs-gate-off-stays-honest
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+/** The gate whose declaration this guard holds to its stated reason. */
+const GATE_ID = "test-node-suites";
+
+/**
+ * Directories that are not this repository's own source.
+ *
+ * `node_modules` matters most: the self-referencing devDependency installs an
+ * older Lisa under it, and counting a suite shipped by that copy as evidence
+ * about THIS repository is exactly the confusion #2695 was filed about.
+ */
+const SKIP_DIRECTORIES = new Set([
+  ".git",
+  "node_modules",
+  "dist",
+  "coverage",
+  ".next",
+  "build",
+]);
+
+/**
+ * Walks the repository for `*.test.mjs`, independent of any glob.
+ *
+ * Deliberately a plain recursive `readdir` rather than the pattern the runner
+ * uses: a guard that derived both sides from the same glob would agree with
+ * itself however wrong the glob became.
+ * @param directory - Absolute directory to walk
+ * @returns Repository-relative paths of every `*.test.mjs` found
+ */
+function findMjsSuites(directory: string): readonly string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap(entry => {
+    if (entry.isDirectory()) {
+      return SKIP_DIRECTORIES.has(entry.name)
+        ? []
+        : findMjsSuites(path.join(directory, entry.name));
+    }
+    return entry.name.endsWith(".test.mjs")
+      ? [path.relative(REPO_ROOT, path.join(directory, entry.name))]
+      : [];
+  });
+}
+
+/**
+ * Reads this repository's declared level for the gate.
+ * @returns The declared level, or `undefined` when the gate is not declared
+ */
+function declaredLevel(): unknown {
+  const raw = readFileSync(path.join(REPO_ROOT, ".lisa.config.json"), "utf-8");
+  const config = JSON.parse(raw) as {
+    readonly gates?: Record<string, unknown>;
+  };
+  return (config.gates ?? {})[GATE_ID];
+}
+
+describe("test-node-suites off stays honest", () => {
+  it("declares the gate off only while no .mjs suite exists to run", () => {
+    const level = declaredLevel();
+    if (level !== "off") {
+      // Declared required/optional, or not declared at all — the runner
+      // governs from here and there is nothing for this guard to contradict.
+      return;
+    }
+
+    const suites = findMjsSuites(REPO_ROOT);
+
+    expect(
+      suites,
+      `gates.${GATE_ID} is declared "off" on the premise that this repository ` +
+        `has no *.test.mjs suites, but ${suites.length} now exist:\n` +
+        `${suites.map(suite => `  ${suite}`).join("\n")}\n` +
+        `Those suites are NOT being run and the gate reports nothing at all. ` +
+        `Remove the "off" declaration so the runner collects them — do not ` +
+        `edit this test, which exists to make that omission impossible.`
+    ).toEqual([]);
+  });
+
+  it("fails if the gate declaration disappears from the config entirely", () => {
+    // An absent declaration is what reddened every pull request in #2695: the
+    // job runs, finds no runner, and refuses to pass. Pinning presence means a
+    // stray edit that drops the key gets caught here rather than in CI.
+    expect(declaredLevel()).toBeDefined();
+  });
+});

--- a/tests/unit/config/mjs-gate-off-stays-honest.test.ts
+++ b/tests/unit/config/mjs-gate-off-stays-honest.test.ts
@@ -19,7 +19,8 @@
  * @module tests/unit/config/mjs-gate-off-stays-honest
  */
 
-import { readdirSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -108,5 +109,91 @@ describe("test-node-suites off stays honest", () => {
     // job runs, finds no runner, and refuses to pass. Pinning presence means a
     // stray edit that drops the key gets caught here rather than in CI.
     expect(declaredLevel()).toBeDefined();
+  });
+});
+
+describe("this repository can resolve its own gate declarations", () => {
+  /**
+   * The candidate list READ OUT OF quality.yml, never a copy of it.
+   *
+   * A hardcoded duplicate would keep passing after someone shortened the real
+   * list — the test would be agreeing with itself about a workflow it no
+   * longer describes. Parsing the workflow means removing a path there fails
+   * here.
+   */
+  const RESOLVER_CANDIDATES: readonly string[] = (() => {
+    const workflow = readFileSync(
+      path.join(REPO_ROOT, ".github/workflows/quality.yml"),
+      "utf-8"
+    );
+    const line = workflow
+      .split("\n")
+      .find(
+        candidate =>
+          candidate.includes("for candidate in") &&
+          candidate.includes("lisa-gates.mjs")
+      );
+    if (line === undefined) {
+      throw new Error(
+        "No gate-resolver candidate loop found in quality.yml — the facades " +
+          "were restructured and this guard no longer describes them."
+      );
+    }
+    return [...line.matchAll(/"([^"]*lisa-gates\.mjs)"/g)].map(
+      match => match[1] as string
+    );
+  })();
+
+  it("finds a gate resolver on at least one candidate path", () => {
+    // Why this exists: for a long time NEITHER of the first two resolved here.
+    // `node_modules/@codyswann/lisa` is this repository's own devDependency,
+    // pinned `^2.328.0` while latest is 3.x — a caret cannot cross the major,
+    // so it installs a version predating lisa-gates.mjs. And Lisa's copy lives
+    // under all/copy-overwrite/, not scripts/. With no resolver the facades
+    // emit `configured=false` and fall through to built-in behaviour, so EVERY
+    // gate this repository declared was inert while reading as configured.
+    const found = RESOLVER_CANDIDATES.filter(candidate =>
+      existsSync(path.join(REPO_ROOT, candidate))
+    );
+
+    expect(
+      found,
+      `No gate resolver is reachable from any path quality.yml searches:\n` +
+        `${RESOLVER_CANDIDATES.map(c => `  ${c}`).join("\n")}\n` +
+        `Every gates block in .lisa.config.json is therefore INERT here — the ` +
+        `facades resolve configured=false and run built-in behaviour, ` +
+        `including for gates declared "off".`
+    ).not.toEqual([]);
+  });
+
+  it("honours an off declaration through the shipped resolver", () => {
+    // The end-to-end check: not "the file exists" but "declaring off actually
+    // reads back as off". A resolver that is present but cannot parse this
+    // repository's config would still leave the gate inert.
+    const resolver = RESOLVER_CANDIDATES.map(c => path.join(REPO_ROOT, c)).find(
+      candidate => existsSync(candidate)
+    );
+    expect(resolver, "no resolver to exercise").toBeDefined();
+
+    const raw = execFileSync(
+      process.execPath,
+      [
+        resolver as string,
+        "list",
+        "--moment=pull-request",
+        "--json",
+        "--include-off",
+      ],
+      { cwd: REPO_ROOT, encoding: "utf-8" }
+    );
+    const gates = JSON.parse(raw) as readonly { id: string; level: string }[];
+    const gate = gates.find(entry => entry.id === GATE_ID);
+
+    expect(
+      gate?.level,
+      `${GATE_ID} is declared "off" in .lisa.config.json but the resolver ` +
+        `reports ${JSON.stringify(gate?.level)}. The declaration is not ` +
+        `reaching the facades, so the job will run built-in behaviour anyway.`
+    ).toBe("off");
   });
 });


### PR DESCRIPTION
`🧪 Run .mjs Suites` reddened every pull request in this repository. The gate was right to fail — it found a real hole rather than causing one.

## Cause

The runner lives at `all/copy-overwrite/scripts/lisa-test-node.mjs`, which is neither path the job searches:

- `scripts/lisa-test-node.mjs` — absent
- `node_modules/@codyswann/lisa/...` — resolves to this repository's **self-referencing devDependency**, pinned `^2.328.0` while latest is `3.33.8`. A caret cannot cross the major, so it installs a 2.x predating the runner.

`main` looked green the whole time. The job runs on `pull_request` only, so a green main said nothing about this gate — the same "the query cannot return the positive" trap as elsewhere in this repo.

## Why `off` and not a devDep bump

This repository has zero `*.test.mjs` suites:

```
$ git ls-tree -r origin/main --name-only | grep -c '\.test\.mjs$'
0
```

The plugin suites are collected by **vitest**, not by the `.mjs` runner. `off` is the honest declaration and the one the gate's own error message prescribes — it drops the required context rather than satisfying it vacuously.

Bumping the devDep would **not** have fixed it: with the runner present, collection finds zero suites, and empty collection also fails — correctly.

## The rot this would otherwise leave

`off` is right today and decays in silence. The first `*.test.mjs` added here would go unrun with the gate reporting nothing at all — the exact defect the gate exists to catch, delivered by the remedy for it. So the declaration ships with a check binding it to the fact it rests on.

Enumeration is a plain recursive `readdir`, deliberately not the runner's glob: a guard deriving both sides from one pattern agrees with itself however wrong the pattern gets.

## Bite control

```
× declares the gate off only while no .mjs suite exists to run
  AssertionError: gates.test-node-suites is declared "off" on the premise that
  this repository has no *.test.mjs suites, but 1 now exist:
    tests/bite-control.test.mjs

× fails if the gate declaration disappears from the config entirely
```

Both restore green (`Tests 2 passed`).

## Scope note

Declared at `push` and `pull-request` only. The validator rejects bare `pre-deploy`/`post-deploy` — they need an environment suffix, and this package has no deploy environment. Running `lisa-gates.mjs validate` is what caught both that and an earlier bare-string `"off"` that would not have parsed.

Changing the two paths the job searches stays out of scope: consumers resolve the runner through their installed package, which is correct for them. This is a self-hosting gap specific to the repository that ships it.

Work-Item: CodySwannGT/lisa#2695


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when resolving quality checks across packaged and local installations.
  * Added safeguards to ensure disabled test-suite checks remain accurately configured and are only allowed when applicable.

* **Tests**
  * Added automated validation to detect unexpected test suites and verify that quality-check configuration is honored consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->