### PR TITLE
fix(ci): fail closed when the security floor-collision script is absent

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3954,6 +3954,17 @@ jobs:
         run: |
           set -o pipefail
           script=scripts/lisa-floor-collisions.mjs
+          upstream=all/copy-overwrite/scripts/lisa-floor-collisions.mjs
+          # Lisa's own repository ships this script as a template and does not
+          # keep a second copy of it under scripts/ — only 2 of the 11
+          # copy-overwrite scripts are mirrored there, and a mirror is a
+          # surface that drifts out of band from the thing it mirrors. So the
+          # upstream path is a legitimate second place to find the SAME file,
+          # not a bypass: when neither exists the job still fails below.
+          if [ ! -f "$script" ] && [ -f "$upstream" ]; then
+            echo "Using the in-repo template at $upstream; no installed copy under scripts/."
+            script="$upstream"
+          fi
           if [ ! -f "$script" ]; then
             echo "::error title=Floor-collision gate missing::$script does not exist, so no security floor was examined. The gate's absence is a FAILURE, never a skip — a security check that passes because it found nothing is worse than no check. Run 'lisa apply' to install the Lisa-managed script, or add 'floor_collisions' to skip_jobs to decline the gate deliberately, which at least records the decision in the caller."
             exit 1

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3930,6 +3930,13 @@ jobs:
     # about the manifest, not a question about the advisory database, so it
     # cannot go quiet when a network call fails. Whether a surviving floor is
     # high enough is the separate job of the advisory check.
+    #
+    # FAILS CLOSED on a missing script, matching the BDD coverage gate above
+    # rather than the `exit 0` this used to carry. A green security check that
+    # examined nothing is the failure mode the whole job exists to catch, and
+    # it is indistinguishable from a real pass at every surface a reader has.
+    # Declining the gate is still possible — it just has to be said out loud,
+    # in the caller's `skip_jobs`, where it is reviewable.
     if: ${{ !contains(format(',{0},', inputs.skip_jobs), ',floor_collisions,') }}
     steps:
       - name: 📥 Checkout repository
@@ -3948,8 +3955,8 @@ jobs:
           set -o pipefail
           script=scripts/lisa-floor-collisions.mjs
           if [ ! -f "$script" ]; then
-            echo "::notice::$script is absent; run 'lisa apply' to install it."
-            exit 0
+            echo "::error title=Floor-collision gate missing::$script does not exist, so no security floor was examined. The gate's absence is a FAILURE, never a skip — a security check that passes because it found nothing is worse than no check. Run 'lisa apply' to install the Lisa-managed script, or add 'floor_collisions' to skip_jobs to decline the gate deliberately, which at least records the decision in the caller."
+            exit 1
           fi
           node "$script" | tee -a "$GITHUB_STEP_SUMMARY"
 

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8683,6 +8683,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/cli-smoke.test.ts": true,
     "tests/integration/environment-facade-gates.test.ts": true,
     "tests/integration/failure-issue-workflows.test.ts": true,
+    "tests/integration/floor-collisions-gate-fail-closed.test.ts": true,
     "tests/integration/gate-config-validity-job.test.ts": true,
     "tests/integration/jest-expo-haste-pruning.test.ts": true,
     "tests/integration/lisa.test.ts": true,

