### PR TITLE
feat(ci): give the Maestro reusable the four capabilities consumers forked for

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -226,6 +226,42 @@ on:
         required: false
         default: 'dev-e2e'
         type: string
+      reuse_build_by_fingerprint:
+        description: >-
+          Reuse a finished EAS build whose fingerprint matches this commit
+          instead of starting a new cloud build. `eas fingerprint:generate`
+          hashes the native inputs (native dependencies, app config, plugin
+          set); a hit means an existing binary is byte-for-byte the app this
+          commit would produce, so building it again buys nothing. On a
+          fingerprint miss the workflow falls back to the latest FINISHED build
+          for this profile and platform, and only starts a fresh build when
+          both miss. Default false = always build, prior behavior preserved.
+          Turn it on when EAS build quota is the binding constraint rather than
+          build freshness: on Expo's Free plan the quota is what stops the
+          suite from running at all, which is why every consumer that hit it
+          forked this workflow. The cost of turning it on is that a suite can
+          run against a binary built from an EARLIER commit whose native inputs
+          hashed the same — which is exactly what the fingerprint asserts, but
+          it is an assertion about NATIVE inputs only. JS-only changes do not
+          move the fingerprint, so a project whose e2e profile embeds the JS
+          bundle should leave this off or it will test stale JS.
+        required: false
+        default: false
+        type: boolean
+      diagnose_eas_quota_exhaustion:
+        description: >-
+          When a fresh EAS build fails, scan its stderr for Expo's Free-plan
+          exhaustion message and re-emit it as a `::error::` naming the remedy.
+          Without this the failure reads as a generic build error and the
+          operator has to open the raw log to learn that nothing is wrong with
+          the code. Default false = prior behavior preserved, because turning
+          it on buffers the build's stderr to a file instead of streaming it
+          live to the job log — worth knowing on a `--wait` build that runs for
+          the better part of an hour. The buffered stderr is replayed in full
+          before the step exits, so nothing is lost, only delayed.
+        required: false
+        default: false
+        type: boolean
       flows_dir:
         description: 'Maestro flows directory'
         required: false
@@ -340,6 +376,25 @@ on:
           deleted flows directory or an expired EXPO_TOKEN looks exactly like a
           passing suite. Adopters have been hand-rolling preflight jobs to get
           this behaviour; set it true instead.
+        required: false
+        default: false
+        type: boolean
+      lint_flow_app_id:
+        description: >-
+          Fail preflight when a Maestro flow would launch an EMPTY app id. The
+          app id reaches flows as `-e MAESTRO_APP_ID=…`, so a flow that writes
+          `appId: ${APP_ID}` — or omits `appId:` entirely — interpolates to
+          nothing and Maestro reports a launch failure that names no cause. It
+          reads as a broken app; it is a one-line config error. Two checks run:
+          no file under the flows directory's Maestro root may reference
+          `${APP_ID}`, and every flow file under the flows directory must
+          declare `appId: ${MAESTRO_APP_ID}`. Default false = prior behavior
+          preserved, because the second check is only correct for a project
+          whose subflows live OUTSIDE the flows directory: `maestro test <dir>`
+          recurses, so a `runFlow`-included subflow sitting inside it is a flow
+          file that legitimately declares no appId and would fail this lint.
+          Move those beside the flows directory rather than inside it, then
+          turn this on.
         required: false
         default: false
         type: boolean
@@ -536,6 +591,55 @@ jobs:
             echo "run_ios=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: 🏷️ Lint per-flow appId
+        # Cheap here, expensive later. An empty interpolated appId does not
+        # announce itself: Maestro reports a launch failure with no cause, the
+        # whole suite reds on its first assertion, and the shape is
+        # indistinguishable by inspection from the app failing to start. That
+        # costs an EAS build and an emulator boot to discover. This costs a
+        # grep, before either.
+        #
+        # Runs only when the prerequisites held — a skipped suite has nothing
+        # to lint, and failing here would convert warn-and-skip into a red for
+        # every unwired adopter, which is `require_prerequisites`' job and not
+        # this one's.
+        if: ${{ inputs.lint_flow_app_id && steps.check.outputs.should_run == 'true' }}
+        env:
+          FLOWS_DIR: ${{ inputs.flows_dir }}
+        run: |
+          set -euo pipefail
+          # The `${APP_ID}` scan deliberately covers the Maestro ROOT, not just
+          # the flows directory. The drift this catches is a shared subflow
+          # naming the wrong variable while every flow beside it names the
+          # right one — and a shared subflow lives outside the flows directory
+          # by convention, so scanning only the flows directory would miss the
+          # exact file that breaks the suite.
+          APP_ID_SCAN_DIR="$(dirname "$FLOWS_DIR")"
+          if [[ "$APP_ID_SCAN_DIR" == "." || -z "$APP_ID_SCAN_DIR" ]]; then
+            APP_ID_SCAN_DIR="$FLOWS_DIR"
+          fi
+
+          # `--include` on BOTH scans, not just the second: an unfiltered
+          # recursive grep also reads whatever screenshots and .ans dumps a
+          # previous debug run left under the Maestro root, and grep reports
+          # ZERO matches in a file it decides is binary — so an unfiltered
+          # scan can pass by refusing to read the file that breaks the suite.
+          bad=$(grep -rlE --include='*.yaml' --include='*.yml' '^[[:space:]]*appId:[[:space:]]*\$\{APP_ID\}' "$APP_ID_SCAN_DIR" || true)
+          if [[ -n "$bad" ]]; then
+            echo "::error title=Maestro flow uses the wrong app id variable::These files declare 'appId: \${APP_ID}', but this workflow forwards the app id as MAESTRO_APP_ID. \${APP_ID} interpolates to EMPTY and Maestro fails to launch with no cause named. Rename the variable to MAESTRO_APP_ID."
+            echo "$bad" >&2
+            exit 1
+          fi
+
+          missing=$(grep -rLE --include='*.yaml' --include='*.yml' '^[[:space:]]*appId:[[:space:]]*\$\{MAESTRO_APP_ID\}' "$FLOWS_DIR" || true)
+          if [[ -n "$missing" ]]; then
+            echo "::error title=Maestro flow declares no appId::These flow files do not declare 'appId: \${MAESTRO_APP_ID}'. A flow with no appId launches nothing and reports a failure that names no cause. If a listed file is a runFlow-included SUBFLOW rather than a flow, move it outside '$FLOWS_DIR' — maestro test recurses, so anything under that directory is executed as a flow."
+            echo "$missing" >&2
+            exit 1
+          fi
+
+          echo "✅ every flow under '$FLOWS_DIR' declares appId: \${MAESTRO_APP_ID}"
+
   build:
     name: 🏗️ EAS Build (${{ matrix.platform }})
     needs: preflight
@@ -549,6 +653,16 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          # No step in this job uses the git token: the work here is an EAS
+          # build / a Maestro run / a caller-supplied setup command, none of
+          # which push. Left at the default, the checkout writes an
+          # unscoped credential into .git/config where every subsequent
+          # step — including third-party actions and the caller's own
+          # command — can read it and push as the workflow. A job that
+          # genuinely needs the token should say so HERE rather than
+          # inherit it silently.
+          persist-credentials: false
 
       - name: 🥟 Setup Bun
         if: inputs.package_manager == 'bun'
@@ -615,20 +729,179 @@ jobs:
         # the Android build dies with MISSING_GOOGLE_SERVICES_JSON. The
         # committed .easignore is authoritative and is what the release
         # pipeline uses.
