### PR TITLE
fix(ci): repin two expo templates off a ref that predates the reusable

### DIFF
--- a/.github/workflows/plugins-sync.yml
+++ b/.github/workflows/plugins-sync.yml
@@ -64,6 +64,24 @@ jobs:
       # on every pull request.
       - name: Check for leftover merge-conflict markers
         run: bun run check:conflict-markers
+      # #2702 shipped two expo templates pinned at @v2.345.1, a Lisa version
+      # that predates the reusable they call. A consumer receiving one gets a
+      # workflow that cannot LOAD: GitHub runs zero jobs, so there is no test
+      # output and nothing reads as red. One of them never succeeded once in
+      # three scheduled runs across two repos and stayed byte-identical to the
+      # broken template, because a workflow that never runs gives nobody a
+      # reason to touch it. Deliberately NOT in the shared gate registry: this
+      # repo is the only one that carries caller templates, and the gate's
+      # refusal to pass an empty scan would fail every consumer's commit.
+      - name: Check caller-template workflow refs resolve
+        # The templates pin immutable tags (Appendix A5), so this gate needs the
+        # tag objects locally to verify them. It refuses to pass a reference it
+        # could not resolve, so a missing tag fails the job loudly instead of
+        # reporting a clean scan — which is the whole point of the gate and not
+        # something to paper over with `|| true`.
+        run: |
+          git fetch --tags --quiet --no-recurse-submodules
+          bun run check:template-workflow-refs
       - name: Check plugin artifacts are in sync with plugins/src
         run: bun run check:plugins
       - name: Check rules eager/reference pairing

--- a/expo/create-only/.github/workflows/nightly-e2e-health.yml
+++ b/expo/create-only/.github/workflows/nightly-e2e-health.yml
@@ -96,7 +96,7 @@ jobs:
     # thing that decides whether code may merge must not change under you
     # between two runs of the same PR. Better still, pin the tag's commit SHA
     # and keep the tag in a trailing comment.
-    uses: CodySwannGT/lisa/.github/workflows/nightly-e2e-health.yml@v2.345.1
+    uses: CodySwannGT/lisa/.github/workflows/nightly-e2e-health.yml@v3.35.0
     with:
       branch: dev
       # Structured JSON, schema-validated before any API call. Duplicated

--- a/expo/create-only/.github/workflows/nightly-e2e-report.yml
+++ b/expo/create-only/.github/workflows/nightly-e2e-report.yml
@@ -60,7 +60,7 @@ jobs:
     # PIN AN IMMUTABLE REF, for the same reason the gate caller does: the two
     # halves must speak the same contract major, and `@main` can change between
     # a report and the gate reading the same night.
-    uses: CodySwannGT/lisa/.github/workflows/nightly-e2e-report.yml@v2.345.1
+    uses: CodySwannGT/lisa/.github/workflows/nightly-e2e-report.yml@v3.35.0
     with:
       branch: dev
       # KEEP THIS IDENTICAL to the `suites` value in nightly-e2e-health.yml.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "check:rules-pairing": "bash scripts/check-rules-pairing.sh",
     "check:workflow-inputs": "node scripts/detect-stale-workflow-inputs.mjs --project . --project typescript/create-only --project rails/create-only --json",
     "check:conflict-markers": "node scripts/check-conflict-markers.mjs",
+    "check:template-workflow-refs": "node scripts/check-template-workflow-refs.mjs",
     "check:duplicate-versions": "node scripts/check-duplicate-versions.mjs",
     "check:required-check-promotions": "node scripts/check-required-check-promotions.mjs",
     "check:work-item": "node scripts/lisa-work-item.mjs validate-pr",