--- a/tests/integration/floor-collisions-gate-fail-closed.test.ts
+++ b/tests/integration/floor-collisions-gate-fail-closed.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Proves the security-floor gate fails CLOSED when its script is absent.
+ *
+ * The step is pulled verbatim out of `quality.yml` and executed, rather than
+ * string-matched, because the property under test is an EXIT CODE. A test that
+ * greps the YAML for `exit 1` passes against a step whose `exit 1` sits on an
+ * unreachable branch — which is the same class of bug as the one being fixed:
+ * something reporting a property it never evaluated.
+ *
+ * The gate's sibling in the same workflow — the BDD coverage gate — already
+ * fails loudly on the identical condition (a Lisa-managed `.mjs` that
+ * `lisa apply` installs being missing). This one used to `exit 0` with a
+ * `::notice::`, so a project without the script got a green SECURITY check
+ * that examined nothing.
+ *
+ * @module tests/integration/floor-collisions-gate-fail-closed
+ */
+
+import * as fs from "fs-extra";
+import { spawnSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { loadWorkflow } from "../helpers/workflow-test-utils.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const QUALITY_YML = path.join(REPO_ROOT, ".github", "workflows", "quality.yml");
+
+/** Filename of the script the gate runs. */
+const GATE_SCRIPT_BASENAME = "lisa-floor-collisions.mjs";
+
+/** The script the gate runs, at the path the gate looks for it. */
+const GATE_SCRIPT_RELATIVE = path.join("scripts", GATE_SCRIPT_BASENAME);
+
+/** Where Lisa ships that script from. */
+const GATE_SCRIPT_SOURCE = path.join(
+  REPO_ROOT,
+  "all",
+  "copy-overwrite",
+  GATE_SCRIPT_RELATIVE
+);
+
+/** `bash` by absolute path — never resolved through a writeable $PATH. */
+const BASH = "/bin/bash";
+
+/** The job whose one substantive step is under test. */
+const JOB_ID = "floor_collisions";
+
+/**
+ * Extracts the gate's `run:` block from the workflow.
+ * @returns The shell source GitHub Actions would execute for that step.
+ */
+function gateStepScript(): string {
+  const workflow = loadWorkflow(QUALITY_YML);
+  const job = workflow.jobs[JOB_ID];
+  const step = (job?.steps ?? []).find(candidate =>
+    candidate.run?.includes(GATE_SCRIPT_BASENAME)
+  );
+  // The block carries no `${{ }}` expressions, so it runs as written. An
+  // absent job and an absent step collapse to the same empty string, which
+  // this asserts on rather than executing.
+  const script = step?.run ?? "";
+
+  expect(
+    script,
+    `quality.yml job '${JOB_ID}' must run ${GATE_SCRIPT_BASENAME}`
+  ).toBeTruthy();
+
+  return script;
+}
+
+describe("🧱 Security Floor Collisions gate", () => {
+  let workdir = "";
+  let summary = "";
+
+  beforeEach(async () => {
+    workdir = await fs.mkdtemp(path.join(os.tmpdir(), "floor-gate-"));
+    summary = path.join(workdir, "step-summary.md");
+    await fs.writeFile(summary, "");
+    await fs.writeJson(path.join(workdir, "package.json"), {
+      name: "fixture",
+      version: "1.0.0",
+    });
+  });
+
+  afterEach(async () => {
+    await fs.remove(workdir);
+  });
+
+  /**
+   * Runs the gate step in the temp workdir.
+   * @returns Exit status and the step's combined output.
+   */
+  function runGate(): { status: number; output: string } {
+    const result = spawnSync(BASH, ["-c", gateStepScript()], {
+      cwd: workdir,
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_STEP_SUMMARY: summary },
+    });
+    return {
+      status: result.status ?? -1,
+      output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+    };
+  }
+
+  it("fails when the Lisa-managed script is absent", () => {
+    // No scripts/ directory at all — a project that has never run `lisa apply`,
+    // or one whose copy was deleted. Reporting green here is a metal detector
+    // reading all-clear while unplugged.
+    const { status, output } = runGate();
+
+    expect(status).not.toBe(0);
+    expect(output).toContain("::error");
+    expect(output).toContain(GATE_SCRIPT_RELATIVE);
+    // The failure must name its own remedy, the way the sibling BDD gate does.
+    expect(output).toContain("lisa apply");
+  });
+
+  it("names skip_jobs as the deliberate way to decline the gate", () => {
+    // Fail-closed is only defensible if declining is possible AND visible in
+    // the caller. A silent `exit 0` was neither.
+    const { output } = runGate();
+
+    expect(output).toContain("floor_collisions");
+    expect(output).toContain("skip_jobs");
+  });
+
+  it("still passes when the script is present and finds no collision", async () => {
+    // Guards the other direction: fail-closed must not redden a project that
+    // has the gate installed and clean.
+    await fs.ensureDir(path.join(workdir, "scripts"));
+    await fs.copy(GATE_SCRIPT_SOURCE, path.join(workdir, GATE_SCRIPT_RELATIVE));
+
+    const { status, output } = runGate();
+
+    expect(status).toBe(0);
+    expect(output).toContain("No override can be collapsed");
+    // `tee -a "$GITHUB_STEP_SUMMARY"` must still reach the job summary.
+    expect(await fs.readFile(summary, "utf8")).toContain("Floor collisions");
+  });
+});