+        #
+        # Every caller-supplied value arrives through `env:`, never through a
+        # `${{ }}` expansion inside the script body. An expansion is
+        # substituted into the script TEXT before bash parses it, which makes a
+        # caller's `eas_profile` workflow SOURCE rather than an argument — the
+        # same rule the profile guard above and the flows-dir handling below
+        # already follow.
+        env:
+          EAS_PLATFORM: ${{ matrix.platform }}
+          EAS_PROFILE: ${{ inputs.eas_profile }}
+          REUSE_BY_FINGERPRINT: ${{ inputs.reuse_build_by_fingerprint }}
+          DIAGNOSE_QUOTA: ${{ inputs.diagnose_eas_quota_exhaustion }}
         run: |
-          eas build \
-            --platform ${{ matrix.platform }} \
-            --profile ${{ inputs.eas_profile }} \
-            --non-interactive \
-            --wait \
-            --json > build.json
+          set -euo pipefail
+          platform="$EAS_PLATFORM"
+          profile="$EAS_PROFILE"
+
+          # `eas build:download` hands back either a file or an already
+          # extracted .app directory, and the two arms downstream expect one
+          # shape each: an .apk for Android, a tarball for iOS.
+          stage_artifact() {
+            src="$1"
+            if [[ "$platform" == "android" ]]; then
+              cp "$src" app-android.apk
+              return
+            fi
+            if [[ -d "$src" ]]; then
+              tar -czf app-ios.tar.gz -C "$(dirname "$src")" "$(basename "$src")"
+            else
+              cp "$src" app-ios.tar.gz
+            fi
+          }
+
+          stage_download_json() {
+            src="$(jq -r '.path // empty' download.json 2>/dev/null || true)"
+            if [[ -n "$src" && -e "$src" ]]; then
+              stage_artifact "$src"
+              return 0
+            fi
+            return 1
+          }
+
+          reused=0
+
+          if [[ "$REUSE_BY_FINGERPRINT" == "true" ]]; then
+            # NO step of the reuse path may fail this job. Every branch below
+            # falls through to the fresh build, which is what this workflow did
+            # before the input existed — so a broken EAS CLI, a fingerprint the
+            # account cannot compute, or a download that 404s degrades to
+            # today's behavior instead of deleting the suite from the night.
+            set +e
+            fp_json="$(eas fingerprint:generate \
+              --platform "$platform" \
+              --build-profile "$profile" \
+              --json \
+              --non-interactive 2>fingerprint.err)"
+            fp_status=$?
+            set -e
+            fingerprint="$(jq -r '.hash // .fingerprintHash // empty' <<<"${fp_json:-}" 2>/dev/null || true)"
+
+            if [[ "$fp_status" -eq 0 && -n "$fingerprint" ]]; then
+              echo "Fingerprint for $platform/$profile: $fingerprint"
+              set +e
+              eas build:download \
+                --fingerprint "$fingerprint" \
+                --platform "$platform" \
+                --non-interactive \
+                --json > download.json 2>download.err
+              dl_status=$?
+              set -e
+              if [[ "$dl_status" -eq 0 ]] && stage_download_json; then
+                reused=1
+                echo "Reusing the finished EAS build matching this fingerprint; no new cloud build started."
+              else
+                echo "No reusable EAS artifact for fingerprint $fingerprint."
+                cat download.err >&2 || true
+              fi
+            else
+              echo "::warning title=EAS fingerprint unavailable::Could not compute a fingerprint for $platform/$profile, so build reuse was skipped and a fresh build will be started."
+              cat fingerprint.err >&2 || true
+            fi
+
+            # Fallback, and a WEAKER guarantee than the fingerprint — this is
+            # simply the newest finished binary for the profile, which may have
+            # been built from different native inputs. It is the arm that keeps
+            # a quota-bound project running at all, so it is deliberately kept,
+            # but a project that needs the binary to match the commit should
+            # read the reuse line in the job log rather than assume.
+            if [[ "$reused" -eq 0 ]]; then
+              echo "Looking up the latest finished $profile $platform EAS build."
+              set +e
+              if [[ "$platform" == "ios" ]]; then
+                # `--simulator` matters: a finished iOS build for this profile
+                # can be a device archive, which no simulator can install.
+                eas build:list \
+                  --platform ios \
+                  --build-profile "$profile" \
+                  --status finished \
+                  --simulator \
+                  --limit 1 \
+                  --json \
+                  --non-interactive > list.json 2>list.err
+              else
+                eas build:list \
+                  --platform android \
+                  --build-profile "$profile" \
+                  --status finished \
+                  --limit 1 \
+                  --json \
+                  --non-interactive > list.json 2>list.err
+              fi
+              list_status=$?
+              set -e
+              build_id="$(jq -r '.[0].id // empty' list.json 2>/dev/null || true)"
+              if [[ "$list_status" -eq 0 && -n "$build_id" ]]; then
+                set +e
+                eas build:download \
+                  --build-id "$build_id" \
+                  --non-interactive \
+                  --json > download.json 2>download.err
+                dl_status=$?
+                set -e
+                if [[ "$dl_status" -eq 0 ]] && stage_download_json; then
+                  reused=1
+                  echo "Reusing finished EAS $profile build $build_id after a fingerprint miss."
+                else
+                  cat download.err >&2 || true
+                fi
+              else
+                cat list.err >&2 || true
+              fi
+            fi
+          fi
+
+          if [[ "$reused" -eq 1 ]]; then
+            exit 0
+          fi
+
+          if [[ "$DIAGNOSE_QUOTA" == "true" ]]; then
+            set +e
+            eas build \
+              --platform "$platform" \
+              --profile "$profile" \
+              --non-interactive \
+              --wait \
+              --json > build.json 2>build.err
+            build_status=$?
+            set -e
+            # Replayed in full, always — the diagnosis is an ADDITION to the
+            # operator's evidence, never a filter on it.
+            cat build.err >&2 || true
+            if [[ "$build_status" -ne 0 ]]; then
+              if grep -q "used its iOS builds from the Free plan" build.err; then
+                echo "::error title=EAS build quota exhausted::Expo refused a new iOS cloud build because this account has used its Free-plan iOS builds for the month. Nothing is wrong with the code under test. Remedies, in order: set reuse_build_by_fingerprint: true so a matching finished build is reused instead of rebuilt; upgrade the Expo plan; or wait for the monthly quota reset and re-dispatch."
+              fi
+              exit "$build_status"
+            fi
+          else
+            eas build \
+              --platform "$platform" \
+              --profile "$profile" \
+              --non-interactive \
+              --wait \
+              --json > build.json
+          fi
+
           BUILD_URL=$(jq -r '.[0].artifacts.buildUrl' build.json)
           if [[ -z "$BUILD_URL" || "$BUILD_URL" == "null" ]]; then
             echo "::error::EAS build produced no artifact URL"
             jq '.' build.json
             exit 1
           fi
-          if [[ "${{ matrix.platform }}" == "android" ]]; then
+          if [[ "$platform" == "android" ]]; then
             curl -fsSL "$BUILD_URL" -o app-android.apk
           else
             # iOS simulator builds ship as a tarball containing the .app bundle
@@ -698,6 +971,9 @@ jobs:
       - name: 📥 Checkout repository
         if: ${{ inputs.pre_suite_command != '' }}
         uses: actions/checkout@v6
+        with:
+          # Nothing downstream needs the git token — see the build job.
+          persist-credentials: false
 
       - name: 🥟 Setup Bun
         if: ${{ inputs.pre_suite_command != '' && inputs.pre_suite_install_dependencies && inputs.package_manager == 'bun' }}
@@ -1093,6 +1369,9 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Nothing downstream needs the git token — see the build job.
+          persist-credentials: false
 
       - name: 📥 Download app artifact
         uses: actions/download-artifact@v4
@@ -1476,6 +1755,9 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v6
+        with:
+          # Nothing downstream needs the git token — see the build job.
+          persist-credentials: false
 
       - name: 📥 Download app artifact
         uses: actions/download-artifact@v4

--- a/expo/create-only/.github/workflows/maestro-e2e.yml
+++ b/expo/create-only/.github/workflows/maestro-e2e.yml
@@ -137,6 +137,33 @@ jobs:
       # concurrency is free coverage in that case. The cost when on is the suite
       # taking iOS PLUS Android instead of the slower of the two.
       # serialize_platform_legs: true
