### PR TITLE
fix(automations): stop an append rewriting rows it did not author

### DIFF
--- a/plugins/lisa-agy/scripts/automation-run-record.mjs
+++ b/plugins/lisa-agy/scripts/automation-run-record.mjs
@@ -33,6 +33,10 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly run_id: string
  * }} AutomationRunRecord
  *
+ * `refs` above is the AUTHORED contract. A row already on disk whose `refs` is
+ * some other shape is round-tripped as stored rather than coerced — see
+ * {@link preserveStoredRefs}.
+ *
  * @typedef {{
  *   readonly projectRoot?: string
  *   readonly loopId: string
@@ -74,14 +78,26 @@ export async function recordAutomationRun(input) {
     };
   }
 
-  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  // Prior rows are carried across as the RAW LINES they were read as, never
+  // re-serialised from the parsed form. Re-serialising is what let an append
+  // rewrite rows it did not author: a stored `refs` shape the writer did not
+  // recognise came back as `[]`, and a row that failed validation came back as
+  // nothing at all (#2682, #2578). Only the row being appended is serialised
+  // here, so an append can no longer be a fleet-wide migration nobody ran.
+  const nextEntries = [
+    ...readResult.entries,
+    { line: JSON.stringify(record), record },
+  ].slice(-maxEntries);
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeJsonlAtomically(filePath, nextRecords);
+  await writeJsonlAtomically(
+    filePath,
+    nextEntries.map(entry => entry.line)
+  );
 
   return {
     path: filePath,
     record,
-    records: nextRecords,
+    records: nextEntries.flatMap(entry => (entry.record ? [entry.record] : [])),
     appended: true,
     skippedCorruptLines: readResult.skippedCorruptLines,
     maxEntries,
@@ -126,8 +142,12 @@ export function automationRunRecordPath(projectRoot, loopId) {
 }
 
 /**
+ * Read a ledger, keeping every non-blank line verbatim alongside its parsed
+ * form. `records` is the validated view for consumers; `entries` is what the
+ * append path rewrites, so a row this module cannot parse or validate survives
+ * instead of being deleted by the next unrelated append (#2578).
  * @param {string} filePath
- * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly entries: readonly { readonly line: string, readonly record?: AutomationRunRecord }[], readonly skippedCorruptLines: number }>}
  */
 export async function readAutomationRunRecords(filePath) {
   let content = "";
@@ -135,12 +155,13 @@ export async function readAutomationRunRecords(filePath) {
     content = await readFile(filePath, "utf8");
   } catch (error) {
     if (error?.code === "ENOENT") {
-      return { records: [], skippedCorruptLines: 0 };
+      return { records: [], entries: [], skippedCorruptLines: 0 };
     }
     throw error;
   }
 
-  const records = [];
+  /** @type {{ readonly line: string, readonly record?: AutomationRunRecord }[]} */
+  const entries = [];
   let skippedCorruptLines = 0;
   for (const line of content.split(/\n/)) {
     if (!line.trim()) {
@@ -148,13 +169,21 @@ export async function readAutomationRunRecords(filePath) {
     }
     try {
       const parsed = JSON.parse(line);
-      records.push(validateStoredRecord(parsed));
+      entries.push({ line, record: validateStoredRecord(parsed) });
     } catch {
+      // Kept, not dropped. The caller rewrites the file from `entries`, so a
+      // row omitted here would be DELETED from disk by the next unrelated
+      // append (#2578). It stays exactly as read; only `records` excludes it.
+      entries.push({ line });
       skippedCorruptLines += 1;
     }
   }
 
-  return { records, skippedCorruptLines };
+  return {
+    records: entries.flatMap(entry => (entry.record ? [entry.record] : [])),
+    entries,
+    skippedCorruptLines,
+  };
 }
 
 /**
@@ -162,12 +191,58 @@ export async function readAutomationRunRecords(filePath) {
  * @returns {AutomationRunRecord}
  */
 function buildAutomationRunRecord(input) {
+  return assembleAutomationRunRecord(input, normalizeAuthoredRefs(input.refs));
+}
+
+/**
+ * `refs` as an author supplied it.
+ *
+ * A shape this module cannot store as written is REJECTED, not quietly
+ * emptied. Coercing to `[]` is how a caller could record a run whose evidence
+ * links were dropped while the write still reported success (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {readonly string[]}
+ */
+function normalizeAuthoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  if (!Array.isArray(refs)) {
+    throw new Error(
+      `Automation run refs must be an array of strings; received ${typeof refs}.`
+    );
+  }
+  return refs.map(ref => String(ref));
+}
+
+/**
+ * `refs` as it was stored, round-tripped rather than coerced.
+ *
+ * A stored shape this module does not recognise — the object form
+ * `{tickets, prs, commits}` observed in the field — is returned unchanged.
+ * Coercing it to `[]` here destroyed the evidence links on every prior row at
+ * the next append: silently, retroactively, and irreversibly (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {unknown}
+ */
+function preserveStoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  return Array.isArray(refs) ? refs.map(ref => String(ref)) : refs;
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @param {unknown} refs - Already-resolved `refs` for this record.
+ * @returns {AutomationRunRecord}
+ */
+function assembleAutomationRunRecord(input, refs) {
   const loopId = normalizeLoopId(input.loopId);
   const summary = String(input.summary ?? "").trim();
   const runbook = String(input.runbook ?? "").trim();
-  const refs = Array.isArray(input.refs)
-    ? input.refs.map(ref => String(ref))
-    : [];
   const ts =
     input.ts instanceof Date
       ? input.ts.toISOString()
@@ -240,21 +315,23 @@ function validateStoredRecord(value) {
   if (!value || typeof value !== "object") {
     throw new Error("Automation run record must be an object.");
   }
-  return buildAutomationRunRecord({
-    ts: String(value.ts ?? ""),
-    loopId: String(value.loop_id ?? ""),
-    outcome: String(value.outcome ?? ""),
-    summary: String(value.summary ?? ""),
-    runbook: String(value.runbook ?? ""),
-    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
-    runId: String(value.run_id ?? ""),
-    // Carry every unrecognised key forward. Without this, re-validating a
-    // stored record on read silently strips it, and the next append writes the
-    // stripped history back over the file (#2524).
-    extras: Object.fromEntries(
-      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
-    ),
-  });
+  return assembleAutomationRunRecord(
+    {
+      ts: String(value.ts ?? ""),
+      loopId: String(value.loop_id ?? ""),
+      outcome: String(value.outcome ?? ""),
+      summary: String(value.summary ?? ""),
+      runbook: String(value.runbook ?? ""),
+      runId: String(value.run_id ?? ""),
+      // Carry every unrecognised key forward. Without this, re-validating a
+      // stored record on read silently strips it, and the next append writes
+      // the stripped history back over the file (#2524).
+      extras: Object.fromEntries(
+        Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+      ),
+    },
+    preserveStoredRefs(value.refs)
+  );
 }
 
 /**
@@ -291,10 +368,10 @@ async function readJsonIfPresent(filePath) {
 
 /**
  * @param {string} filePath
- * @param {readonly AutomationRunRecord[]} records
+ * @param {readonly string[]} lines - Serialised rows, written verbatim.
  */
-async function writeJsonlAtomically(filePath, records) {
-  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+async function writeJsonlAtomically(filePath, lines) {
+  const content = `${lines.join("\n")}\n`;
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
   await writeFile(tempPath, content, "utf8");
   await rename(tempPath, filePath);

--- a/plugins/lisa-copilot/scripts/automation-run-record.mjs
+++ b/plugins/lisa-copilot/scripts/automation-run-record.mjs
@@ -33,6 +33,10 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly run_id: string
  * }} AutomationRunRecord
  *
+ * `refs` above is the AUTHORED contract. A row already on disk whose `refs` is
+ * some other shape is round-tripped as stored rather than coerced — see
+ * {@link preserveStoredRefs}.
+ *
  * @typedef {{
  *   readonly projectRoot?: string
  *   readonly loopId: string
@@ -74,14 +78,26 @@ export async function recordAutomationRun(input) {
     };
   }
 
-  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  // Prior rows are carried across as the RAW LINES they were read as, never
+  // re-serialised from the parsed form. Re-serialising is what let an append
+  // rewrite rows it did not author: a stored `refs` shape the writer did not
+  // recognise came back as `[]`, and a row that failed validation came back as
+  // nothing at all (#2682, #2578). Only the row being appended is serialised
+  // here, so an append can no longer be a fleet-wide migration nobody ran.
+  const nextEntries = [
+    ...readResult.entries,
+    { line: JSON.stringify(record), record },
+  ].slice(-maxEntries);
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeJsonlAtomically(filePath, nextRecords);
+  await writeJsonlAtomically(
+    filePath,
+    nextEntries.map(entry => entry.line)
+  );
 
   return {
     path: filePath,
     record,
-    records: nextRecords,
+    records: nextEntries.flatMap(entry => (entry.record ? [entry.record] : [])),
     appended: true,
     skippedCorruptLines: readResult.skippedCorruptLines,
     maxEntries,
@@ -126,8 +142,12 @@ export function automationRunRecordPath(projectRoot, loopId) {
 }
 
 /**
+ * Read a ledger, keeping every non-blank line verbatim alongside its parsed
+ * form. `records` is the validated view for consumers; `entries` is what the
+ * append path rewrites, so a row this module cannot parse or validate survives
+ * instead of being deleted by the next unrelated append (#2578).
  * @param {string} filePath
- * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly entries: readonly { readonly line: string, readonly record?: AutomationRunRecord }[], readonly skippedCorruptLines: number }>}
  */
 export async function readAutomationRunRecords(filePath) {
   let content = "";
@@ -135,12 +155,13 @@ export async function readAutomationRunRecords(filePath) {
     content = await readFile(filePath, "utf8");
   } catch (error) {
     if (error?.code === "ENOENT") {
-      return { records: [], skippedCorruptLines: 0 };
+      return { records: [], entries: [], skippedCorruptLines: 0 };
     }
     throw error;
   }
 
-  const records = [];
+  /** @type {{ readonly line: string, readonly record?: AutomationRunRecord }[]} */
+  const entries = [];
   let skippedCorruptLines = 0;
   for (const line of content.split(/\n/)) {
     if (!line.trim()) {
@@ -148,13 +169,21 @@ export async function readAutomationRunRecords(filePath) {
     }
     try {
       const parsed = JSON.parse(line);
-      records.push(validateStoredRecord(parsed));
+      entries.push({ line, record: validateStoredRecord(parsed) });
     } catch {
+      // Kept, not dropped. The caller rewrites the file from `entries`, so a
+      // row omitted here would be DELETED from disk by the next unrelated
+      // append (#2578). It stays exactly as read; only `records` excludes it.
+      entries.push({ line });
       skippedCorruptLines += 1;
     }
   }
 
-  return { records, skippedCorruptLines };
+  return {
+    records: entries.flatMap(entry => (entry.record ? [entry.record] : [])),
+    entries,
+    skippedCorruptLines,
+  };
 }
 
 /**
@@ -162,12 +191,58 @@ export async function readAutomationRunRecords(filePath) {
  * @returns {AutomationRunRecord}
  */
 function buildAutomationRunRecord(input) {
+  return assembleAutomationRunRecord(input, normalizeAuthoredRefs(input.refs));
+}
+
+/**
+ * `refs` as an author supplied it.
+ *
+ * A shape this module cannot store as written is REJECTED, not quietly
+ * emptied. Coercing to `[]` is how a caller could record a run whose evidence
+ * links were dropped while the write still reported success (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {readonly string[]}
+ */
+function normalizeAuthoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  if (!Array.isArray(refs)) {
+    throw new Error(
+      `Automation run refs must be an array of strings; received ${typeof refs}.`
+    );
+  }
+  return refs.map(ref => String(ref));
+}
+
+/**
+ * `refs` as it was stored, round-tripped rather than coerced.
+ *
+ * A stored shape this module does not recognise — the object form
+ * `{tickets, prs, commits}` observed in the field — is returned unchanged.
+ * Coercing it to `[]` here destroyed the evidence links on every prior row at
+ * the next append: silently, retroactively, and irreversibly (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {unknown}
+ */
+function preserveStoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  return Array.isArray(refs) ? refs.map(ref => String(ref)) : refs;
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @param {unknown} refs - Already-resolved `refs` for this record.
+ * @returns {AutomationRunRecord}
+ */
+function assembleAutomationRunRecord(input, refs) {
   const loopId = normalizeLoopId(input.loopId);
   const summary = String(input.summary ?? "").trim();
   const runbook = String(input.runbook ?? "").trim();
-  const refs = Array.isArray(input.refs)
-    ? input.refs.map(ref => String(ref))
-    : [];
   const ts =
     input.ts instanceof Date
       ? input.ts.toISOString()
@@ -240,21 +315,23 @@ function validateStoredRecord(value) {
   if (!value || typeof value !== "object") {
     throw new Error("Automation run record must be an object.");
   }
-  return buildAutomationRunRecord({
-    ts: String(value.ts ?? ""),
-    loopId: String(value.loop_id ?? ""),
-    outcome: String(value.outcome ?? ""),
-    summary: String(value.summary ?? ""),
-    runbook: String(value.runbook ?? ""),
-    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
-    runId: String(value.run_id ?? ""),
-    // Carry every unrecognised key forward. Without this, re-validating a
-    // stored record on read silently strips it, and the next append writes the
-    // stripped history back over the file (#2524).
-    extras: Object.fromEntries(
-      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
-    ),
-  });
+  return assembleAutomationRunRecord(
+    {
+      ts: String(value.ts ?? ""),
+      loopId: String(value.loop_id ?? ""),
+      outcome: String(value.outcome ?? ""),
+      summary: String(value.summary ?? ""),
+      runbook: String(value.runbook ?? ""),
+      runId: String(value.run_id ?? ""),
+      // Carry every unrecognised key forward. Without this, re-validating a
+      // stored record on read silently strips it, and the next append writes
+      // the stripped history back over the file (#2524).
+      extras: Object.fromEntries(
+        Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+      ),
+    },
+    preserveStoredRefs(value.refs)
+  );
 }
 
 /**
@@ -291,10 +368,10 @@ async function readJsonIfPresent(filePath) {
 
 /**
  * @param {string} filePath
- * @param {readonly AutomationRunRecord[]} records
+ * @param {readonly string[]} lines - Serialised rows, written verbatim.
  */
-async function writeJsonlAtomically(filePath, records) {
-  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+async function writeJsonlAtomically(filePath, lines) {
+  const content = `${lines.join("\n")}\n`;
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
   await writeFile(tempPath, content, "utf8");
   await rename(tempPath, filePath);

--- a/plugins/lisa-cursor/scripts/automation-run-record.mjs
+++ b/plugins/lisa-cursor/scripts/automation-run-record.mjs
@@ -33,6 +33,10 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly run_id: string
  * }} AutomationRunRecord
  *
+ * `refs` above is the AUTHORED contract. A row already on disk whose `refs` is
+ * some other shape is round-tripped as stored rather than coerced — see
+ * {@link preserveStoredRefs}.
+ *
  * @typedef {{
  *   readonly projectRoot?: string
  *   readonly loopId: string
@@ -74,14 +78,26 @@ export async function recordAutomationRun(input) {
     };
   }
 
-  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  // Prior rows are carried across as the RAW LINES they were read as, never
+  // re-serialised from the parsed form. Re-serialising is what let an append
+  // rewrite rows it did not author: a stored `refs` shape the writer did not
+  // recognise came back as `[]`, and a row that failed validation came back as
+  // nothing at all (#2682, #2578). Only the row being appended is serialised
+  // here, so an append can no longer be a fleet-wide migration nobody ran.
+  const nextEntries = [
+    ...readResult.entries,
+    { line: JSON.stringify(record), record },
+  ].slice(-maxEntries);
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeJsonlAtomically(filePath, nextRecords);
+  await writeJsonlAtomically(
+    filePath,
+    nextEntries.map(entry => entry.line)
+  );
 
   return {
     path: filePath,
     record,
-    records: nextRecords,
+    records: nextEntries.flatMap(entry => (entry.record ? [entry.record] : [])),
     appended: true,
     skippedCorruptLines: readResult.skippedCorruptLines,
     maxEntries,
@@ -126,8 +142,12 @@ export function automationRunRecordPath(projectRoot, loopId) {
 }
 
 /**
+ * Read a ledger, keeping every non-blank line verbatim alongside its parsed
+ * form. `records` is the validated view for consumers; `entries` is what the
+ * append path rewrites, so a row this module cannot parse or validate survives
+ * instead of being deleted by the next unrelated append (#2578).
  * @param {string} filePath
- * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly entries: readonly { readonly line: string, readonly record?: AutomationRunRecord }[], readonly skippedCorruptLines: number }>}
  */
 export async function readAutomationRunRecords(filePath) {
   let content = "";
@@ -135,12 +155,13 @@ export async function readAutomationRunRecords(filePath) {
     content = await readFile(filePath, "utf8");
   } catch (error) {
     if (error?.code === "ENOENT") {
-      return { records: [], skippedCorruptLines: 0 };
+      return { records: [], entries: [], skippedCorruptLines: 0 };
     }
     throw error;
   }
 
-  const records = [];
+  /** @type {{ readonly line: string, readonly record?: AutomationRunRecord }[]} */
+  const entries = [];
   let skippedCorruptLines = 0;
   for (const line of content.split(/\n/)) {
     if (!line.trim()) {
@@ -148,13 +169,21 @@ export async function readAutomationRunRecords(filePath) {
     }
     try {
       const parsed = JSON.parse(line);
-      records.push(validateStoredRecord(parsed));
+      entries.push({ line, record: validateStoredRecord(parsed) });
     } catch {
+      // Kept, not dropped. The caller rewrites the file from `entries`, so a
+      // row omitted here would be DELETED from disk by the next unrelated
+      // append (#2578). It stays exactly as read; only `records` excludes it.
+      entries.push({ line });
       skippedCorruptLines += 1;
     }
   }
 
-  return { records, skippedCorruptLines };
+  return {
+    records: entries.flatMap(entry => (entry.record ? [entry.record] : [])),
+    entries,
+    skippedCorruptLines,
+  };
 }
 
 /**
@@ -162,12 +191,58 @@ export async function readAutomationRunRecords(filePath) {
  * @returns {AutomationRunRecord}
  */
 function buildAutomationRunRecord(input) {
+  return assembleAutomationRunRecord(input, normalizeAuthoredRefs(input.refs));
+}
+
+/**
+ * `refs` as an author supplied it.
+ *
+ * A shape this module cannot store as written is REJECTED, not quietly
+ * emptied. Coercing to `[]` is how a caller could record a run whose evidence
+ * links were dropped while the write still reported success (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {readonly string[]}
+ */
+function normalizeAuthoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  if (!Array.isArray(refs)) {
+    throw new Error(
+      `Automation run refs must be an array of strings; received ${typeof refs}.`
+    );
+  }
+  return refs.map(ref => String(ref));
+}
+
+/**
+ * `refs` as it was stored, round-tripped rather than coerced.
+ *
+ * A stored shape this module does not recognise — the object form
+ * `{tickets, prs, commits}` observed in the field — is returned unchanged.
+ * Coercing it to `[]` here destroyed the evidence links on every prior row at
+ * the next append: silently, retroactively, and irreversibly (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {unknown}
+ */
+function preserveStoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  return Array.isArray(refs) ? refs.map(ref => String(ref)) : refs;
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @param {unknown} refs - Already-resolved `refs` for this record.
+ * @returns {AutomationRunRecord}
+ */
+function assembleAutomationRunRecord(input, refs) {
   const loopId = normalizeLoopId(input.loopId);
   const summary = String(input.summary ?? "").trim();
   const runbook = String(input.runbook ?? "").trim();
-  const refs = Array.isArray(input.refs)
-    ? input.refs.map(ref => String(ref))
-    : [];
   const ts =
     input.ts instanceof Date
       ? input.ts.toISOString()
@@ -240,21 +315,23 @@ function validateStoredRecord(value) {
   if (!value || typeof value !== "object") {
     throw new Error("Automation run record must be an object.");
   }
-  return buildAutomationRunRecord({
-    ts: String(value.ts ?? ""),
-    loopId: String(value.loop_id ?? ""),
-    outcome: String(value.outcome ?? ""),
-    summary: String(value.summary ?? ""),
-    runbook: String(value.runbook ?? ""),
-    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
-    runId: String(value.run_id ?? ""),
-    // Carry every unrecognised key forward. Without this, re-validating a
-    // stored record on read silently strips it, and the next append writes the
-    // stripped history back over the file (#2524).
-    extras: Object.fromEntries(
-      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
-    ),
-  });
+  return assembleAutomationRunRecord(
+    {
+      ts: String(value.ts ?? ""),
+      loopId: String(value.loop_id ?? ""),
+      outcome: String(value.outcome ?? ""),
+      summary: String(value.summary ?? ""),
+      runbook: String(value.runbook ?? ""),
+      runId: String(value.run_id ?? ""),
+      // Carry every unrecognised key forward. Without this, re-validating a
+      // stored record on read silently strips it, and the next append writes
+      // the stripped history back over the file (#2524).
+      extras: Object.fromEntries(
+        Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+      ),
+    },
+    preserveStoredRefs(value.refs)
+  );
 }
 
 /**
@@ -291,10 +368,10 @@ async function readJsonIfPresent(filePath) {
 
 /**
  * @param {string} filePath
- * @param {readonly AutomationRunRecord[]} records
+ * @param {readonly string[]} lines - Serialised rows, written verbatim.
  */
-async function writeJsonlAtomically(filePath, records) {
-  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+async function writeJsonlAtomically(filePath, lines) {
+  const content = `${lines.join("\n")}\n`;
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
   await writeFile(tempPath, content, "utf8");
   await rename(tempPath, filePath);

--- a/plugins/lisa/scripts/automation-run-record.mjs
+++ b/plugins/lisa/scripts/automation-run-record.mjs
@@ -33,6 +33,10 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly run_id: string
  * }} AutomationRunRecord
  *
+ * `refs` above is the AUTHORED contract. A row already on disk whose `refs` is
+ * some other shape is round-tripped as stored rather than coerced — see
+ * {@link preserveStoredRefs}.
+ *
  * @typedef {{
  *   readonly projectRoot?: string
  *   readonly loopId: string
@@ -74,14 +78,26 @@ export async function recordAutomationRun(input) {
     };
   }
 
-  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  // Prior rows are carried across as the RAW LINES they were read as, never
+  // re-serialised from the parsed form. Re-serialising is what let an append
+  // rewrite rows it did not author: a stored `refs` shape the writer did not
+  // recognise came back as `[]`, and a row that failed validation came back as
+  // nothing at all (#2682, #2578). Only the row being appended is serialised
+  // here, so an append can no longer be a fleet-wide migration nobody ran.
+  const nextEntries = [
+    ...readResult.entries,
+    { line: JSON.stringify(record), record },
+  ].slice(-maxEntries);
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeJsonlAtomically(filePath, nextRecords);
+  await writeJsonlAtomically(
+    filePath,
+    nextEntries.map(entry => entry.line)
+  );
 
   return {
     path: filePath,
     record,
-    records: nextRecords,
+    records: nextEntries.flatMap(entry => (entry.record ? [entry.record] : [])),
     appended: true,
     skippedCorruptLines: readResult.skippedCorruptLines,
     maxEntries,
@@ -126,8 +142,12 @@ export function automationRunRecordPath(projectRoot, loopId) {
 }
 
 /**
+ * Read a ledger, keeping every non-blank line verbatim alongside its parsed
+ * form. `records` is the validated view for consumers; `entries` is what the
+ * append path rewrites, so a row this module cannot parse or validate survives
+ * instead of being deleted by the next unrelated append (#2578).
  * @param {string} filePath
- * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly entries: readonly { readonly line: string, readonly record?: AutomationRunRecord }[], readonly skippedCorruptLines: number }>}
  */
 export async function readAutomationRunRecords(filePath) {
   let content = "";
@@ -135,12 +155,13 @@ export async function readAutomationRunRecords(filePath) {
     content = await readFile(filePath, "utf8");
   } catch (error) {
     if (error?.code === "ENOENT") {
-      return { records: [], skippedCorruptLines: 0 };
+      return { records: [], entries: [], skippedCorruptLines: 0 };
     }
     throw error;
   }
 
-  const records = [];
+  /** @type {{ readonly line: string, readonly record?: AutomationRunRecord }[]} */
+  const entries = [];
   let skippedCorruptLines = 0;
   for (const line of content.split(/\n/)) {
     if (!line.trim()) {
@@ -148,13 +169,21 @@ export async function readAutomationRunRecords(filePath) {
     }
     try {
       const parsed = JSON.parse(line);
-      records.push(validateStoredRecord(parsed));
+      entries.push({ line, record: validateStoredRecord(parsed) });
     } catch {
+      // Kept, not dropped. The caller rewrites the file from `entries`, so a
+      // row omitted here would be DELETED from disk by the next unrelated
+      // append (#2578). It stays exactly as read; only `records` excludes it.
+      entries.push({ line });
       skippedCorruptLines += 1;
     }
   }
 
-  return { records, skippedCorruptLines };
+  return {
+    records: entries.flatMap(entry => (entry.record ? [entry.record] : [])),
+    entries,
+    skippedCorruptLines,
+  };
 }
 
 /**
@@ -162,12 +191,58 @@ export async function readAutomationRunRecords(filePath) {
  * @returns {AutomationRunRecord}
  */
 function buildAutomationRunRecord(input) {
+  return assembleAutomationRunRecord(input, normalizeAuthoredRefs(input.refs));
+}
+
+/**
+ * `refs` as an author supplied it.
+ *
+ * A shape this module cannot store as written is REJECTED, not quietly
+ * emptied. Coercing to `[]` is how a caller could record a run whose evidence
+ * links were dropped while the write still reported success (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {readonly string[]}
+ */
+function normalizeAuthoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  if (!Array.isArray(refs)) {
+    throw new Error(
+      `Automation run refs must be an array of strings; received ${typeof refs}.`
+    );
+  }
+  return refs.map(ref => String(ref));
+}
+
+/**
+ * `refs` as it was stored, round-tripped rather than coerced.
+ *
+ * A stored shape this module does not recognise — the object form
+ * `{tickets, prs, commits}` observed in the field — is returned unchanged.
+ * Coercing it to `[]` here destroyed the evidence links on every prior row at
+ * the next append: silently, retroactively, and irreversibly (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {unknown}
+ */
+function preserveStoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  return Array.isArray(refs) ? refs.map(ref => String(ref)) : refs;
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @param {unknown} refs - Already-resolved `refs` for this record.
+ * @returns {AutomationRunRecord}
+ */
+function assembleAutomationRunRecord(input, refs) {
   const loopId = normalizeLoopId(input.loopId);
   const summary = String(input.summary ?? "").trim();
   const runbook = String(input.runbook ?? "").trim();
-  const refs = Array.isArray(input.refs)
-    ? input.refs.map(ref => String(ref))
-    : [];
   const ts =
     input.ts instanceof Date
       ? input.ts.toISOString()
@@ -240,21 +315,23 @@ function validateStoredRecord(value) {
   if (!value || typeof value !== "object") {
     throw new Error("Automation run record must be an object.");
   }
-  return buildAutomationRunRecord({
-    ts: String(value.ts ?? ""),
-    loopId: String(value.loop_id ?? ""),
-    outcome: String(value.outcome ?? ""),
-    summary: String(value.summary ?? ""),
-    runbook: String(value.runbook ?? ""),
-    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
-    runId: String(value.run_id ?? ""),
-    // Carry every unrecognised key forward. Without this, re-validating a
-    // stored record on read silently strips it, and the next append writes the
-    // stripped history back over the file (#2524).
-    extras: Object.fromEntries(
-      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
-    ),
-  });
+  return assembleAutomationRunRecord(
+    {
+      ts: String(value.ts ?? ""),
+      loopId: String(value.loop_id ?? ""),
+      outcome: String(value.outcome ?? ""),
+      summary: String(value.summary ?? ""),
+      runbook: String(value.runbook ?? ""),
+      runId: String(value.run_id ?? ""),
+      // Carry every unrecognised key forward. Without this, re-validating a
+      // stored record on read silently strips it, and the next append writes
+      // the stripped history back over the file (#2524).
+      extras: Object.fromEntries(
+        Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+      ),
+    },
+    preserveStoredRefs(value.refs)
+  );
 }
 
 /**
@@ -291,10 +368,10 @@ async function readJsonIfPresent(filePath) {
 
 /**
  * @param {string} filePath
- * @param {readonly AutomationRunRecord[]} records
+ * @param {readonly string[]} lines - Serialised rows, written verbatim.
  */
-async function writeJsonlAtomically(filePath, records) {
-  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+async function writeJsonlAtomically(filePath, lines) {
+  const content = `${lines.join("\n")}\n`;
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
   await writeFile(tempPath, content, "utf8");
   await rename(tempPath, filePath);

--- a/plugins/src/base/scripts/automation-run-record.mjs
+++ b/plugins/src/base/scripts/automation-run-record.mjs
@@ -33,6 +33,10 @@ export const DEFAULT_AUTOMATION_RUN_HISTORY_MAX_ENTRIES = 50;
  *   readonly run_id: string
  * }} AutomationRunRecord
  *
+ * `refs` above is the AUTHORED contract. A row already on disk whose `refs` is
+ * some other shape is round-tripped as stored rather than coerced — see
+ * {@link preserveStoredRefs}.
+ *
  * @typedef {{
  *   readonly projectRoot?: string
  *   readonly loopId: string
@@ -74,14 +78,26 @@ export async function recordAutomationRun(input) {
     };
   }
 
-  const nextRecords = [...readResult.records, record].slice(-maxEntries);
+  // Prior rows are carried across as the RAW LINES they were read as, never
+  // re-serialised from the parsed form. Re-serialising is what let an append
+  // rewrite rows it did not author: a stored `refs` shape the writer did not
+  // recognise came back as `[]`, and a row that failed validation came back as
+  // nothing at all (#2682, #2578). Only the row being appended is serialised
+  // here, so an append can no longer be a fleet-wide migration nobody ran.
+  const nextEntries = [
+    ...readResult.entries,
+    { line: JSON.stringify(record), record },
+  ].slice(-maxEntries);
   await mkdir(path.dirname(filePath), { recursive: true });
-  await writeJsonlAtomically(filePath, nextRecords);
+  await writeJsonlAtomically(
+    filePath,
+    nextEntries.map(entry => entry.line)
+  );
 
   return {
     path: filePath,
     record,
-    records: nextRecords,
+    records: nextEntries.flatMap(entry => (entry.record ? [entry.record] : [])),
     appended: true,
     skippedCorruptLines: readResult.skippedCorruptLines,
     maxEntries,
@@ -126,8 +142,12 @@ export function automationRunRecordPath(projectRoot, loopId) {
 }
 
 /**
+ * Read a ledger, keeping every non-blank line verbatim alongside its parsed
+ * form. `records` is the validated view for consumers; `entries` is what the
+ * append path rewrites, so a row this module cannot parse or validate survives
+ * instead of being deleted by the next unrelated append (#2578).
  * @param {string} filePath
- * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly skippedCorruptLines: number }>}
+ * @returns {Promise<{ readonly records: readonly AutomationRunRecord[], readonly entries: readonly { readonly line: string, readonly record?: AutomationRunRecord }[], readonly skippedCorruptLines: number }>}
  */
 export async function readAutomationRunRecords(filePath) {
   let content = "";
@@ -135,12 +155,13 @@ export async function readAutomationRunRecords(filePath) {
     content = await readFile(filePath, "utf8");
   } catch (error) {
     if (error?.code === "ENOENT") {
-      return { records: [], skippedCorruptLines: 0 };
+      return { records: [], entries: [], skippedCorruptLines: 0 };
     }
     throw error;
   }
 
-  const records = [];
+  /** @type {{ readonly line: string, readonly record?: AutomationRunRecord }[]} */
+  const entries = [];
   let skippedCorruptLines = 0;
   for (const line of content.split(/\n/)) {
     if (!line.trim()) {
@@ -148,13 +169,21 @@ export async function readAutomationRunRecords(filePath) {
     }
     try {
       const parsed = JSON.parse(line);
-      records.push(validateStoredRecord(parsed));
+      entries.push({ line, record: validateStoredRecord(parsed) });
     } catch {
+      // Kept, not dropped. The caller rewrites the file from `entries`, so a
+      // row omitted here would be DELETED from disk by the next unrelated
+      // append (#2578). It stays exactly as read; only `records` excludes it.
+      entries.push({ line });
       skippedCorruptLines += 1;
     }
   }
 
-  return { records, skippedCorruptLines };
+  return {
+    records: entries.flatMap(entry => (entry.record ? [entry.record] : [])),
+    entries,
+    skippedCorruptLines,
+  };
 }
 
 /**
@@ -162,12 +191,58 @@ export async function readAutomationRunRecords(filePath) {
  * @returns {AutomationRunRecord}
  */
 function buildAutomationRunRecord(input) {
+  return assembleAutomationRunRecord(input, normalizeAuthoredRefs(input.refs));
+}
+
+/**
+ * `refs` as an author supplied it.
+ *
+ * A shape this module cannot store as written is REJECTED, not quietly
+ * emptied. Coercing to `[]` is how a caller could record a run whose evidence
+ * links were dropped while the write still reported success (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {readonly string[]}
+ */
+function normalizeAuthoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  if (!Array.isArray(refs)) {
+    throw new Error(
+      `Automation run refs must be an array of strings; received ${typeof refs}.`
+    );
+  }
+  return refs.map(ref => String(ref));
+}
+
+/**
+ * `refs` as it was stored, round-tripped rather than coerced.
+ *
+ * A stored shape this module does not recognise — the object form
+ * `{tickets, prs, commits}` observed in the field — is returned unchanged.
+ * Coercing it to `[]` here destroyed the evidence links on every prior row at
+ * the next append: silently, retroactively, and irreversibly (#2682).
+ *
+ * @param {unknown} refs
+ * @returns {unknown}
+ */
+function preserveStoredRefs(refs) {
+  if (refs === undefined || refs === null) {
+    return [];
+  }
+  return Array.isArray(refs) ? refs.map(ref => String(ref)) : refs;
+}
+
+/**
+ * @param {RecordAutomationRunInput} input
+ * @param {unknown} refs - Already-resolved `refs` for this record.
+ * @returns {AutomationRunRecord}
+ */
+function assembleAutomationRunRecord(input, refs) {
   const loopId = normalizeLoopId(input.loopId);
   const summary = String(input.summary ?? "").trim();
   const runbook = String(input.runbook ?? "").trim();
-  const refs = Array.isArray(input.refs)
-    ? input.refs.map(ref => String(ref))
-    : [];
   const ts =
     input.ts instanceof Date
       ? input.ts.toISOString()
@@ -240,21 +315,23 @@ function validateStoredRecord(value) {
   if (!value || typeof value !== "object") {
     throw new Error("Automation run record must be an object.");
   }
-  return buildAutomationRunRecord({
-    ts: String(value.ts ?? ""),
-    loopId: String(value.loop_id ?? ""),
-    outcome: String(value.outcome ?? ""),
-    summary: String(value.summary ?? ""),
-    runbook: String(value.runbook ?? ""),
-    refs: Array.isArray(value.refs) ? value.refs.map(ref => String(ref)) : [],
-    runId: String(value.run_id ?? ""),
-    // Carry every unrecognised key forward. Without this, re-validating a
-    // stored record on read silently strips it, and the next append writes the
-    // stripped history back over the file (#2524).
-    extras: Object.fromEntries(
-      Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
-    ),
-  });
+  return assembleAutomationRunRecord(
+    {
+      ts: String(value.ts ?? ""),
+      loopId: String(value.loop_id ?? ""),
+      outcome: String(value.outcome ?? ""),
+      summary: String(value.summary ?? ""),
+      runbook: String(value.runbook ?? ""),
+      runId: String(value.run_id ?? ""),
+      // Carry every unrecognised key forward. Without this, re-validating a
+      // stored record on read silently strips it, and the next append writes
+      // the stripped history back over the file (#2524).
+      extras: Object.fromEntries(
+        Object.entries(value).filter(([key]) => !KNOWN_RECORD_KEYS.has(key))
+      ),
+    },
+    preserveStoredRefs(value.refs)
+  );
 }
 
 /**
@@ -291,10 +368,10 @@ async function readJsonIfPresent(filePath) {
 
 /**
  * @param {string} filePath
- * @param {readonly AutomationRunRecord[]} records
+ * @param {readonly string[]} lines - Serialised rows, written verbatim.
  */
-async function writeJsonlAtomically(filePath, records) {
-  const content = `${records.map(record => JSON.stringify(record)).join("\n")}\n`;
+async function writeJsonlAtomically(filePath, lines) {
+  const content = `${lines.join("\n")}\n`;
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
   await writeFile(tempPath, content, "utf8");
   await rename(tempPath, filePath);

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -929,7 +929,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/work-item-definition-of-ready.md":
       "ebcfe89f5a33a8008c4a54c1c2f4a092952df3263adc8f537a4c0b6ad8dbe18d",
     "plugins/src/base/scripts/automation-run-record.mjs":
-      "77ea269502b97300c400916ee851dc85082a9237ce3d4468688455084d96413a",
+      "8ecaa19f039339e7d4dc1d9287fac58139ebc19b784dccc71817bb8267215ca8",
     "plugins/src/base/scripts/automation-status-claude-adapter.mjs":
       "1f77b28fd59986ac3f76a55296b70d8c45385bbdb759e97691e49db121725ee2",
     "plugins/src/base/scripts/automation-status-codex-adapter.mjs":
@@ -9185,6 +9185,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/strategies/atlassian-access-changelog.test.ts": true,
     "tests/unit/strategies/automation-run-history-helpers.ts": true,
     "tests/unit/strategies/automation-run-record-cli.test.ts": true,
+    "tests/unit/strategies/automation-run-record-preservation.test.ts": true,
     "tests/unit/strategies/automation-run-record.test.ts": true,
     "tests/unit/strategies/automation-runbook-contract-rule.test.ts": true,
     "tests/unit/strategies/automation-status-claude-adapter.test.ts": true,

--- a/tests/unit/strategies/automation-run-record-preservation.test.ts
+++ b/tests/unit/strategies/automation-run-record-preservation.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests that an append leaves rows it did not author alone (#2682, #2578).
+ *
+ * The recorder rewrites the whole ledger on every append. These tests pin the
+ * two ways that rewrite used to damage history: a stored `refs` shape the
+ * writer did not recognise came back as `[]`, and a row that failed validation
+ * came back as nothing at all. Both losses were silent, retroactive, and
+ * inflicted by a loop that had no reason to touch the row.
+ * @module tests/unit/strategies/automation-run-record-preservation
+ */
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  readAutomationRunRecords,
+  recordAutomationRun,
+} from "../../../plugins/src/base/scripts/automation-run-record.mjs";
+
+const LOOP_ID = "intake-build";
+const RUNBOOK_PATH = ".lisa/automations/intake-build.runbook.md";
+const RECORDS_PATH = ".lisa/automations/runs/intake-build.jsonl";
+const CONFIG_PATH = ".lisa.config.json";
+const NOTHING_NEEDED = "nothing-needed";
+const BASE_TS = "2026-07-20T07:00:00.000Z";
+const A_REF = "https://example.invalid/1";
+
+const OBJECT_REFS = Object.freeze({
+  tickets: ["ABC-1"],
+  prs: [42],
+  commits: ["deadbeef"],
+});
+const OBJECT_REFS_ROW = JSON.stringify({
+  ts: BASE_TS,
+  loop_id: LOOP_ID,
+  outcome: "change-proved",
+  summary: "prior run with object-shaped refs",
+  runbook: RUNBOOK_PATH,
+  refs: OBJECT_REFS,
+  run_id: "run-1",
+});
+const UNPARSEABLE_ROW = '{"truncated"';
+
+let root: string;
+
+const put = (rel: string, contents: string): void => {
+  const abs = path.join(root, rel);
+  mkdirSync(path.dirname(abs), { recursive: true });
+  writeFileSync(abs, contents);
+};
+
+const readLines = (rel: string): string[] =>
+  readFileSync(path.join(root, rel), "utf8").trim().split(/\n/);
+
+const appendUnrelated = async (runId: string): Promise<void> => {
+  await recordAutomationRun({
+    projectRoot: root,
+    loopId: LOOP_ID,
+    outcome: NOTHING_NEEDED,
+    summary: "an unrelated later append",
+    runbook: RUNBOOK_PATH,
+    runId,
+    ts: "2026-07-20T07:05:00.000Z",
+  });
+};
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "lisa-run-record-preserve-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("prior rows survive an append they did not author (#2682, #2578)", () => {
+  it("leaves a prior object-shaped refs row byte-identical", async () => {
+    put(RECORDS_PATH, `${OBJECT_REFS_ROW}\n`);
+
+    await appendUnrelated("run-2");
+
+    expect(readLines(RECORDS_PATH)[0]).toBe(OBJECT_REFS_ROW);
+  });
+
+  it("never replaces a refs value it cannot normalize with an empty array", async () => {
+    put(RECORDS_PATH, `${OBJECT_REFS_ROW}\n`);
+
+    await appendUnrelated("run-2");
+    const { records } = await readAutomationRunRecords(
+      path.join(root, RECORDS_PATH)
+    );
+
+    expect(records[0]?.refs).toEqual(OBJECT_REFS);
+  });
+
+  it("survives repeated appends rather than losing refs on the first one", async () => {
+    put(RECORDS_PATH, `${OBJECT_REFS_ROW}\n`);
+
+    await appendUnrelated("run-2");
+    await appendUnrelated("run-3");
+    await appendUnrelated("run-4");
+
+    expect(readLines(RECORDS_PATH)[0]).toBe(OBJECT_REFS_ROW);
+  });
+
+  it("keeps a row it could not validate instead of deleting it (#2578)", async () => {
+    put(RECORDS_PATH, `${UNPARSEABLE_ROW}\n`);
+
+    await appendUnrelated("run-2");
+    const lines = readLines(RECORDS_PATH);
+
+    expect(lines[0]).toBe(UNPARSEABLE_ROW);
+    expect(lines).toHaveLength(2);
+  });
+
+  it("refuses to author a new record whose refs cannot be stored as written", async () => {
+    await expect(
+      recordAutomationRun({
+        projectRoot: root,
+        loopId: LOOP_ID,
+        outcome: NOTHING_NEEDED,
+        summary: "refs the writer cannot store",
+        runbook: RUNBOOK_PATH,
+        runId: "run-1",
+        ts: BASE_TS,
+        refs: OBJECT_REFS as unknown as readonly string[],
+      })
+    ).rejects.toThrow("must be an array of strings");
+  });
+
+  it("still appends a well-formed record unchanged", async () => {
+    const result = await recordAutomationRun({
+      projectRoot: root,
+      loopId: LOOP_ID,
+      outcome: NOTHING_NEEDED,
+      summary: "well-formed",
+      runbook: RUNBOOK_PATH,
+      runId: "run-1",
+      ts: BASE_TS,
+      refs: [A_REF],
+    });
+
+    expect(result.appended).toBe(true);
+    expect(result.record.refs).toEqual([A_REF]);
+    expect(JSON.parse(readLines(RECORDS_PATH)[0] ?? "{}")).toMatchObject({
+      run_id: "run-1",
+      refs: [A_REF],
+    });
+  });
+
+  it("trims the bound over every stored line, unvalidatable ones included", async () => {
+    put(
+      CONFIG_PATH,
+      JSON.stringify({ automations: { runHistory: { maxEntries: 2 } } })
+    );
+    put(RECORDS_PATH, `${UNPARSEABLE_ROW}\n${OBJECT_REFS_ROW}\n`);
+
+    await appendUnrelated("run-2");
+
+    const lines = readLines(RECORDS_PATH);
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toBe(OBJECT_REFS_ROW);
+  });
+});


### PR DESCRIPTION
Work-Item: CodySwannGT/lisa#2682

## Read this first: no data was actually lost

The defect was real and is fixed below, but **nothing needs recovering**. Measured
across every tracked live ledger reachable locally — **132 files, 12,022 rows,
10,448 `run_id`s that ever carried a richer `refs` in git history, and 0 of them
sitting at `[]` today.** The one ledger this issue was filed from probed clean; it
had already been restored from its pre-append backup.

So this ships as a guard against a loss that was caught in time, not as a repair.
Method, the wider shape survey, and a proposed repair procedure for the case where
a damaged ledger does turn up are at the bottom.

## What was wrong

`recordAutomationRun` rewrote the entire ledger from **re-normalized records** on
every append. Prior rows were re-serialized by a writer that had no business
touching them, and two kinds of row were damaged in that pass:

- a stored `refs` the writer did not recognize — the object form
  `{tickets, prs, commits}` seen in the field — was coerced to `[]`
  (`validateStoredRecord`, `refs: Array.isArray(value.refs) ? … : []`)
- a row that failed to parse or validate was dropped from `records` entirely, so
  the next append wrote a file that no longer contained it

Both losses were silent (nothing warned, the row still parsed afterwards),
retroactive (the damage was to rows written earlier by other loops), and
irreversible in an untracked ledger. `refs` is the link from a run to the
tickets, PRs, and commits it touched — the evidence the ledger exists to hold.

## What changed

**Prior rows are carried across as the raw lines they were read as.**
`readAutomationRunRecords` now returns `entries` — every non-blank line verbatim,
paired with its parsed form when it had one — alongside the existing validated
`records` view. The append path rewrites from `entries` and serializes only the
row being appended, so a prior row is byte-identical afterwards whatever shape it
holds. The history bound is applied over stored lines, unvalidatable ones
included, so the file stays bounded.

**A non-array `refs` from an author is rejected, not quietly emptied.** A caller
can no longer record a run whose evidence links were dropped while the write
still reports success. The CLI only ever builds `refs` from repeated `--ref`
flags, so it reaches this by an array and is unaffected.

`skippedCorruptLines` is unchanged and still surfaced by automation status — an
unparsable row is reported rather than repaired in place, so the operator
decides. This is the issue's option (1) plus option (2); option (3), widening the
schema to bless the object form, is explicitly out of scope.

Applied to `plugins/src/base/` and fanned out to all four agent plugin payloads;
`bun run build:plugins` reproduces the fanout with no further delta.

## Bite control

New suite `tests/unit/strategies/automation-run-record-preservation.test.ts`, run
against the **unfixed** source (`plugins/*/scripts/automation-run-record.mjs`
stashed, defect site `refs: Array.isArray(value.refs) ? … : []` present at
line 249):

```
 FAIL  … > leaves a prior object-shaped refs row byte-identical
 FAIL  … > never replaces a refs value it cannot normalize with an empty array
 FAIL  … > survives repeated appends rather than losing refs on the first one
 FAIL  … > keeps a row it could not validate instead of deleting it (#2578)
 FAIL  … > refuses to author a new record whose refs cannot be stored as written
 FAIL  … > trims the bound over every stored line, unvalidatable ones included
```

The first failure is the exact reported defect:

```
Expected: "…,"refs":{"tickets":["ABC-1"],"prs":[42],"commits":["deadbeef"]},"run_id":"run-1"}"
Received: "…,"refs":[],"run_id":"run-1"}"
```

With the fix restored, the defect site is gone and the three run-record suites
are green:

```
 Test Files  3 passed (3)
      Tests  26 passed (26)
```

## Acceptance criteria

| Scenario | Pinned by |
| --- | --- |
| appending does not alter prior rows | `leaves a prior object-shaped refs row byte-identical` (`toBe` on the raw line), `survives repeated appends…` |
| a non-conforming row is not silently emptied | `never replaces a refs value it cannot normalize…`, `keeps a row it could not validate…`, `refuses to author a new record…` |
| the new record still validates | `still appends a well-formed record unchanged` |

## Verification

- `bun run typecheck` — exit 0
- `bun run lint` — exit 0 (`Found 0 warnings and 0 errors`)
- `bun run test` — the three run-record suites green; full suite green apart from
  wall-clock timeouts on unrelated slow integration/unit fixtures under a loaded
  machine (load average >20 from concurrent sessions), each of which passes when
  run alone
- `bun run check:upstream-evidence-manifest` and
  `bun run check:lisa-owned-hash-ledger` — both regenerated after `git add` and
  passing

## Field survey — method and full numbers

Reading a ledger cannot answer "was anything lost", because `refs: []` is
indistinguishable from "never had refs". That is the issue's own point. Git
history *can* answer it where the ledger is tracked, and these ledgers **are**
tracked in caller repos.

**Method.** For each tracked ledger, `git log -p --unified=0 -- <ledger>` yields
every row line ever added to the file. Index by `run_id`, keep the richest `refs`
shape each one ever had, and compare against the shape on disk now. A row that is
`[]` today and was richer before was destroyed.

| | |
| --- | --- |
| ledger files probed | 132 |
| rows currently on disk | 12,022 |
| `run_id`s that ever carried a richer `refs` | 10,448 |
| `run_id`s now `[]` that were richer before | **0** |

A wider shape survey across 267 files / 25,309 rows, tracked and untracked:
18,525 rows carry a non-empty array `refs`, 6,677 carry `[]`, 103 omit `refs`,
and 4 still hold an object shape. All 4 sit in an `.archive.jsonl`, which the
appender never rewrites — which is exactly why they survived. Lisa writes no
archive file; that rotation is a caller-repo convention.

**Limits of the probe.** A destroy-and-recover that happened entirely between two
commits leaves no evidence in history, which is probably the case for the incident
this issue reports. Untracked ledgers have no prior copy at all, so their `[]`
rows are permanently ambiguous.

**No repair was run.** A procedure is proposed on the issue for the case where a
damaged ledger does turn up: discover read-only and print the report first; repair
only behind an explicit flag, rewriting only the `refs` value from the historical
copy and only when the rest of the line matches exactly; `.bak` plus line-count,
byte-identity, and `skippedCorruptLines` assertions as guards.