--- a/tests/integration/floor-collisions-gate-fail-closed.test.ts
+++ b/tests/integration/floor-collisions-gate-fail-closed.test.ts
@@ -35,12 +35,14 @@ const GATE_SCRIPT_BASENAME = "lisa-floor-collisions.mjs";
 /** The script the gate runs, at the path the gate looks for it. */
 const GATE_SCRIPT_RELATIVE = path.join("scripts", GATE_SCRIPT_BASENAME);
 
+/** Directory Lisa ships the script from, relative to a repo root. */
+const UPSTREAM_SCRIPT_DIR = path.join("all", "copy-overwrite", "scripts");
+
 /** Where Lisa ships that script from. */
 const GATE_SCRIPT_SOURCE = path.join(
   REPO_ROOT,
-  "all",
-  "copy-overwrite",
-  GATE_SCRIPT_RELATIVE
+  UPSTREAM_SCRIPT_DIR,
+  GATE_SCRIPT_BASENAME
 );
 
 /** `bash` by absolute path — never resolved through a writeable $PATH. */
@@ -106,10 +108,11 @@ describe("🧱 Security Floor Collisions gate", () => {
     };
   }
 
-  it("fails when the Lisa-managed script is absent", () => {
+  it("fails when the script is absent from BOTH resolution paths", () => {
     // No scripts/ directory at all — a project that has never run `lisa apply`,
     // or one whose copy was deleted. Reporting green here is a metal detector
-    // reading all-clear while unplugged.
+    // reading all-clear while unplugged. The upstream template path is absent
+    // too, which is every consumer repo: only Lisa itself ships all/.
     const { status, output } = runGate();
 
     expect(status).not.toBe(0);
@@ -140,5 +143,52 @@ describe("🧱 Security Floor Collisions gate", () => {
     expect(output).toContain("No override can be collapsed");
     // `tee -a "$GITHUB_STEP_SUMMARY"` must still reach the job summary.
     expect(await fs.readFile(summary, "utf8")).toContain("Floor collisions");
+  });
+
+  it("falls back to the in-repo template when no copy is installed", async () => {
+    // Lisa's own repository is this case: it SHIPS the script from
+    // all/copy-overwrite/ and deliberately keeps no second copy under
+    // scripts/ (only 2 of its 11 copy-overwrite scripts are mirrored there).
+    // Without this the fail-closed flip would redden Lisa's own CI forever,
+    // and the obvious way to quiet that — adding a mirrored copy — is the
+    // drift surface the repo already declined to create.
+    await fs.ensureDir(path.join(workdir, UPSTREAM_SCRIPT_DIR));
+    await fs.copy(
+      GATE_SCRIPT_SOURCE,
+      path.join(workdir, UPSTREAM_SCRIPT_DIR, GATE_SCRIPT_BASENAME)
+    );
+    expect(await fs.pathExists(path.join(workdir, GATE_SCRIPT_RELATIVE))).toBe(
+      false
+    );
+
+    const { status, output } = runGate();
+
+    expect(status).toBe(0);
+    expect(output).toContain("No override can be collapsed");
+    // The fallback announces itself; a silent substitution would be the same
+    // unreadable state the ::notice:: created.
+    expect(output).toContain(UPSTREAM_SCRIPT_DIR);
+  });
+
+  it("reports a real collision through the fallback path too", async () => {
+    // The fallback must run the check, not merely resolve a file. A manifest
+    // whose override collapses into a weaker direct range has to come back
+    // non-zero from either resolution path.
+    await fs.ensureDir(path.join(workdir, UPSTREAM_SCRIPT_DIR));
+    await fs.copy(
+      GATE_SCRIPT_SOURCE,
+      path.join(workdir, UPSTREAM_SCRIPT_DIR, GATE_SCRIPT_BASENAME)
+    );
+    await fs.writeJson(path.join(workdir, "package.json"), {
+      name: "fixture",
+      version: "1.0.0",
+      dependencies: { postcss: "^8.5.0" },
+      overrides: { postcss: ">=8.5.18" },
+    });
+
+    const { status, output } = runGate();
+
+    expect(status).not.toBe(0);
+    expect(output).toContain("postcss");
   });
 });


### PR DESCRIPTION
## What

Makes the `🧱 Security Floor Collisions` gate in `.github/workflows/quality.yml` **fail closed** when `scripts/lisa-floor-collisions.mjs` is absent.

Before, it exited 0 with a `::notice::`. A project without the script got a green **security** check that examined nothing — indistinguishable, at every surface a reader has, from a check that ran and found the manifest clean.

## Why this shape

The BDD coverage gate in the same file meets the identical condition — a Lisa-managed `.mjs` that `lisa apply` installs being missing — and fails loudly, calling the absence "a FAILURE, never a skip". Same situation, opposite answer, and the one that shrugged was the security one. This adopts the sibling's shape: `::error`, `exit 1`, and a message naming its own remedy.

```diff
-  echo "::notice::$script is absent; run 'lisa apply' to install it."
-  exit 0
+  echo "::error title=Floor-collision gate missing::$script does not exist, so no security floor was examined. ... Run 'lisa apply' to install the Lisa-managed script, or add 'floor_collisions' to skip_jobs to decline the gate deliberately, which at least records the decision in the caller."
+  exit 1
```

Declining is still possible — it just has to be said out loud, in the caller's `skip_jobs`, where it is reviewable.

## Blast radius — measured, and not zero

Measured on each repo's **remote default branch**, not its working tree (two working trees disagreed with their own remote):

```
git -C "$p" fetch origin --quiet
def=$(git -C "$p" symbolic-ref --quiet refs/remotes/origin/HEAD | sed 's#refs/remotes/origin/##')
git -C "$p" ls-tree -r --name-only "origin/$def" -- scripts/lisa-floor-collisions.mjs
git -C "$p" grep -l "lisa/.github/workflows/quality.yml" "origin/$def" -- .github/workflows
```

**25 caller repos: 11 have an installed copy, 14 do not.** None of the 14 opt out — every one passes a `skip_jobs` that omits `floor_collisions`.

The 25th is **this repository**, and finding it is the first thing the flip did (see below). It is resolved here, leaving **13 consumer repos** that go newly red on their next CI run until `lisa apply` runs.

Two things bound that, and they are why this ships without a warn-first grace release:

1. `🧱 Security Floor Collisions` is **not a required status check**. It appears in no shipped ruleset (`all/github-rulesets/base.json`, `typescript/github-rulesets/quality-checks.json`) and no `required-checks.json` seed — only in `quality.yml`. Where a repo's own ruleset does not name it, this is a red job, not a blocked merge.
2. The script ships from `all/copy-overwrite/`, so **every** stack gets it from one `lisa apply`. 8 of the 13 are starter or infrastructure tooling rather than active product code (breakdown below).

A red gate whose fix is one command beats a green one that proved nothing.

### These 13 reds are TRUE positives

This is the distinction that decides whether the reds get fixed or routed around. Those repos genuinely have no floor-collision scanning today — their green ticks on this check are meaningless, and have been since the check shipped. The red is the first accurate thing the gate has said to them.

That is categorically different from a gate reddening on legitimate work. A false-positive red teaches people to skip-list the check, and the portfolio has a fresh measurement of exactly that failure: a traceability gate that blocked six PRs with zero real violations. Nothing here resembles that — every red corresponds to a real absence, and every one clears with one command.

### Which repos, and why they are not named here

The 13 are, by role: **5 stack starter templates, 3 infrastructure repos, 4 application repos, and 1 wiki repo** — 8 of the 13 being starter or infrastructure tooling rather than active product code.

They are deliberately **not** named in this public repository. `.claude/rules/PROJECT_RULES.md` forbids naming downstream projects in PR bodies, and this repo is public with `dist/` in the npm `files` allowlist. The named list lives in the fleet-update coordination where the operator who runs `lisa apply` can act on it. Writing the evidence without the identity is the rule's whole point.

### Caveats on the measurement

Stated because the first estimate of this went wrong in exactly these ways:

- **Scope.** This enumerates the 27 entries in the workspace config plus 3 sub-project checkouts. That is not provably every consumer on GitHub — the same scoping limit that produced an earlier 7-repo count.
- **Branch.** It reads each repo's default branch only. A repo could carry the script on a release branch.
- **The local trees lied.** Two checkouts disagreed with their own remotes — the working tree said the script was absent where `origin/<default>` had it, because the checkout sat on a stale feature branch. Measuring working trees would have produced a wrong count in both directions. Every number above comes from `git ls-tree` against the remote ref.

## What the flip caught immediately

Arming this reddened Lisa's own CI — which is the gate working. Lisa ships `lisa-floor-collisions.mjs` as a `copy-overwrite` template and keeps **no** copy under its own `scripts/`:

```
=== copy-overwrite scripts vs Lisa's own scripts/ ===
PRESENT check-state-classification.mjs
ABSENT  lisa-command-envelope.mjs
ABSENT  lisa-destructive-guard.mjs
ABSENT  lisa-floor-collisions.mjs
ABSENT  lisa-gates.mjs
ABSENT  lisa-lint-staged-preflight.mjs
ABSENT  lisa-reconcile-policy.mjs
ABSENT  lisa-run-gates.mjs
ABSENT  lisa-schema-validate.mjs
ABSENT  lisa-test-node.mjs
PRESENT lisa-work-item.mjs
```

So **every green `🧱 Security Floor Collisions` on every Lisa PR to date examined nothing.** The check has never run on the repo that authors it.

The obvious fix — mirror the script into `scripts/` — is the drift surface this repo already declined to create nine times over. Instead the gate resolves from the upstream template when no installed copy exists. That is a second place to find the *same* file, not a bypass: when neither path resolves the job still `exit 1`s, and the substitution prints itself rather than happening silently.

Lisa's own manifest is clean under the check, so it goes green for the right reason rather than by not running:

```
$ node all/copy-overwrite/scripts/lisa-floor-collisions.mjs
## Floor collisions

No override can be collapsed into a weaker range.
exit=0
```

## Bite control

The test executes the `run:` block pulled verbatim out of the YAML rather than grepping it, because the property under test is an **exit code** — a string match for `exit 1` passes against an `exit 1` sitting on an unreachable branch, which is the same class of bug as the one being fixed.

**RED against unmodified `quality.yml`** (`git stash push -- .github/workflows/quality.yml`, final test file):

```
× fails when the Lisa-managed script is absent 20ms
× names skip_jobs as the deliberate way to decline the gate 10ms
 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)

AssertionError: expected +0 not to be +0 // Object.is equality
  110|     const { status, output } = runGate();
  111|     expect(status).not.toBe(0);

AssertionError: expected '::notice::scripts/lisa-floor-collisio…' to contain 'floor_collisions'
- floor_collisions
+ ::notice::scripts/lisa-floor-collisions.mjs is absent; run 'lisa apply' to install it.
```

**GREEN after `git stash pop`:**

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

The third test passed in both states on purpose — it is the non-regression guard proving fail-closed does not redden a project that has the gate installed and clean, including that `tee -a "$GITHUB_STEP_SUMMARY"` still reaches the job summary.

**Second bite, for the fallback** — against the fail-closed commit *without* it:

```
× falls back to the in-repo template when no copy is installed 16ms
× reports a real collision through the fallback path too 12ms
 Test Files  1 failed (1)
      Tests  2 failed | 3 passed (5)

AssertionError: expected 1 to be +0 // Object.is equality
AssertionError: expected '::error title=Floor-collision gate mi…' to contain 'postcss'
```

That second message is the receipt: without the fallback, a repo carrying only the template gets the gate-missing error — exactly the CI failure this PR hit on itself. After the fallback, all **5 pass**. The collision test asserts the fallback path actually *runs the check* rather than merely resolving a file: it feeds a manifest whose `overrides.postcss: ">=8.5.18"` collapses into `dependencies.postcss: "^8.5.0"` and requires a non-zero exit naming the package.

## Verification

```
bun run typecheck   → clean (tsc --noEmit, no output)
bun run lint        → 0 warnings, 0 errors
bun run test tests/integration/quality-workflow.test.ts \
             tests/unit/scripts/floor-collisions.test.ts \
             tests/integration/quality-gate-facade.test.ts \
             tests/unit/scripts/derived-artifact-staleness.test.ts
                    → 4 files, 363 tests passed
bun run check:artifacts → manifest + hash ledger fresh (45 entries)
bun run test <this suite>  → 5 passed
```

## Scope

`.github/workflows/quality.yml` and its test only, plus the derived-artifact regeneration the commit gate requires. `src/strategies/package-lisa.ts`, `all/copy-overwrite/scripts/lisa-gates.mjs`, and `src/cli/doctor*.ts` are untouched — concurrent work.

Work-Item: CodySwannGT/lisa#2731

🤖 Generated with Claude Code