+      #
+      # Uncomment when EAS build quota — not build freshness — is what limits
+      # this suite. On Expo's Free plan the monthly iOS quota is what stops the
+      # nightly running at all, and a rebuild of native inputs that did not
+      # change buys nothing. `eas fingerprint:generate` hashes those inputs; a
+      # match means the finished binary IS the app this commit would build, so
+      # it is downloaded instead of rebuilt. A miss falls back to the latest
+      # finished build for the profile, and only then does a fresh build start.
+      # Leave it off if your e2e profile embeds the JS bundle: JS-only changes
+      # do not move the fingerprint, so reuse would test stale JS.
+      # reuse_build_by_fingerprint: true
+      #
+      # Uncomment to have a failed build say WHY when Expo refuses it for
+      # quota. Without this the run reds with a generic build error and the
+      # cause is only in the raw log. The cost is that the build's stderr is
+      # buffered and replayed at the end rather than streaming live.
+      # diagnose_eas_quota_exhaustion: true
+      #
+      # Uncomment once every flow declares `appId: ${MAESTRO_APP_ID}` and any
+      # runFlow-included SUBFLOWS live OUTSIDE .maestro/flows. The app id
+      # arrives as `-e MAESTRO_APP_ID=…`, so a flow naming a different variable
+      # (or none) launches an EMPTY app id — which Maestro reports as a launch
+      # failure naming no cause, after you have already paid for an EAS build
+      # and an emulator boot. This turns that into a grep in preflight.
+      # `maestro test` recurses, so anything under the flows directory is a
+      # flow and is expected to declare an appId.
+      # lint_flow_app_id: true
     secrets:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       MAESTRO_SECRET_ENV: ${{ secrets.MAESTRO_SECRET_ENV }}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -227,7 +227,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/.github/workflows/deploy.yml":
       "27f5037db910501f8d76f828f91a605e3c4d321d1df362d317c440ab7abc9f14",
     "expo/create-only/.github/workflows/maestro-e2e.yml":
-      "cb7ae17a845f4a0cab21b8eb87291f2746610880c6a611731520ee1b925ecf85",
+      "cd587cd38ca985b621d572e96f05425bcb9ca8dcef9af5b338349cfa1e6cfd39",
     "expo/create-only/.github/workflows/nightly-e2e-bypass-reaper.yml":
       "db78a1012a00cf4e8b023a67bb57566ae85cf790c3856f3e299636c766f0c242",
     "expo/create-only/.github/workflows/nightly-e2e-health.yml":
@@ -8678,8 +8678,12 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/gate-config-validity-job.test.ts": true,
     "tests/integration/jest-expo-haste-pruning.test.ts": true,
     "tests/integration/lisa.test.ts": true,
+    "tests/integration/maestro-build-reuse.test.ts": true,
     "tests/integration/maestro-caller-template.test.ts": true,
+    "tests/integration/maestro-checkout-credentials.test.ts": true,
     "tests/integration/maestro-eas-profile-guard.test.ts": true,
+    "tests/integration/maestro-eas-quota-diagnosis.test.ts": true,
+    "tests/integration/maestro-flow-app-id-lint.test.ts": true,
     "tests/integration/maestro-leg-order-wait.test.ts": true,
     "tests/integration/maestro-leg-order.test.ts": true,
     "tests/integration/maestro-native-concurrency.test.ts": true,
@@ -8709,6 +8713,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/standards-proof-tamper.test.ts": true,
     "tests/integration/standards-proof-timeout.test.ts": true,
     "tests/integration/standards-proof-typescript.test.ts": true,
+    "tests/integration/support/maestro-build-step-harness.ts": true,
     "tests/integration/support/maestro-leg-order-harness.ts": true,
     "tests/integration/support/reusable-workflow-scopes.ts": true,
     "tests/unit/agy/block-no-verify-agy.test.ts": true,

--- a/tests/integration/maestro-build-reuse.test.ts
+++ b/tests/integration/maestro-build-reuse.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Behavioral tests for `reuse_build_by_fingerprint` — these EXECUTE the
+ * workflow's own shell, pulled verbatim out of the YAML, against a stubbed
+ * `eas` CLI.
+ *
+ * Asserting that the input appears in the file would prove only that somebody
+ * typed it. What has to be true is narrower and is the whole reason the input
+ * exists: with it ON and a fingerprint hit, `eas build` must NEVER be invoked.
+ * On Expo's Free plan that invocation is what exhausts the monthly quota, and
+ * an exhausted quota does not slow the suite down — it stops it running at all.
+ * Every case below therefore reads the stub's invocation LOG, so a pass and a
+ * fail differ in behaviour rather than in wording.
+ *
+ * The negative cases carry the same weight as the positive ones. Reuse OFF must
+ * not fingerprint anything; reuse ON with both lookups missing must still
+ * build; a fingerprint the account cannot compute must degrade to a build
+ * rather than fail the job. A reuse path that can delete the suite from the
+ * night would be worse than the quota problem it solves.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  ANDROID_ARTIFACT,
+  BUILD_SUBCOMMAND,
+  DOWNLOAD_SUBCOMMAND,
+  FINGERPRINT_SUBCOMMAND,
+  IOS_ARTIFACT,
+  LIST_SUBCOMMAND,
+  buildStepScript,
+  loadReusable,
+  ran,
+  runBuildStep,
+} from "./support/maestro-build-step-harness";
+
+describe("maestro-native-e2e EAS build reuse (executed)", () => {
+  let script: string;
+
+  beforeAll(async () => {
+    script = buildStepScript(await loadReusable());
+  });
+
+  it("OFF by default: builds fresh and never computes a fingerprint", async () => {
+    // The compatibility case. Four repositories consume this reusable; a
+    // default that started reusing binaries would change what every one of
+    // them tests, silently, on the night this lands.
+    const result = await runBuildStep(script, { reuse: false });
+    expect(result.status).toBe(0);
+    expect(ran(result.invocations, FINGERPRINT_SUBCOMMAND)).toBe(false);
+    expect(ran(result.invocations, DOWNLOAD_SUBCOMMAND)).toBe(false);
+    expect(ran(result.invocations, LIST_SUBCOMMAND)).toBe(false);
+    expect(ran(result.invocations, BUILD_SUBCOMMAND)).toBe(true);
+    expect(result.staged).toContain(ANDROID_ARTIFACT);
+  });
+
+  it("ON with a fingerprint hit: SKIPS the build entirely — the quota this saves", async () => {
+    // The bite. `eas build` absent from the log IS the feature.
+    const result = await runBuildStep(script, {
+      reuse: true,
+      fingerprint: "hit",
+      download: "hit",
+    });
+    expect(result.status).toBe(0);
+    expect(ran(result.invocations, FINGERPRINT_SUBCOMMAND)).toBe(true);
+    expect(ran(result.invocations, BUILD_SUBCOMMAND)).toBe(false);
+    expect(result.output).toContain("Reusing the finished EAS build");
+    expect(result.staged).toContain(ANDROID_ARTIFACT);
+  });
+
+  it("ON with a fingerprint MISS: falls back to the latest finished build, still no fresh build", async () => {
+    const result = await runBuildStep(script, {
+      reuse: true,
+      fingerprint: "hit",
+      download: "miss",
+      list: "hit",
+      buildIdDownload: "hit",
+    });
+    expect(result.status).toBe(0);
+    expect(ran(result.invocations, LIST_SUBCOMMAND)).toBe(true);
+    expect(
+      result.invocations.some(line => line.includes("--build-id build-id-777"))
+    ).toBe(true);
+    expect(ran(result.invocations, BUILD_SUBCOMMAND)).toBe(false);
+    expect(result.output).toContain("after a fingerprint miss");
+    expect(result.staged).toContain(ANDROID_ARTIFACT);
+  });
+
+  it("ON with BOTH lookups missing: builds fresh rather than failing the job", async () => {
+    // Reuse must never be able to delete the suite from the night. A run with
+    // nothing to reuse is exactly today's run.
+    const result = await runBuildStep(script, {
+      reuse: true,
+      fingerprint: "hit",
+      download: "miss",
+      list: "miss",
+    });
+    expect(result.status).toBe(0);
+    expect(ran(result.invocations, BUILD_SUBCOMMAND)).toBe(true);
+    expect(result.staged).toContain(ANDROID_ARTIFACT);
+  });
+
+  it("ON with the fingerprint UNCOMPUTABLE: warns and degrades to a fresh build", async () => {
+    const result = await runBuildStep(script, {
+      reuse: true,
+      fingerprint: "fail",
+      list: "miss",
+    });
+    expect(result.status).toBe(0);
+    expect(result.output).toContain(
+      "::warning title=EAS fingerprint unavailable::"
+    );
+    expect(ran(result.invocations, BUILD_SUBCOMMAND)).toBe(true);
+  });
+
+  it("ON with an EMPTY fingerprint hash: treated as unavailable, not as a hit", async () => {
+    const result = await runBuildStep(script, {
+      reuse: true,
+      fingerprint: "empty",
+      list: "miss",
+    });
+    expect(result.status).toBe(0);
+    expect(ran(result.invocations, DOWNLOAD_SUBCOMMAND)).toBe(false);
+    expect(ran(result.invocations, BUILD_SUBCOMMAND)).toBe(true);
+  });
+
+  it("iOS reuse of an extracted .app DIRECTORY produces the tarball the suite installs", async () => {
+    // `eas build:download` hands back a directory for a simulator build; the
+    // iOS job downstream expects a tarball and nothing else.
+    const result = await runBuildStep(script, {
+      platform: "ios",
+      reuse: true,
+      fingerprint: "hit",
+      download: "hit",
+      artifactIsDir: true,
+    });
+    expect(result.status).toBe(0);
+    expect(result.staged).toEqual([IOS_ARTIFACT]);
+    expect(ran(result.invocations, BUILD_SUBCOMMAND)).toBe(false);
+  });
+
+  it("iOS build:list asks for a SIMULATOR build — a device archive installs nowhere", async () => {
+    const result = await runBuildStep(script, {
+      platform: "ios",
+      reuse: true,
+      fingerprint: "hit",
+      download: "miss",
+      list: "hit",
+      buildIdDownload: "hit",
+    });
+    const listCall = result.invocations.find(line =>
+      line.startsWith(LIST_SUBCOMMAND)
+    );
+    expect(listCall).toContain("--simulator");
+  });
+});