--- a/scripts/check-template-workflow-refs.mjs
+++ b/scripts/check-template-workflow-refs.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+/**
+ * Deterministic gate that every `uses:` in a shipped caller template resolves
+ * at the ref it names (issue #2702).
+ *
+ * Two expo templates shipped pinned at `@v2.345.1`, a Lisa version that
+ * predates the reusable they call. The referenced file does not exist at that
+ * tag, so the workflow cannot load: GitHub reports "this run likely failed
+ * because of a workflow file issue" and runs ZERO jobs.
+ *
+ * Nothing caught it, and the reason is the point of this gate:
+ *
+ *   - a workflow that fails to LOAD produces no test output, so no suite goes
+ *     red and no report shows a failure to read;
+ *   - `nightly-e2e-report.yml` therefore stayed byte-identical to the broken
+ *     template in every consumer that received it, and a filename/hash audit
+ *     scored that as the HEALTHY row — identical-and-never-worked outranks
+ *     diverged-and-working on every measure except whether it works;
+ *   - it had never once succeeded: three scheduled runs across two repos,
+ *     three failures, zero successes, from the day it shipped.
+ *
+ * The sibling defect was visible and so it was repaired four different ways.
+ * `nightly-e2e-health.yml` backs a required gate, so consumers noticed
+ * instantly: one repointed to `@v3.27.0`, one to `@v3.14.8`, and two abandoned
+ * the reusable and reimplemented it locally. None of those repairs flowed back
+ * upstream, so every new consumer inherited the same broken pin.
+ *
+ * This script reads what the templates actually reference and confirms the
+ * target exists. Only that.
+ *
+ * Determinism guarantees (so the unit test is reproducible and CI is stable):
+ *   - zero third-party dependencies (Node built-ins only),
+ *   - no network access,
+ *   - no `Date` / `Math.random`,
+ *   - the file list comes from `git ls-files`, so the gate sees exactly what a
+ *     release would carry.
+ *
+ * A `@main` reference is checked against the working tree, which needs no
+ * history and so is correct in a depth-1 CI clone. A reference pinned to a tag
+ * or SHA needs that object locally; when it is missing the gate reports
+ * UNVERIFIABLE and exits 2. It never treats "I could not look" as "it is fine"
+ * — a gate that passes because it did nothing is the exact failure this file
+ * exists to prevent, and it would be perverse to reproduce it here.
+ *
+ * Discovering zero templates is likewise exit 2, not a clean pass. Finding
+ * nothing to check is a broken invocation, not conformance.
+ *
+ * CLI:
+ *   node scripts/check-template-workflow-refs.mjs [--root <dir>] [--json]
+ *
+ * Exit codes (mirroring the sibling parity scripts):
+ *   0 — every `uses:` in every caller template resolves at its ref.
+ *   1 — ≥1 reference names a target that does not exist at that ref.
+ *   2 — operational/usage error: unknown flag, a flag missing its value,
+ *       `--root` absent or not a git repository, git unavailable, zero
+ *       templates discovered, or a pinned ref that is not present locally.
+ *
+ * @module scripts/check-template-workflow-refs
+ */
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  ".."
+);
+
+/**
+ * A caller template: `<lane>/<mode>/.github/workflows/<name>.yml`, e.g.
+ * `expo/create-only/.github/workflows/maestro-e2e.yml`. The two leading
+ * segments are what distinguishes a shipped template from Lisa's OWN
+ * `.github/workflows/`, which is not delivered to anyone.
+ */
+const TEMPLATE_RE = /^[^/]+\/[^/]+\/\.github\/workflows\/[^/]+\.ya?ml$/;
+
+/** `uses: CodySwannGT/lisa/<path>@<ref>` — the reference this gate verifies. */
+const USES_RE = /uses:\s*CodySwannGT\/lisa\/([^\s@]+)@([^\s"'#]+)/g;
+
+/** The moving ref, resolvable against the working tree with no history. */
+const MOVING_REF = "main";
+
+/** Max bytes of `git ls-files` output (7k+ tracked paths is ~0.3 MB today). */
+const MAX_GIT_OUTPUT_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Usage error — thrown for an invalid invocation or an unverifiable state so
+ * `main` can distinguish it (exit 2) from a finding (exit 1).
+ */
+export class UsageError extends Error {}
+
+/**
+ * Extract every Lisa workflow reference in `content`.
+ *
+ * @param {string} content - full text of a template.
+ * @returns {{ target: string, ref: string, line: number }[]} one entry per
+ *   reference, with 1-based line numbers, in file order.
+ */
+export function findWorkflowRefs(content) {
+  const lines = String(content).split(/\r?\n/);
+  const refs = [];
+  for (let index = 0; index < lines.length; index++) {
+    // A fresh lastIndex per line: the regex is global and shared.
+    USES_RE.lastIndex = 0;
+    let match;
+    while ((match = USES_RE.exec(lines[index])) !== null) {
+      refs.push({ line: index + 1, ref: match[2], target: match[1] });
+    }
+  }
+  return refs;
+}
+
+/**
+ * List every tracked file in `root`, relative to it. Throws `UsageError` when
+ * git is unavailable or `root` is not a repository.
+ *
+ * @param {string} root - the repository root.
+ * @returns {string[]} tracked paths, relative to `root`.
+ */
+function listTrackedFiles(root) {
+  let stdout;
+  try {
+    stdout = execFileSync("git", ["-C", root, "ls-files", "-z"], {
+      encoding: "utf8",
+      maxBuffer: MAX_GIT_OUTPUT_BYTES,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch (error) {
+    throw new UsageError(
+      `could not list tracked files in ${root}: ${error.message}`
+    );
+  }
+  return stdout.split("\0").filter(entry => entry !== "");
+}
+
+/**
+ * Whether `ref` names an object present in this clone.
+ *
+ * @param {string} root - the repository root.
+ * @param {string} ref - a tag, branch, or SHA.
+ * @returns {boolean} whether the ref resolves locally.
+ */
+function refExists(root, ref) {
+  try {
+    execFileSync(
+      "git",
+      ["-C", root, "rev-parse", "--verify", `${ref}^{commit}`],
+      {
+        stdio: ["ignore", "ignore", "ignore"],
+      }
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Whether `target` exists in the tree named by `ref`.
+ *
+ * @param {string} root - the repository root.
+ * @param {string} ref - a tag, branch, or SHA known to resolve.
+ * @param {string} target - a repo-relative path.
+ * @returns {boolean} whether the path exists at that ref.
+ */
+function pathExistsAtRef(root, ref, target) {
+  try {
+    execFileSync("git", ["-C", root, "cat-file", "-e", `${ref}:${target}`], {
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve one reference to a verdict.
+ *
+ * `@main` is checked against the working tree so the gate is correct in a
+ * depth-1 clone, where `main` frequently is not a local ref at all. A pinned
+ * ref that is absent locally yields `unverifiable`, never `ok`.
+ *
+ * @param {string} root - the repository root.
+ * @param {{ target: string, ref: string }} reference - the parsed reference.
+ * @returns {"ok" | "missing" | "unverifiable"} the verdict.
+ */
+export function classifyRef(root, reference) {
+  const { ref, target } = reference;
+  if (ref === MOVING_REF) {
+    return fs.existsSync(path.join(root, target)) ? "ok" : "missing";
+  }
+  if (!refExists(root, ref)) {
+    return "unverifiable";
+  }
+  return pathExistsAtRef(root, ref, target) ? "ok" : "missing";
+}
+
+/**
+ * Assemble the machine-readable report.
+ *
+ * @param {ReadonlyArray<Record<string, unknown>>} results - non-ok references.
+ * @param {{ root: string, templates: number, checked: number }} opts - resolved
+ *   options plus scan size.
+ * @returns {Record<string, unknown>} the report object.
+ */
+export function buildReport(results, opts) {
+  const missing = results.filter(result => result.verdict === "missing");
+  const unverifiable = results.filter(
+    result => result.verdict === "unverifiable"
+  );
+  return {
+    results,
+    root: opts.root,
+    schemaVersion: 1,
+    summary: {
+      checked: opts.checked,
+      missing: missing.length,
+      ok: opts.checked - results.length,
+      templates: opts.templates,
+      unverifiable: unverifiable.length,
+    },
+  };
+}
+
+/**
+ * Render the human-readable report.
+ *
+ * @param {{ results: ReadonlyArray<Record<string, unknown>>, summary: Record<string, number> }} report
+ *   the report object.
+ * @returns {string} the rendered report.
+ */
+function humanReport(report) {
+  const { summary } = report;
+  if (summary.missing === 0 && summary.unverifiable === 0) {
+    return `✓ ${summary.checked} workflow reference(s) across ${summary.templates} caller template(s) all resolve`;
+  }
+  const lines = report.results.map(result =>
+    result.verdict === "missing"
+      ? `✗ ${result.file}:${result.line}\n    ${result.target}@${result.ref} — target does not exist at that ref`
+      : `? ${result.file}:${result.line}\n    ${result.target}@${result.ref} — ref not present in this clone, cannot verify`
+  );
+  const tail = [];
+  if (summary.missing > 0) {
+    tail.push(
+      `${summary.missing} reference(s) name a target that does not exist at the pinned ref.`,
+      "A consumer receiving this template gets a workflow that cannot load:",
+      "GitHub runs zero jobs and reports a workflow file issue, which produces",
+      "no test output and so reads as silence rather than as failure."
+    );
+  }
+  if (summary.unverifiable > 0) {
+    tail.push(
+      `${summary.unverifiable} reference(s) could not be verified because the ref`,
+      "is absent from this clone. Fetch tags and history, then re-run. This is",
+      "reported rather than passed: a gate that cannot look must not claim it saw."
+    );
+  }
+  return [...lines, "", ...tail].join("\n");
+}
+
+/**
+ * Parse argv into resolved options. Throws `UsageError` on a bad invocation.
+ *
+ * @param {readonly string[]} argv - arguments (without node/script prefix).
+ * @returns {{ root: string, json: boolean }} options.
+ */
+export function parseArgs(argv) {
+  let root = null;
+  let json = false;
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--root") {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new UsageError("--root requires a value");
+      }
+      root = next;
+      i += 1;
+    } else {
+      throw new UsageError(`unknown argument: ${arg}`);
+    }
+  }
+  return { json, root: path.resolve(root ?? REPO_ROOT) };
+}
+
+/**
+ * Run the gate. Returns the process exit code (does not call `exit`).
+ *
+ * @param {readonly string[]} argv - arguments (without node/script prefix).
+ * @param {{ stdout?: { write(s: string): void }, stderr?: { write(s: string): void } }} [io]
+ *   injectable streams (defaults to process streams).
+ * @returns {number} exit code (0 clean, 1 finding, 2 usage/unverifiable).
+ */
+export function main(argv, io = {}) {
+  const out = io.stdout ?? process.stdout;
+  const err = io.stderr ?? process.stderr;
+  let opts;
+  let templates;
+  try {
+    opts = parseArgs(argv);
+    if (!fs.existsSync(opts.root) || !fs.statSync(opts.root).isDirectory()) {
+      throw new UsageError(`--root is not a directory: ${opts.root}`);
+    }
+    templates = listTrackedFiles(opts.root).filter(file =>
+      TEMPLATE_RE.test(file)
+    );
+    if (templates.length === 0) {
+      // Finding nothing to check is a broken invocation, not conformance.
+      throw new UsageError(
+        `no caller templates found under ${opts.root} — expected paths like ` +
+          "expo/create-only/.github/workflows/*.yml. Refusing to report a " +
+          "clean run for a scan that examined nothing."
+      );
+    }
+  } catch (error) {
+    err.write(`error: ${error.message}\n`);
+    return 2;
+  }
+
+  let checked = 0;
+  const results = [];
+  try {
+    for (const file of templates) {
+      const content = fs.readFileSync(path.join(opts.root, file), "utf8");
+      for (const reference of findWorkflowRefs(content)) {
+        checked += 1;
+        const verdict = classifyRef(opts.root, reference);
+        if (verdict !== "ok") {
+          results.push({ ...reference, file, verdict });
+        }
+      }
+    }
+  } catch (error) {
+    err.write(`error: failed to scan caller templates: ${error.message}\n`);
+    return 2;
+  }
+
+  const report = buildReport(results, {
+    checked,
+    root: opts.root,
+    templates: templates.length,
+  });
+  out.write(
+    `${opts.json ? JSON.stringify(report, null, 2) : humanReport(report)}\n`
+  );
+  if (report.summary.unverifiable > 0) {
+    return 2;
+  }
+  return report.summary.missing === 0 ? 0 : 1;
+}
+
+if (invokedAsScript(import.meta.url)) {
+  // exitCode (not process.exit): when stdout is a pipe, writes are async and
+  // process.exit() truncates the report mid-flush.
+  process.exitCode = main(process.argv.slice(2));
+}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -231,9 +231,9 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/.github/workflows/nightly-e2e-bypass-reaper.yml":
       "db78a1012a00cf4e8b023a67bb57566ae85cf790c3856f3e299636c766f0c242",
     "expo/create-only/.github/workflows/nightly-e2e-health.yml":
-      "9852ce44177be171aca0c0f66136c88ae654409d7bcfc8bad989eedc18980780",
+      "89d9096af748fe608e669ea1e5bd71ac2520bcaceb88d36d55da2763eec20e55",
     "expo/create-only/.github/workflows/nightly-e2e-report.yml":
-      "5fccbcbb3f121eb80b165e6403ef131d4ed71da9b9f58386fa0db66daf4026f9",
+      "34dcd26108b814d00fbe61af8f954bf79590df0610657d01bff79adde5276330",
     "expo/create-only/.maestro/flake-classification.json":
       "b1259c17a875dcdc0fa2398bb280f084e898f46fefaf51e35c3c5aadcbef5a5d",
     "expo/create-only/.zap/baseline.conf":
@@ -2126,6 +2126,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "0060a0f65885b54fc93bd3885ca249cbb1ac822c52813817aae640bc1303827b",
     "scripts/check-state-classification.mjs":
       "26baaa85c0758fa41f1f66257f7d3a31ea4dd5cf17a9c0acaa3e89caaaf6265a",
+    "scripts/check-template-workflow-refs.mjs":
+      "659f2f11f20ea8414d1732b90f388c937a9b628f8689f02a7fbaa93666e6bd2f",
     "scripts/claude-remote-setup.sh":
       "0e33accf8aa057c70497f01c38bef9f9f3801d649272f583578d89201b242655",
     "scripts/clean-dist.mjs":
@@ -8170,6 +8172,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/check-rules-pairing.sh": true,
     "scripts/check-security-floors.mjs": true,
     "scripts/check-state-classification.mjs": true,
+    "scripts/check-template-workflow-refs.mjs": true,
     "scripts/claude-remote-setup.sh": true,
     "scripts/clean-dist.mjs": true,
     "scripts/cleanup-amplify-branches.sh": true,
@@ -9049,6 +9052,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/check-duplicate-versions.units.test.ts": true,
     "tests/unit/scripts/check-learnings-budget-helpers.ts": true,
     "tests/unit/scripts/check-learnings-budget.test.ts": true,
+    "tests/unit/scripts/check-template-workflow-refs.test.ts": true,
     "tests/unit/scripts/codex-hook-filter.test.ts": true,
     "tests/unit/scripts/command-envelope.test.ts": true,
     "tests/unit/scripts/cross-pollinate.test.ts": true,

--- a/tests/unit/scripts/check-template-workflow-refs.test.ts
+++ b/tests/unit/scripts/check-template-workflow-refs.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for scripts/check-template-workflow-refs.mjs (issue #2702).
+ *
+ * The headline case: `expo/create-only/.github/workflows/nightly-e2e-report.yml`
+ * shipped pinned at `@v2.345.1`, a Lisa version that predates the reusable it
+ * calls. A consumer receiving it gets a workflow that cannot LOAD — GitHub runs
+ * zero jobs and reports a workflow file issue — so there is no test output and
+ * nothing reads as red. It never succeeded once in three scheduled runs across
+ * two repos, and stayed byte-identical to the broken template in both, because
+ * a workflow that never runs gives nobody a reason to edit it.
+ *
+ * The two exit-2 cases carry as much weight as the exit-1 case. A gate that
+ * scans nothing, or that cannot resolve the ref it was asked about, must say so
+ * rather than report a clean run — reproducing the very defect it exists to
+ * catch would be the worst possible outcome for this file.
+ *
+ * Per the Test Isolation house rule, expected values are HARDCODED.
+ *
+ * @module tests/unit/scripts/check-template-workflow-refs
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  classifyRef,
+  findWorkflowRefs,
+} from "../../../scripts/check-template-workflow-refs.mjs";
+import { cleanGitEnv } from "../../helpers/test-utils";
+
+const SCRIPT = path.resolve("scripts/check-template-workflow-refs.mjs");
+const GIT = "/usr/bin/git";
+const ADD_ALL = ["add", "-A"] as const;
+
+/** A template path the gate recognises: `<lane>/<mode>/.github/workflows/…`. */
+const TEMPLATE = "expo/create-only/.github/workflows/nightly-e2e-report.yml";
+
+/** The reusable the template above calls, as it lives in this repository. */
+const REUSABLE = ".github/workflows/nightly-e2e-report.yml";
+
+/** Stand-in body for the reusable, so its presence at a ref is what varies. */
+const REUSABLE_BODY = "name: reusable\n";
+
+/**
+ * A caller template referencing the reusable at `ref`.
+ *
+ * @param ref - the git ref to pin in the `uses:` line.
+ * @returns The template's YAML text.
+ */
+function callerTemplate(ref: string): string {
+  return [
+    "name: 🌙 Nightly E2E Report",
+    "on:",
+    "  workflow_dispatch:",
+    "jobs:",
+    "  report:",
+    `    uses: CodySwannGT/lisa/${REUSABLE}@${ref}`,
+    "",
+  ].join("\n");
+}
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { force: true, recursive: true });
+  }
+});
+
+/**
+ * Create a temporary git repository with `files` written and committed.
+ *
+ * @param files - relative path to file contents.
+ * @returns The absolute repository root.
+ */
+function tempRepo(files: Readonly<Record<string, string>>): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-2702-"));
+  const env = cleanGitEnv(process.env);
+  const entries = Object.entries(files);
+  const git = (...args: readonly string[]): void => {
+    execFileSync(GIT, [...args], { cwd: root, env, stdio: "ignore" });
+  };
+  roots.push(root);
+  for (const [relative, content] of entries) {
+    const target = path.join(root, relative);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, content, "utf8");
+  }
+  git("init", "-q");
+  git("config", "user.email", "test@example.com");
+  git("config", "user.name", "Test");
+  if (entries.length > 0) {
+    git(...ADD_ALL);
+    git("commit", "-q", "-m", "seed");
+  }
+  return root;
+}
+
+/**
+ * Run the CLI and capture its exit code plus combined output.
+ *
+ * @param args - CLI arguments after the script path.
+ * @returns The exit code, stdout, and stderr text.
+ */
+function run(args: readonly string[]): {
+  code: number;
+  stdout: string;
+  stderr: string;
+} {
+  try {
+    const stdout = execFileSync(process.execPath, [SCRIPT, ...args], {
+      encoding: "utf8",
+    });
+    return { code: 0, stderr: "", stdout };
+  } catch (error) {
+    const e = error as { status?: number; stdout?: string; stderr?: string };
+    return {
+      code: typeof e.status === "number" ? e.status : -1,
+      stderr: e.stderr ?? "",
+      stdout: e.stdout ?? "",
+    };
+  }
+}
+
+describe("findWorkflowRefs", () => {
+  it("extracts the target and ref with a 1-based line number", () => {
+    const refs = findWorkflowRefs(callerTemplate("v2.345.1"));
+    expect(refs).toEqual([{ line: 6, ref: "v2.345.1", target: REUSABLE }]);
+  });
+
+  it("ignores uses: lines that point at other repositories", () => {
+    // Both negative cases stay inside orgs Lisa is allowed to name: a third
+    // party (actions/) and this org's OTHER repositories. The gate verifies
+    // paths in THIS repository, so a same-org different-repo reference is out
+    // of scope in exactly the way a third-party one is.
+    const yaml = [
+      "jobs:",
+      "  build:",
+      "    steps:",
+      "      - uses: actions/checkout@v4",
+      "      - uses: CodySwannGT/not-lisa/.github/workflows/x.yml@main",
+    ].join("\n");
+    expect(findWorkflowRefs(yaml)).toEqual([]);
+  });
+
+  it("finds every reference when one template calls several reusables", () => {
+    const yaml = [
+      "    uses: CodySwannGT/lisa/.github/workflows/a.yml@main",
+      "    uses: CodySwannGT/lisa/.github/workflows/b.yml@v3.1.0",
+    ].join("\n");
+    expect(findWorkflowRefs(yaml)).toEqual([
+      { line: 1, ref: "main", target: ".github/workflows/a.yml" },
+      { line: 2, ref: "v3.1.0", target: ".github/workflows/b.yml" },
+    ]);
+  });
+});
+
+describe("classifyRef", () => {
+  it("resolves @main against the working tree, needing no history", () => {
+    const root = tempRepo({
+      [REUSABLE]: REUSABLE_BODY,
+      [TEMPLATE]: callerTemplate("main"),
+    });
+    expect(classifyRef(root, { ref: "main", target: REUSABLE })).toBe("ok");
+  });
+
+  it("reports missing when @main names a file that is not there", () => {
+    const root = tempRepo({ [TEMPLATE]: callerTemplate("main") });
+    expect(classifyRef(root, { ref: "main", target: REUSABLE })).toBe(
+      "missing"
+    );
+  });
+
+  it("reports unverifiable — never ok — for a ref absent from the clone", () => {
+    const root = tempRepo({
+      [REUSABLE]: REUSABLE_BODY,
+      [TEMPLATE]: callerTemplate("v99.99.99"),
+    });
+    expect(classifyRef(root, { ref: "v99.99.99", target: REUSABLE })).toBe(
+      "unverifiable"
+    );
+  });
+});
+
+describe("check-template-workflow-refs CLI", () => {
+  it("exits 0 when every reference resolves", () => {
+    const root = tempRepo({
+      [REUSABLE]: REUSABLE_BODY,
+      [TEMPLATE]: callerTemplate("main"),
+    });
+    const result = run(["--root", root]);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("all resolve");
+  });
+
+  it("exits 1 on the #2702 defect: a pin predating the reusable", () => {
+    // The tag exists, and the reusable does not exist at it — the exact shape
+    // that ships a workflow which cannot load.
+    const root = tempRepo({
+      [REUSABLE]: REUSABLE_BODY,
+      [TEMPLATE]: callerTemplate("v0.1.0"),
+    });
+    const env = cleanGitEnv(process.env);
+    // Tag a commit that predates the reusable, so the ref resolves but the
+    // path does not exist in its tree.
+    execFileSync(GIT, ["rm", "-q", "--cached", REUSABLE], { cwd: root, env });
+    execFileSync(GIT, ["commit", "-q", "-m", "before the reusable existed"], {
+      cwd: root,
+      env,
+    });
+    execFileSync(GIT, ["tag", "v0.1.0"], { cwd: root, env });
+    execFileSync(GIT, [...ADD_ALL], { cwd: root, env });
+    execFileSync(GIT, ["commit", "-q", "-m", "restore"], { cwd: root, env });
+
+    const result = run(["--root", root]);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain("does not exist at that ref");
+  });
+
+  it("exits 2 rather than 0 when it discovers no templates at all", () => {
+    // The absent-case rule. A scan that examined nothing is a broken
+    // invocation, not conformance.
+    const root = tempRepo({ "readme.md": "nothing to see\n" });
+    const result = run(["--root", root]);
+    expect(result.code).toBe(2);
+    expect(result.stderr).toContain("no caller templates found");
+  });
+
+  it("exits 2 rather than 0 when a pinned ref cannot be resolved", () => {
+    // A gate that cannot look must not claim it saw.
+    const root = tempRepo({
+      [REUSABLE]: REUSABLE_BODY,
+      [TEMPLATE]: callerTemplate("v99.99.99"),
+    });
+    const result = run(["--root", root]);
+    expect(result.code).toBe(2);
+    expect(result.stdout).toContain("cannot verify");
+  });
+
+  it("exits 2 on an unknown flag", () => {
+    expect(run(["--nope"]).code).toBe(2);
+  });
+});


### PR DESCRIPTION
Two expo caller templates shipped pinned at `@v2.345.1`, a Lisa version that **predates the reusable they call**. The reusables first exist at `v3.1.0`. A consumer receiving either gets a workflow that cannot **load** — GitHub reports *"this run likely failed because of a workflow file issue"* and runs **zero jobs**.

Repinned to `v3.35.0`, where both are present.

## The fix is a correct pin, not an unpinned ref

My first attempt moved both to `@main`, matching the other six expo references. **The existing integration suites rejected it**, and they were right:

```
✗ the caller PINS AN IMMUTABLE REF — `@main` is not a pin for a merge gate
✗ the report caller pins an immutable ref, like the gate caller
```

> The thing that decides whether code may merge must not change under you between two runs of the same PR (Appendix A5).

Those two callers are pinned **deliberately**. The bug was never that they were pinned — it was that the pin named a version predating the file. Nothing outside those two tests even references the pin pattern, so no automation maintains it: `v2.345.1` was simply the wrong tag at authoring time, and nothing since could notice.

## Why one was repaired everywhere and the other nowhere

**`nightly-e2e-health.yml` backs a required gate**, so a broken load blocks merges instantly. All four consumers noticed and repaired it locally — two repointed to different newer tags, two abandoned the reusable and reimplemented the gate by hand. One consumer's copy differs from the template by **exactly one line**, and that line is the ref. None of the four repairs flowed back, so every new consumer kept inheriting the defect.

**`nightly-e2e-report.yml` produces no output anyone reads.** A workflow that fails to *load* emits no test results, so no suite goes red and no report shows a failure. Nobody fixed it, and it has **never once succeeded**:

```
TunnlAI/frontend      2026-08-18T02:34  failure
PropSwapLLC/frontend  2026-08-18T01:59  failure
PropSwapLLC/frontend  2026-08-17T02:00  failure
```

Its own commit message is `feat(nightly-e2e): tell somebody the nightly is red, and stop when it is not`. **The job that exists to tell you the nightly is broken has been broken since the day it shipped.**

It's also why that file was the only byte-identical row in the #2700 drift audit — not convergence, but because a workflow that never runs gives nobody a reason to touch it. Identical-and-never-worked scores as the *healthy* row on a filename or hash census, and it's strictly worse than diverged-and-working.

## The guard

`check-template-workflow-refs.mjs` reads every `uses:` in every shipped caller template and confirms the target exists at the named ref. Follows the sibling parity scripts: zero third-party deps, no network, no `Date`/`Math.random`, file list from `git ls-files`, injectable IO, exit 0/1/2.

Two decisions matter more than the happy path:

- **Zero templates discovered exits 2, never 0.** A scan that examined nothing is a broken invocation, not conformance.
- **A pinned ref absent from the clone is UNVERIFIABLE and exits 2, never ok.** A gate that cannot look must not claim it saw. `@main` is instead resolved against the working tree, so the gate stays correct for the six references that legitimately track a moving ref.

Reproducing the defect this file exists to catch would be the worst outcome for it, so both exit-2 paths carry unit tests alongside the exit-1 one.

Verified by hand as well:

| control | result |
| --- | --- |
| clean tree | exit 0, 21 refs across 21 templates |
| reintroduce the real `@v2.345.1` pin | **exit 1**, names file and line |
| valid git repo, zero templates | exit 2 |
| unresolvable pin | exit 2 |

Wired into `plugins-sync.yml` beside the conflict-marker gate, with an explicit `git fetch --tags` — verifying an immutable pin needs the tag object, and the gate correctly refuses to pass what it could not resolve.

**Deliberately not added to the shared gate registry** in `lisa-gates.mjs`: this repo is the only one carrying caller templates, so the absent-case rule that makes the gate honest here would fail every consumer's commit.

Work-Item: CodySwannGT/lisa#2702