--- a/tests/integration/maestro-checkout-credentials.test.ts
+++ b/tests/integration/maestro-checkout-credentials.test.ts
@@ -1,0 +1,126 @@
+/**
+ * `actions/checkout` writes an unscoped git credential into `.git/config`
+ * unless told not to. Every later step in that job can read it — including
+ * third-party actions, the caller-supplied `pre_suite_command`, and anything
+ * Maestro executes — and use it to push as the workflow.
+ *
+ * No job in this workflow pushes. It builds with EAS, boots a device, and runs
+ * flows. So the credential is pure blast radius, and the fix is one line per
+ * checkout.
+ *
+ * The check is written as a pure function over the parsed document so it can be
+ * run against a DELIBERATELY BROKEN copy in the same file. A guard observed
+ * only passing has not been shown to work; the second test mutates each
+ * checkout in turn and requires the guard to name that exact job.
+ */
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/** Shape of a single step inside a workflow job's `steps:` list. */
+interface WorkflowStep {
+  name?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+}
+
+/** Root shape of the parsed reusable workflow. */
+interface Workflow {
+  jobs: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+/** The action every checkout step in this workflow uses. */
+const CHECKOUT_ACTION = "actions/checkout";
+
+/** The `with:` key that stops the checkout writing a token into .git/config. */
+const PERSIST_CREDENTIALS = "persist-credentials";
+
+/**
+ * Every checkout in the workflow that would leave a git credential behind.
+ *
+ * Enumerated from the parsed document rather than checked against a count, so a
+ * checkout added to a NEW job in future is covered the day it lands — a guard
+ * pinned to "five checkouts" passes the moment a sixth appears.
+ * @param doc - The parsed workflow to inspect
+ * @returns `job/step-name` for each offending checkout
+ */
+const credentialLeaks = (doc: Workflow): string[] => {
+  const leaks: string[] = [];
+  for (const [jobName, job] of Object.entries(doc.jobs)) {
+    for (const step of job.steps ?? []) {
+      if (!String(step.uses ?? "").startsWith(CHECKOUT_ACTION)) {
+        continue;
+      }
+      if (step.with?.[PERSIST_CREDENTIALS] !== false) {
+        leaks.push(`${jobName}/${step.name ?? step.uses}`);
+      }
+    }
+  }
+  return leaks;
+};
+
+/**
+ * Every checkout step in the workflow, with the job that owns it.
+ * @param doc - The parsed workflow to inspect
+ * @returns Pairs of job name and checkout step
+ */
+const checkoutSteps = (doc: Workflow): Array<[string, WorkflowStep]> => {
+  const found: Array<[string, WorkflowStep]> = [];
+  for (const [jobName, job] of Object.entries(doc.jobs)) {
+    for (const step of job.steps ?? []) {
+      if (String(step.uses ?? "").startsWith(CHECKOUT_ACTION)) {
+        found.push([jobName, step]);
+      }
+    }
+  }
+  return found;
+};
+
+describe("maestro-native-e2e checkout credentials", () => {
+  let workflow: Workflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(await fs.readFile(REUSABLE_YML, "utf-8")) as Workflow;
+  });
+
+  it("leaves no git credential in .git/config in ANY job", () => {
+    expect(credentialLeaks(workflow)).toEqual([]);
+  });
+
+  it("covers every checkout the workflow has, not a remembered subset", () => {
+    // Guards decay into stale proxies when they encode which values existed at
+    // the time they were written. This one asserts only that checkouts EXIST to
+    // be covered; the coverage itself comes from the enumeration above.
+    expect(checkoutSteps(workflow).length).toBeGreaterThan(0);
+  });
+
+  it("BITE: the check fails when any single checkout drops the setting", () => {
+    for (const [jobName, step] of checkoutSteps(workflow)) {
+      const mutated = yaml.load(yaml.dump(workflow)) as Workflow;
+      const victim = (mutated.jobs[jobName].steps ?? []).find(
+        candidate =>
+          String(candidate.uses ?? "").startsWith(CHECKOUT_ACTION) &&
+          candidate.name === step.name
+      );
+      if (victim?.with) {
+        delete victim.with[PERSIST_CREDENTIALS];
+      }
+      expect(
+        credentialLeaks(mutated),
+        `dropping persist-credentials in ${jobName} went undetected`
+      ).toContain(`${jobName}/${step.name ?? step.uses}`);
+    }
+  });
+});

--- a/tests/integration/maestro-eas-quota-diagnosis.test.ts
+++ b/tests/integration/maestro-eas-quota-diagnosis.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Behavioral tests for `diagnose_eas_quota_exhaustion` — these EXECUTE the
+ * workflow's own shell against a stubbed `eas` CLI that fails the way Expo
+ * fails when a Free-plan account has spent its monthly iOS builds.
+ *
+ * A detector asserted only to fire has not been shown to discriminate. The
+ * three cases that matter here are the ones where it must STAY QUIET: with the
+ * input off, on an ordinary build failure, and on a build that succeeded. A
+ * quota banner on a Gradle failure sends the operator to Expo's billing page
+ * for a code bug, which is a worse outcome than the generic error this
+ * replaces.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  buildStepScript,
+  loadReusable,
+  runBuildStep,
+} from "./support/maestro-build-step-harness";
+import type { BuildMode } from "./support/maestro-build-step-harness";
+
+/** The annotation the diagnosis emits, and the only string worth matching. */
+const QUOTA_BANNER = "::error title=EAS build quota exhausted::";
+
+describe("maestro-native-e2e Free-plan quota diagnosis (executed)", () => {
+  let script: string;
+
+  beforeAll(async () => {
+    script = buildStepScript(await loadReusable());
+  });
+
+  /**
+   * Runs the build step through an `eas build` of the given flavour, with reuse
+   * off so the fresh-build path is always the one exercised.
+   * @param diagnose - Whether the caller opted into the diagnosis
+   * @param build - Which outcome the stubbed `eas build` should produce
+   * @returns The step's exit status and combined output
+   */
+  const buildWith = async (
+    diagnose: boolean,
+    build: BuildMode
+  ): Promise<{ status: number; output: string }> => {
+    const result = await runBuildStep(script, {
+      platform: "ios",
+      reuse: false,
+      diagnose,
+      build,
+    });
+    return { status: result.status, output: result.output };
+  };
+
+  it("ON: names the quota AND the remedy on a Free-plan refusal", async () => {
+    const result = await buildWith(true, "quota");
+    expect(result.status).not.toBe(0);
+    expect(result.output).toContain(QUOTA_BANNER);
+    expect(result.output).toContain("reuse_build_by_fingerprint");
+    // The raw EAS stderr is an ADDITION to the operator's evidence, never a
+    // replacement for it — buffering it must not swallow it.
+    expect(result.output).toContain("used its iOS builds from the Free plan");
+  });
+
+  it("OFF: the same refusal reds with NO diagnosis — the input is load-bearing", async () => {
+    // The discrimination. Without this case an always-on annotation would pass
+    // the test above and the input would be inert.
+    const result = await buildWith(false, "quota");
+    expect(result.status).not.toBe(0);
+    expect(result.output).not.toContain(QUOTA_BANNER);
+  });
+
+  it("ON: an ORDINARY build failure gets no quota diagnosis", async () => {
+    const result = await buildWith(true, "error");
+    expect(result.status).not.toBe(0);
+    expect(result.output).not.toContain(QUOTA_BANNER);
+    expect(result.output).toContain("Gradle build failed");
+  });
+
+  it("ON: a SUCCEEDING build is untouched", async () => {
+    const result = await buildWith(true, "ok");
+    expect(result.status).toBe(0);
+    expect(result.output).not.toContain(QUOTA_BANNER);
+  });
+});

--- a/tests/integration/maestro-flow-app-id-lint.test.ts
+++ b/tests/integration/maestro-flow-app-id-lint.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Behavioral tests for the preflight per-flow `appId` lint — these EXECUTE the
+ * workflow's own shell, pulled verbatim out of the YAML, against fixture flow
+ * trees on disk.
+ *
+ * The lint exists because its failure mode is silent. The app id reaches flows
+ * as `-e MAESTRO_APP_ID=…`, so a flow naming `${APP_ID}` interpolates to an
+ * EMPTY app id and Maestro reports a launch failure that names no cause — a
+ * red suite that reads as a broken app and is a one-line config error, found
+ * only after an EAS build and an emulator boot have been paid for.
+ *
+ * So the load-bearing case here is the FAILING one: a lint asserted only to
+ * pass a healthy tree has never been shown to catch anything. Every check
+ * below is paired — the clean tree must pass AND the specific defect must fail
+ * by name.
+ */
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/** `bash` by absolute path — never resolved through a writeable $PATH. */
+const BASH = "/bin/bash";
+
+/** Shape of a single step inside a workflow job's `steps:` list. */
+interface WorkflowStep {
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  if?: string;
+  env?: Record<string, unknown>;
+}
+
+/** Root shape of the parsed reusable workflow. */
+interface ReusableWorkflow {
+  on: {
+    workflow_call?: {
+      inputs?: Record<string, { default?: unknown; type?: string }>;
+    };
+  };
+  jobs: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+/** A flow file to write into the fixture tree, keyed by repo-relative path. */
+type FlowTree = Record<string, string>;
+
+/** A flow that declares the app id correctly. */
+const GOOD_FLOW = `appId: \${MAESTRO_APP_ID}
+---
+- launchApp
+- assertVisible: "Home"
+`;
+
+/** A flow naming the variable the workflow does NOT forward. */
+const WRONG_VARIABLE_FLOW = `appId: \${APP_ID}
+---
+- launchApp
+`;
+
+/**
+ * A leftover debug artifact under the Maestro root that WOULD match the
+ * ${APP_ID} scan if the scan read it. Deliberately plain ASCII with no
+ * padding: pad it with spaces and a formatter can rewrite them, pad it with
+ * NUL and grep binary-suppresses the file — either way the fixture would
+ * stop proving that `--include` is what excludes it.
+ */
+const DEBUG_ARTIFACT = `appId: \${APP_ID}\n`;
+
+/** A flow with no appId at all — a subflow shape, in the wrong place. */
+const NO_APP_ID_FLOW = `---
+- tapOn: "Continue"
+`;
+
+describe("maestro-native-e2e per-flow appId lint (executed)", () => {
+  let workflow: ReusableWorkflow;
+  let lintScript: string;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as ReusableWorkflow;
+    const step = (workflow.jobs.preflight.steps ?? []).find(candidate =>
+      candidate.name?.includes("Lint per-flow appId")
+    );
+    if (!step?.run) {
+      throw new Error("no `Lint per-flow appId` step in the preflight job");
+    }
+    lintScript = step.run;
+  });
+
+  /**
+   * Runs the real lint against a fixture tree.
+   * @param tree - Files to create, keyed by path relative to the fixture root
+   * @param flowsDir - The `flows_dir` input the caller passed
+   * @returns The lint's exit status and combined output
+   */
+  const lint = async (
+    tree: FlowTree,
+    flowsDir = ".maestro/flows"
+  ): Promise<{ status: number; output: string }> => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "maestro-appid-"));
+    try {
+      for (const [relative, contents] of Object.entries(tree)) {
+        const target = path.join(dir, relative);
+        await fs.ensureDir(path.dirname(target));
+        await fs.writeFile(target, contents);
+      }
+      try {
+        const stdout = execFileSync(BASH, ["-c", lintScript], {
+          cwd: dir,
+          env: { ...process.env, FLOWS_DIR: flowsDir },
+          encoding: "utf-8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        return { status: 0, output: stdout };
+      } catch (error) {
+        const failure = error as {
+          status?: number;
+          stdout?: string;
+          stderr?: string;
+        };
+        return {
+          status: failure.status ?? -1,
+          output: `${failure.stdout ?? ""}${failure.stderr ?? ""}`,
+        };
+      }
+    } finally {
+      await fs.remove(dir);
+    }
+  };
+
+  it("PASSES a tree where every flow declares appId: ${MAESTRO_APP_ID}", async () => {
+    const result = await lint({
+      ".maestro/flows/sign-in.yaml": GOOD_FLOW,
+      ".maestro/flows/browse.yml": GOOD_FLOW,
+    });
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("every flow under '.maestro/flows'");
+  });
+
+  it("FAILS a flow that omits appId, and names the file", async () => {
+    // The load-bearing case. Without this the lint could be a no-op and every
+    // other assertion here would still pass.
+    const result = await lint({
+      ".maestro/flows/sign-in.yaml": GOOD_FLOW,
+      ".maestro/flows/browse.yaml": NO_APP_ID_FLOW,
+    });
+    expect(result.status).toBe(1);
+    expect(result.output).toContain(
+      "::error title=Maestro flow declares no appId::"
+    );
+    expect(result.output).toContain(".maestro/flows/browse.yaml");
+    // Naming the innocent file would send the reader to the wrong place.
+    expect(result.output).not.toContain("flows/sign-in.yaml");
+  });
+
+  it("FAILS a flow naming ${APP_ID}, the variable this workflow does not forward", async () => {
+    const result = await lint({
+      ".maestro/flows/sign-in.yaml": WRONG_VARIABLE_FLOW,
+    });
+    expect(result.status).toBe(1);
+    expect(result.output).toContain(
+      "::error title=Maestro flow uses the wrong app id variable::"
+    );
+    expect(result.output).toContain("interpolates to EMPTY");
+    expect(result.output).toContain(".maestro/flows/sign-in.yaml");
+  });
+
+  it("FAILS a shared SUBFLOW outside the flows directory — the drift that started this", async () => {
+    // The measured shape: every flow declared MAESTRO_APP_ID while the shared
+    // subflow beside them still said APP_ID. A lint scanning only the flows
+    // directory passes that tree and the suite still dies on launch, which is
+    // why the ${APP_ID} scan covers the Maestro ROOT.
+    const result = await lint({
+      ".maestro/flows/sign-in.yaml": GOOD_FLOW,
+      ".maestro/shared/open-app.yaml": WRONG_VARIABLE_FLOW,
+    });
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("wrong app id variable");
+    expect(result.output).toContain(".maestro/shared/open-app.yaml");
+  });
+
+  it("does not read debug artifacts left under the Maestro root", async () => {
+    // grep reports ZERO matches in a file it decides is binary, so an
+    // unfiltered recursive scan can pass by refusing to read. The `--include`
+    // filters keep the scan to files that are actually flows — proven here by
+    // a fixture that would otherwise match.
+    const result = await lint({
+      ".maestro/flows/sign-in.yaml": GOOD_FLOW,
+      ".maestro/screenshot.png": DEBUG_ARTIFACT,
+    });
+    expect(result.status).toBe(0);
+  });
+
+  it("handles a flows_dir with no parent path component", async () => {
+    // `dirname flows` is `.`, and scanning the repo ROOT for ${APP_ID} would
+    // walk node_modules. The step falls back to the flows directory itself.
+    const clean = await lint({ "flows/sign-in.yaml": GOOD_FLOW }, "flows");
+    expect(clean.status).toBe(0);
+
+    const dirty = await lint(
+      { "flows/sign-in.yaml": WRONG_VARIABLE_FLOW },
+      "flows"
+    );
+    expect(dirty.status).toBe(1);
+    expect(dirty.output).toContain("wrong app id variable");
+  });
+
+  it("tolerates leading whitespace and both file extensions", async () => {
+    const result = await lint({
+      ".maestro/flows/a.yaml": `  appId: \${MAESTRO_APP_ID}\n---\n- launchApp\n`,
+      ".maestro/flows/b.yml": GOOD_FLOW,
+    });
+    expect(result.status).toBe(0);
+  });
+});
+
+describe("maestro-native-e2e per-flow appId lint contract", () => {
+  let workflow: ReusableWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as ReusableWorkflow;
+  });
+
+  it("is OFF by default — four repositories consume this reusable", () => {
+    const inputs = workflow.on.workflow_call?.inputs ?? {};
+    expect(inputs.lint_flow_app_id?.default).toBe(false);
+    expect(inputs.lint_flow_app_id?.type).toBe("boolean");
+  });
+
+  it("runs only when opted in AND the prerequisites held", () => {
+    const step = (workflow.jobs.preflight.steps ?? []).find(candidate =>
+      candidate.name?.includes("Lint per-flow appId")
+    );
+    // The second clause matters: an unwired adopter has no flows directory,
+    // and failing there would convert warn-and-skip into a red for reasons
+    // that belong to `require_prerequisites` rather than to this lint.
+    expect(step?.if).toBe(
+      "${{ inputs.lint_flow_app_id && steps.check.outputs.should_run == 'true' }}"
+    );
+    // Caller-supplied, so it travels through `env:` — a `${{ }}` expansion
+    // inside the script body would make `flows_dir` workflow SOURCE.
+    expect(step?.env?.FLOWS_DIR).toBe("${{ inputs.flows_dir }}");
+    expect(step?.run).not.toContain("${{ inputs.flows_dir }}");
+  });
+
+  it("keeps the two build-reuse inputs off by default too", () => {
+    const inputs = workflow.on.workflow_call?.inputs ?? {};
+    expect(inputs.reuse_build_by_fingerprint?.default).toBe(false);
+    expect(inputs.reuse_build_by_fingerprint?.type).toBe("boolean");
+    expect(inputs.diagnose_eas_quota_exhaustion?.default).toBe(false);
+    expect(inputs.diagnose_eas_quota_exhaustion?.type).toBe("boolean");
+  });
+});

--- a/tests/integration/maestro-native-workflow.test.ts
+++ b/tests/integration/maestro-native-workflow.test.ts
@@ -171,7 +171,15 @@ describe("maestro-native-e2e reusable workflow", () => {
     const easStep = (build.steps ?? []).find(step =>
       step.run?.includes("eas build")
     );
-    expect(easStep?.run).toContain("--profile ${{ inputs.eas_profile }}");
+    // The profile still reaches `eas build`, but through `env:` rather than a
+    // `${{ }}` expansion in the script body. An expansion is substituted into
+    // the script TEXT before bash parses it, which makes a caller-supplied
+    // profile workflow SOURCE rather than an argument — the same rule the
+    // profile guard and the flows-dir handling in this file already follow.
+    expect(easStep?.env?.EAS_PROFILE).toBe("${{ inputs.eas_profile }}");
+    expect(easStep?.env?.EAS_PLATFORM).toBe("${{ matrix.platform }}");
+    expect(easStep?.run).toContain('--profile "$profile"');
+    expect(easStep?.run).not.toContain("${{ inputs.eas_profile }}");
     expect(easStep?.run).toContain("--non-interactive");
     // The iOS simulator artifact is a tarball, not an .ipa.
     expect(easStep?.run).toContain("app-ios.tar.gz");

--- a/tests/integration/support/maestro-build-step-harness.ts
+++ b/tests/integration/support/maestro-build-step-harness.ts
@@ -1,0 +1,315 @@
+/**
+ * Harness that EXECUTES the reusable workflow's EAS build step, pulled verbatim
+ * out of the YAML, against a stubbed `eas` CLI.
+ *
+ * The stub exists so the assertions can read which EAS subcommands actually
+ * ran. That is the only way to prove `reuse_build_by_fingerprint` does its job:
+ * the feature is not "a fingerprint was computed", it is "`eas build` was NOT
+ * invoked" — which on Expo's Free plan is the difference between a suite that
+ * runs and a suite that has no quota left to run with.
+ *
+ * Shared by maestro-build-reuse.test.ts and maestro-eas-quota-diagnosis.test.ts
+ * so the two read the same step through the same seam.
+ */
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+/** The reusable workflow under test. */
+export const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/** `bash` by absolute path — never resolved through a writeable $PATH. */
+const BASH = "/bin/bash";
+
+/** The Android artifact the build job must leave behind. */
+export const ANDROID_ARTIFACT = "app-android.apk";
+
+/** The iOS artifact the build job must leave behind. */
+export const IOS_ARTIFACT = "app-ios.tar.gz";
+
+/** The `eas` subcommand whose ABSENCE is the point of build reuse. */
+export const BUILD_SUBCOMMAND = "build";
+
+/** The `eas` subcommand that computes the reuse key. */
+export const FINGERPRINT_SUBCOMMAND = "fingerprint:generate";
+
+/** The `eas` subcommand that fetches a finished binary. */
+export const DOWNLOAD_SUBCOMMAND = "build:download";
+
+/** The `eas` subcommand behind the weaker latest-finished-build fallback. */
+export const LIST_SUBCOMMAND = "build:list";
+
+/** Shape of a single step inside a workflow job's `steps:` list. */
+export interface WorkflowStep {
+  id?: string;
+  name?: string;
+  run?: string;
+  uses?: string;
+  if?: string;
+  env?: Record<string, unknown>;
+  with?: Record<string, unknown>;
+}
+
+/** Root shape of the parsed reusable workflow. */
+export interface ReusableWorkflow {
+  on: {
+    workflow_call?: {
+      inputs?: Record<string, { default?: unknown; type?: string }>;
+    };
+  };
+  jobs: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+/** How the stubbed `eas fingerprint:generate` should behave. */
+export type FingerprintMode = "hit" | "fail" | "empty";
+
+/** How a stubbed `eas build:download` should behave. */
+export type DownloadMode = "hit" | "miss";
+
+/** How the stubbed `eas build:list` should behave. */
+export type ListMode = "hit" | "miss";
+
+/** How the stubbed `eas build` should behave. */
+export type BuildMode = "ok" | "quota" | "error";
+
+/** One execution of the build step, plus what the stub observed. */
+export interface StepRun {
+  status: number;
+  output: string;
+  /** Every `eas` argv the step invoked, in order. */
+  invocations: string[];
+  /** `app-*` files staged in the working directory afterwards. */
+  staged: string[];
+}
+
+/** Which inputs the caller passed and how the stubbed EAS should behave. */
+export interface BuildStepOptions {
+  /** Which matrix arm to execute. */
+  platform?: "android" | "ios";
+  /** The `reuse_build_by_fingerprint` input. */
+  reuse?: boolean;
+  /** The `diagnose_eas_quota_exhaustion` input. */
+  diagnose?: boolean;
+  /** How `eas fingerprint:generate` should behave. */
+  fingerprint?: FingerprintMode;
+  /** How `eas build:download --fingerprint` should behave. */
+  download?: DownloadMode;
+  /** How `eas build:list` should behave. */
+  list?: ListMode;
+  /** How `eas build:download --build-id` should behave. */
+  buildIdDownload?: DownloadMode;
+  /** How `eas build` should behave. */
+  build?: BuildMode;
+  /** Whether the reusable artifact is an extracted .app DIRECTORY. */
+  artifactIsDir?: boolean;
+}
+
+/**
+ * A stub `eas` whose behaviour is driven entirely by env vars, so one script
+ * covers every branch. It logs every invocation before dispatching — the log is
+ * what the assertions read.
+ */
+const EAS_STUB = `#!/bin/bash
+echo "$*" >> "$STUB_LOG"
+case "$1" in
+  fingerprint:generate)
+    case "$FP_MODE" in
+      hit) echo '{"hash":"fp-abc123"}'; exit 0 ;;
+      empty) echo '{}'; exit 0 ;;
+      *) echo "eas: could not compute a fingerprint" >&2; exit 1 ;;
+    esac
+    ;;
+  build:download)
+    if [[ "$*" == *--fingerprint* ]]; then
+      MODE="$DL_MODE"
+    else
+      MODE="$BUILD_ID_DL_MODE"
+    fi
+    if [[ "$MODE" == "hit" ]]; then
+      if [[ "$STUB_ARTIFACT_IS_DIR" == "true" ]]; then
+        mkdir -p "$STUB_ARTIFACT"
+        echo "binary" > "$STUB_ARTIFACT/Payload"
+      else
+        echo "binary" > "$STUB_ARTIFACT"
+      fi
+      echo "{\\"path\\":\\"$STUB_ARTIFACT\\"}"
+      exit 0
+    fi
+    echo "eas: no matching build to download" >&2
+    exit 1
+    ;;
+  build:list)
+    if [[ "$LIST_MODE" == "hit" ]]; then
+      echo '[{"id":"build-id-777"}]'
+      exit 0
+    fi
+    echo '[]'
+    exit 0
+    ;;
+  build)
+    case "$BUILD_MODE" in
+      quota)
+        echo "Your account has used its iOS builds from the Free plan for this month." >&2
+        exit 1
+        ;;
+      error)
+        echo "Gradle build failed with exit code 1" >&2
+        exit 1
+        ;;
+      *)
+        echo '[{"artifacts":{"buildUrl":"https://example.invalid/app"}}]'
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+exit 0
+`;
+
+/** A stub `curl` that writes the requested output file without any network. */
+const CURL_STUB = `#!/bin/bash
+out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -o) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[[ -n "$out" ]] && echo "downloaded" > "$out"
+exit 0
+`;
+
+/**
+ * Parses the reusable workflow from disk.
+ * @returns The parsed workflow document
+ */
+export const loadReusable = async (): Promise<ReusableWorkflow> =>
+  yaml.load(await fs.readFile(REUSABLE_YML, "utf-8")) as ReusableWorkflow;
+
+/**
+ * The verbatim `run:` text of the EAS build step — never a copy of it.
+ * @param workflow - The parsed reusable workflow
+ * @returns The build step's shell script exactly as CI will run it
+ */
+export const buildStepScript = (workflow: ReusableWorkflow): string => {
+  const step = (workflow.jobs.build.steps ?? []).find(candidate =>
+    candidate.name?.includes("Build with EAS")
+  );
+  if (!step?.run) {
+    throw new Error("no `Build with EAS` step in the build job");
+  }
+  return step.run;
+};
+
+/**
+ * Runs a script under bash, folding a non-zero exit into a value rather than a
+ * throw — a failing build IS an outcome under test here, not an error.
+ * @param script - The shell to execute
+ * @param cwd - Working directory for the run
+ * @param env - Environment for the run
+ * @returns The exit status and the combined stdout/stderr
+ */
+const execute = (
+  script: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv
+): { status: number; output: string } => {
+  try {
+    return {
+      status: 0,
+      output: execFileSync(BASH, ["-c", script], {
+        cwd,
+        env,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
+    };
+  } catch (error) {
+    const failure = error as {
+      status?: number;
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      status: failure.status ?? -1,
+      output: `${failure.stdout ?? ""}${failure.stderr ?? ""}`,
+    };
+  }
+};
+
+/**
+ * Runs the real build step against the stubbed CLI.
+ * @param script - The build step's shell, from {@link buildStepScript}
+ * @param options - Which inputs the caller passed and how EAS should behave
+ * @returns The step's exit status, output, EAS invocations, and staged files
+ */
+export const runBuildStep = async (
+  script: string,
+  options: BuildStepOptions = {}
+): Promise<StepRun> => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "maestro-build-"));
+  try {
+    const stubs = path.join(dir, "stubs");
+    await fs.ensureDir(stubs);
+    await fs.writeFile(path.join(stubs, "eas"), EAS_STUB, { mode: 0o755 });
+    await fs.writeFile(path.join(stubs, "curl"), CURL_STUB, { mode: 0o755 });
+
+    const log = path.join(dir, "eas-invocations.log");
+    await fs.writeFile(log, "");
+
+    const env = {
+      ...process.env,
+      PATH: `${stubs}${path.delimiter}${process.env.PATH ?? ""}`,
+      STUB_LOG: log,
+      STUB_ARTIFACT: path.join(
+        dir,
+        options.artifactIsDir === true ? "Reused.app" : "reused-artifact.bin"
+      ),
+      STUB_ARTIFACT_IS_DIR: String(options.artifactIsDir === true),
+      FP_MODE: options.fingerprint ?? "hit",
+      DL_MODE: options.download ?? "hit",
+      LIST_MODE: options.list ?? "miss",
+      BUILD_ID_DL_MODE: options.buildIdDownload ?? "hit",
+      BUILD_MODE: options.build ?? "ok",
+      EAS_PLATFORM: options.platform ?? "android",
+      EAS_PROFILE: "dev-e2e",
+      REUSE_BY_FINGERPRINT: String(options.reuse === true),
+      DIAGNOSE_QUOTA: String(options.diagnose === true),
+    };
+
+    const outcome = execute(script, dir, env);
+
+    const invocations = (await fs.readFile(log, "utf-8"))
+      .split("\n")
+      .filter(Boolean);
+    const staged = (await fs.readdir(dir)).filter(name =>
+      name.startsWith("app-")
+    );
+    return { ...outcome, invocations, staged };
+  } finally {
+    await fs.remove(dir);
+  }
+};
+
+/**
+ * Whether any logged EAS invocation started with the given subcommand.
+ * @param invocations - The stub's invocation log
+ * @param subcommand - The `eas` subcommand to look for
+ * @returns True when that subcommand ran at least once
+ */
+export const ran = (invocations: string[], subcommand: string): boolean =>
+  invocations.some(
+    line => line === subcommand || line.startsWith(`${subcommand} `)
+  );


### PR DESCRIPTION
## Why

`gunnertech/frontend` runs a **fully vendored copy** of `maestro-native-e2e.yml`
("Vendored from CodySwannGT/lisa with one change"). Four capabilities it has
cannot be expressed through Lisa's reusable, so retiring that fork today would
delete working functionality — which is what blocks the portfolio converging on
Lisa.

This PR adds all four. It touches only `.github/workflows/maestro-native-e2e.yml`
and the expo caller template; the nightly-gate workflows and the guard script
belong to other work on this issue and are untouched.

## What landed

| # | Capability | Input | Default |
|---|---|---|---|
| 1 | EAS fingerprint build reuse | `reuse_build_by_fingerprint` | `false` |
| 2 | Free-plan quota diagnosis | `diagnose_eas_quota_exhaustion` | `false` |
| 3 | `persist-credentials: false` on every checkout | *(none — security fix)* | always on |
| 4 | Per-flow `appId` lint in preflight | `lint_flow_app_id` | `false` |

**Every new behaviour defaults to today's behaviour.** Four repos consume this
reusable; a default change is a portfolio-wide incident. No existing input or
job name changed — consumers pin them.

### 1. `reuse_build_by_fingerprint` — the blocking one

`eas fingerprint:generate` → `eas build:download --fingerprint`; on a miss,
`eas build:list --status finished` → `eas build:download --build-id`; build
fresh only when both miss. Lisa's reusable previously had **zero** matches for
`fingerprint` or `build:download` — it always built.

Without reuse the suite **cannot run at all** on Expo's Free plan: the monthly
quota is not a slowdown, it is the reason there is nothing to test with. That is
why the consumer forked.

Every arm degrades to a fresh build rather than failing — a broken CLI, an
uncomputable fingerprint, an empty hash, a 404 download, both lookups missing.
Reuse must never be able to delete the suite from the night.

**Deliberately NOT ported from the fork:** their `gh run download` arm (reuses a
GitHub Actions artifact from a green `main` run) hardcodes a workflow filename
and branch and needs a `GH_TOKEN`; and their hard `exit 1` when no iOS binary is
available encodes a project-specific plan decision. Both are project policy, not
reusable behaviour. Their fresh-build path also `curl`s to `app-android.apk`
unconditionally — this keeps Lisa's correct per-platform staging.

### 2. `diagnose_eas_quota_exhaustion`

Scans a failed build's stderr for `used its iOS builds from the Free plan` and
re-emits it as an `::error::` naming the remedy (reuse → upgrade → wait for the
reset). Opt-in because detecting it means buffering the build's stderr to a file
rather than streaming it live on a `--wait` build that can run for the better
part of an hour. The buffered stderr is replayed in full before the step exits.

The diagnosis **discriminates**: an ordinary Gradle failure gets no quota
banner. A quota banner on a code bug sends the operator to Expo's billing page.

### 3. `persist-credentials: false` — measured 1/5 here vs 5/5 in the fork

A straight security fix where the fork was better than Lisa, so it ships with no
input. The default writes an unscoped token into `.git/config` where every
subsequent step can read it and push as the workflow — including third-party
actions, the caller-supplied `pre_suite_command`, and anything Maestro executes.
No job here pushes; each checkout carries a comment saying so.

**Also in this PR:** `eas_profile` and `matrix.platform` move out of `${{ }}`
expansions in the build script body and into `env:`. An expansion is substituted
into the script TEXT before bash parses it, so a caller-supplied profile was
workflow SOURCE rather than an argument — the same rule the EAS profile guard
and the flows-dir handling already follow. This required updating one assertion
in `maestro-native-workflow.test.ts`, which had encoded the inline form.

### 4. `lint_flow_app_id`

Fails preflight when a flow would launch an **empty** app id: a file naming
`${APP_ID}` (which this workflow does not forward) or declaring no `appId:` at
all. Maestro reports that as a launch failure naming no cause, discovered only
after an EAS build and an emulator boot have been paid for.

Two deliberate choices, both proven by a test:

- The `${APP_ID}` scan covers the **Maestro root** (`dirname` of the flows dir),
  not just the flows directory. The drift this catches is a shared subflow
  disagreeing with the flows beside it — and subflows live outside the flows
  directory by convention, so a narrower scan misses the exact file that breaks
  the suite.
- Both scans carry `--include='*.yaml' --include='*.yml'`. `grep` reports **zero
  matches in a file it decides is binary**, so an unfiltered recursive scan over
  a root holding leftover debug screenshots can pass by refusing to read.

Off by default because the "every flow declares appId" half is only correct for
a project whose `runFlow`-included subflows sit outside the flows directory —
`maestro test <dir>` recurses, so anything under it is executed as a flow.

## Bite controls — how each was PROVEN, not observed

Five new suites (25 tests) **execute the workflow's own shell**, pulled verbatim
out of the YAML, against a stubbed `eas`/`curl` on `$PATH`. They assert on
**which EAS subcommands ran**, so a pass and a fail differ in behaviour rather
than in wording — the feature is not "a fingerprint was computed", it is
"`eas build` was NOT invoked".

Each was then proven by **mutating the real workflow** and requiring the suite to
go red. Mutations that fail to apply abort loudly; a silently unapplied mutation
makes a missing bite look like a present one.

| Mutation to `maestro-native-e2e.yml` | Result |
|---|---|
| Reuse path never engages | **5 tests red** |
| Reuse forced ON (default not honored) | **4 red**, incl. `OFF by default` |
| Quota diagnosis forced ON (input inert) | **1 red** — `OFF: …no diagnosis` |
| `persist-credentials` removed from checkout #0…#4, each in turn | **1 red each time (5/5)** |
| Missing-`appId` check neutered | **1 red** |
| Root scan narrowed to the flows dir | **1 red** — the subflow case |
| `--include` dropped from the root scan | **1 red** — the debug-artifact case |

The credentials guard additionally carries an in-file `BITE:` test that mutates
every checkout in a parsed copy, so it stays honest as jobs are added. It
enumerates checkouts from the document rather than asserting a count — a guard
pinned to "five checkouts" passes the moment a sixth appears.

## Verified vs inferred

**Verified locally:** all 40 integration suites (785 tests) green; the full
`test:cov` suite (13,356 tests) green; `lint`, `typecheck`, and the 9-gate
pre-push all pass; the workflow and the caller template both parse; the three new
inputs are `boolean` with default `false`; all 5 checkouts carry
`persist-credentials: false`; every bite mutation above reds its named case.

**Inferred, not verified:** the stubbed `eas` reproduces the CLI's argument and
JSON shapes from the consumer's working fork, not from a live EAS account — no
real EAS build, download, or fingerprint was executed here. The first live proof
will be gunnertech/frontend's first run with `reuse_build_by_fingerprint: true`.

**One judgement call flagged for the owner:** #2 is gated by an input purely to
honour the "every new behaviour is opt-in" rule. It only adds an annotation to an
already-failing build, so it is arguably safe on by default; say the word and the
default flips.

Work-Item: CodySwannGT/lisa#2704

🤖 Generated with Claude Code
