### PR TITLE
fix(doctor): report universal Lisa-owned artifacts that were never installed

### DIFF
--- a/src/cli/doctor-lisa-owned-artifacts.ts
+++ b/src/cli/doctor-lisa-owned-artifacts.ts
@@ -18,7 +18,6 @@
 import { readFile } from "node:fs/promises";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import * as fse from "fs-extra";
 
 import { PROJECT_TYPE_ORDER } from "../core/config.js";
 import {
@@ -26,9 +25,7 @@ import {
   mayRefreshLisaOwned,
 } from "../core/lisa-owned-provenance.js";
 import type { HashLedger } from "../core/lisa-owned-provenance.js";
-import { isLisaOwnedTemplate } from "../core/lisa-owned-templates.js";
 import { isLisaSourceRepo } from "../core/self-apply.js";
-import { listFilesRecursive } from "../utils/file-operations.js";
 import {
   matchesAnyPattern,
   parseIgnorePatterns,
@@ -37,9 +34,13 @@ import {
   describeResolvableCopies,
   type MultiCopyArtifact,
 } from "./doctor-lisa-owned-artifact-copies.js";
+import {
+  shippedByStack,
+  UNIVERSAL_STACK,
+  universalDestinations,
+} from "./doctor-lisa-owned-universal.js";
 
 const CHECK_NAME = "Lisa enforcement artifacts current?";
-const COPY_OVERWRITE = "copy-overwrite";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /**
@@ -56,9 +57,6 @@ interface ArtifactCheck {
   detail: string;
 }
 
-/** One shipped Lisa-owned artifact and the destination it installs to. */
-type ShippedArtifact = readonly [destination: string, source: string];
-
 /** Per-destination assessment before it is folded into one doctor line. */
 interface ArtifactAssessment {
   readonly finding?: readonly [string, Finding];
@@ -71,29 +69,6 @@ interface ArtifactAssessment {
  */
 function defaultLisaRoot(): string {
   return path.resolve(__dirname, "..", "..");
-}
-
-/**
- * List the Lisa-owned artifacts one stack's copy-overwrite tree ships.
- * @param lisaRoot - Installed Lisa package root
- * @param type - Stack directory name
- * @returns Destination/source pairs shipped by that stack
- */
-async function shippedByStack(
-  lisaRoot: string,
-  type: string
-): Promise<readonly ShippedArtifact[]> {
-  const directory = path.join(lisaRoot, type, COPY_OVERWRITE);
-  if (!(await fse.pathExists(directory))) return [];
-  return (await listFilesRecursive(directory))
-    .map(
-      source =>
-        [
-          path.relative(directory, source).split(path.sep).join("/"),
-          source,
-        ] as const
-    )
-    .filter(([destination]) => isLisaOwnedTemplate(destination));
 }
 
 /**
@@ -110,7 +85,7 @@ async function shippedArtifacts(
 ): Promise<ReadonlyMap<string, readonly string[]>> {
   const shipped = (
     await Promise.all(
-      ["all", ...PROJECT_TYPE_ORDER].map(async type =>
+      [UNIVERSAL_STACK, ...PROJECT_TYPE_ORDER].map(async type =>
         shippedByStack(lisaRoot, type)
       )
     )
@@ -184,8 +159,10 @@ function reExportsShippedTemplate(
  * nobody can account for is worth a line either way, and staying silent about a
  * downstream edit would let a project quietly swap a guard for a stub.
  *
- * Only artifacts the project already has are considered: a missing one means
- * the stack does not apply here, not that something drifted.
+ * A third finding covers absence, but only for the universal tree. A missing
+ * stack-specific artifact means that stack does not apply here, which is not
+ * drift. A missing universal one means apply has not run, and the CI gate that
+ * calls it is not running at all.
  * @param targetPath - Project path to inspect
  * @param lisaRoot - Installed Lisa package root (injected by tests)
  * @param ledger - Known-good hashes, defaulting to Lisa's shipping history
@@ -197,6 +174,7 @@ export async function checkLisaOwnedArtifacts(
   ledger?: HashLedger
 ): Promise<ArtifactCheck> {
   const shipped = await shippedArtifacts(lisaRoot);
+  const universal = await universalDestinations(lisaRoot);
   if (shipped.size === 0) {
     return {
       name: CHECK_NAME,
@@ -226,6 +204,7 @@ export async function checkLisaOwnedArtifacts(
           sources,
           ignorePatterns,
           selfHost,
+          universal.has(destination),
           ledger
         )
       )
@@ -251,8 +230,9 @@ export async function checkLisaOwnedArtifacts(
  * @param sources - Absolute shipped package variants
  * @param ignorePatterns - Parsed .lisaignore patterns
  * @param selfHost - Whether the target is Lisa's own source repository
+ * @param universal - Whether every project receives this destination
  * @param ledger - Known-good hashes, defaulting to Lisa's shipping history
- * @returns Per-artifact assessment, or undefined when no installed copy exists
+ * @returns Per-artifact assessment, or undefined when nothing is reportable
  */
 async function assessArtifact(
   targetPath: string,
@@ -261,17 +241,14 @@ async function assessArtifact(
   sources: readonly string[],
   ignorePatterns: readonly string[],
   selfHost: boolean,
+  universal: boolean,
   ledger?: HashLedger
 ): Promise<ArtifactAssessment | undefined> {
   const installedPath = path.join(targetPath, destination);
   const installed = await readFile(installedPath).catch(() => undefined);
   const ignored = matchesAnyPattern(destination, ignorePatterns);
   if (installed === undefined) {
-    return ignored
-      ? ({
-          finding: [destination, "ignored"] as const,
-        } satisfies ArtifactAssessment)
-      : undefined;
+    return assessAbsent(destination, ignored, universal, selfHost);
   }
   const multiCopy = await describeResolvableCopies(
     lisaRoot,
@@ -299,6 +276,41 @@ async function assessArtifact(
 }
 
 /**
+ * Assess a Lisa-owned artifact the project does not have.
+ *
+ * An absent stack-specific artifact means that stack does not apply here, which
+ * is not drift — that exemption is why absence used to report nothing at all.
+ * It over-reached: a universal artifact has no stack it does not apply to, so
+ * its absence means apply never ran and the CI gate that calls it is not
+ * running. Measured on `scripts/lisa-floor-collisions.mjs` (#2731), whose job
+ * exited 0 on the missing script — green, having examined nothing, with doctor
+ * silent too. Fixing only the job turns a silent pass into a red nobody has
+ * been told how to clear.
+ *
+ * Never for Lisa's own repository: it is the source of these artifacts, not a
+ * consumer, and installs only the few it runs on itself, so "apply never ran"
+ * is a category error there.
+ * @param destination - Project-relative artifact destination
+ * @param ignored - Whether .lisaignore names this destination
+ * @param universal - Whether every project receives this destination
+ * @param selfHost - Whether the target is Lisa's own source repository
+ * @returns Per-artifact assessment, or undefined when absence proves nothing
+ */
+function assessAbsent(
+  destination: string,
+  ignored: boolean,
+  universal: boolean,
+  selfHost: boolean
+): ArtifactAssessment | undefined {
+  if (ignored) {
+    return { finding: [destination, "ignored"] as const };
+  }
+  return universal && !selfHost
+    ? { finding: [destination, "missing"] as const }
+    : undefined;
+}
+
+/**
  * Attach optional multi-copy provenance without materialising undefined fields.
  * @param finding - Artifact finding tuple
  * @param multiCopy - Optional multi-copy provenance
@@ -312,7 +324,7 @@ function withMultiCopy(
 }
 
 /** Which finding an artifact produced. */
-type Finding = "stale" | "modified" | "ignored";
+type Finding = "stale" | "modified" | "ignored" | "missing";
 
 /**
  * Turn the per-artifact findings into one doctor line.
@@ -333,11 +345,13 @@ function summarise(
   const stale = pick("stale");
   const modified = pick("modified");
   const ignored = pick("ignored");
+  const missing = pick("missing");
   const copyDisagreements = multiCopies.filter(copy => copy.disagrees);
   const copyReports = renderCopyReports(multiCopies);
   const warningFree =
     stale.length === 0 &&
     modified.length === 0 &&
+    missing.length === 0 &&
     copyDisagreements.length === 0;
   if (warningFree) {
     // Named rather than folded into the pass. A guard excluded by
@@ -354,6 +368,9 @@ function summarise(
   const parts = [
     ignored.length > 0
       ? `${ignored.length} not assessed (.lisaignore): ${ignored.join(", ")}`
+      : "",
+    missing.length > 0
+      ? `Lisa-owned guards every project receives are not installed, so the CI gates that call them run against nothing (run \`npx lisa apply .\` to install them): ${missing.join(", ")}`
       : "",
     stale.length > 0
       ? `Outdated Lisa-owned guards (run \`npx lisa apply .\` to refresh): ${stale.join(", ")}`

--- a/src/cli/doctor-lisa-owned-universal.ts
+++ b/src/cli/doctor-lisa-owned-universal.ts
@@ -1,0 +1,68 @@
+/**
+ * Which Lisa-owned artifacts every project receives, whatever stack it is.
+ *
+ * Kept separate from `doctor-lisa-owned-artifacts.ts` for the max-lines budget,
+ * the same way the safety-net fixtures are split. The distinction it encodes is
+ * small but load-bearing: absence of a STACK artifact proves nothing, because
+ * that stack may simply not apply here, while absence of a UNIVERSAL one means
+ * apply never ran and the CI gate that calls it is not running at all.
+ * @module cli/doctor-lisa-owned-universal
+ */
+import * as path from "node:path";
+import * as fse from "fs-extra";
+
+import { isLisaOwnedTemplate } from "../core/lisa-owned-templates.js";
+import { listFilesRecursive } from "../utils/file-operations.js";
+
+/** Directory name of the strategy tree these artifacts are shipped from. */
+export const COPY_OVERWRITE = "copy-overwrite";
+
+/**
+ * The stack tree every project receives regardless of detected type.
+ *
+ * `Lisa.processProjectType("all")` runs unconditionally and every downstream
+ * loop is `["all", ...detectedTypes]`, so an artifact shipped here has no stack
+ * it legitimately does not apply to.
+ */
+export const UNIVERSAL_STACK = "all";
+
+/** One shipped Lisa-owned artifact and the destination it installs to. */
+export type ShippedArtifact = readonly [destination: string, source: string];
+
+/**
+ * List the Lisa-owned artifacts one stack's copy-overwrite tree ships.
+ * @param lisaRoot - Installed Lisa package root
+ * @param type - Stack directory name
+ * @returns Destination/source pairs shipped by that stack
+ */
+export async function shippedByStack(
+  lisaRoot: string,
+  type: string
+): Promise<readonly ShippedArtifact[]> {
+  const directory = path.join(lisaRoot, type, COPY_OVERWRITE);
+  if (!(await fse.pathExists(directory))) return [];
+  return (await listFilesRecursive(directory))
+    .map(
+      source =>
+        [
+          path.relative(directory, source).split(path.sep).join("/"),
+          source,
+        ] as const
+    )
+    .filter(([destination]) => isLisaOwnedTemplate(destination));
+}
+
+/**
+ * Destinations shipped by the universal tree, which every project receives.
+ * @param lisaRoot - Installed Lisa package root
+ * @returns Destination paths no project can legitimately be without
+ */
+export async function universalDestinations(
+  lisaRoot: string
+): Promise<ReadonlySet<string>> {
+  return new Set(
+    (await shippedByStack(lisaRoot, UNIVERSAL_STACK)).map(
+      ([destination]) => destination
+    )
+  );
+}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8253,6 +8253,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/doctor-legacy-overlay.ts": true,
     "src/cli/doctor-lisa-owned-artifact-copies.ts": true,
     "src/cli/doctor-lisa-owned-artifacts.ts": true,
+    "src/cli/doctor-lisa-owned-universal.ts": true,
     "src/cli/doctor-monitor-thresholds.ts": true,
     "src/cli/doctor-readiness-action-pins.ts": true,
     "src/cli/doctor-readiness-audit-allowlist.ts": true,

--- a/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
+++ b/tests/unit/cli/doctor-lisa-owned-artifacts.test.ts
@@ -25,8 +25,14 @@ const SHIPPED_GUARD_VERSION = "sha256:1f8d79a5e303";
 const OLD_GUARD_VERSION = "sha256:5708bbd8b37f";
 const SHIPPED_GENERATED_VERSION = "sha256:c534dbb9ff9e";
 const ENTRYPOINT = "scripts/lisa-work-item.mjs";
+const SHIPPED_ENTRYPOINT = "export function runCli() {}\n";
+/** Shipped by one stack only, so its absence is not evidence of anything. */
+const STACK_ONLY_ARTIFACT = "scripts/lisa-expo-only.mjs";
 const LISA_PACKAGE = '{"name":"@codyswann/lisa"}';
 const HOST_PACKAGE = '{"name":"some-host-app"}';
+const COPY_OVERWRITE = "copy-overwrite";
+/** The uninstalled-universal-guard fragment of the doctor detail line. */
+const NOT_INSTALLED = "not installed";
 const OK = "ok";
 const WARN = "warn";
 
@@ -37,7 +43,22 @@ const WARN = "warn";
  * @returns Absolute path to the shipped template.
  */
 function shippedPath(lisaRoot: string, destination: string): string {
-  return path.join(lisaRoot, "all", "copy-overwrite", destination);
+  return path.join(lisaRoot, "all", COPY_OVERWRITE, destination);
+}
+
+/**
+ * Absolute path of a destination as one specific stack ships it.
+ * @param lisaRoot - Lisa package root shipping the template.
+ * @param stack - Stack directory name.
+ * @param destination - Project-relative destination path.
+ * @returns Absolute path to the shipped template.
+ */
+function stackShippedPath(
+  lisaRoot: string,
+  stack: string,
+  destination: string
+): string {
+  return path.join(lisaRoot, stack, COPY_OVERWRITE, destination);
 }
 
 /**
@@ -101,11 +122,14 @@ describe("checkLisaOwnedArtifacts", () => {
     projectDir = path.join(tempDir, "project");
     await fs.outputFile(shippedPath(lisaRoot, GUARD), SHIPPED_GUARD);
     await fs.outputFile(shippedPath(lisaRoot, HOST_CONFIG), '{"strict":true}');
-    await fs.outputFile(
-      shippedPath(lisaRoot, ENTRYPOINT),
-      "export function runCli() {}\n"
-    );
+    await fs.outputFile(shippedPath(lisaRoot, ENTRYPOINT), SHIPPED_ENTRYPOINT);
     await fs.ensureDir(projectDir);
+    // A project that has run apply holds every universal artifact at shipped
+    // bytes. Starting from that state rather than from an empty directory is
+    // what lets a test perturb exactly one thing and attribute the result to
+    // it; an empty project is now itself a finding.
+    await fs.outputFile(path.join(projectDir, GUARD), SHIPPED_GUARD);
+    await fs.outputFile(path.join(projectDir, ENTRYPOINT), SHIPPED_ENTRYPOINT);
   });
 
   afterEach(async () => {
@@ -164,12 +188,65 @@ describe("checkLisaOwnedArtifacts", () => {
     );
   });
 
-  it("passes when the project never installed the guard", async () => {
-    // A missing artifact means the stack does not apply here, not drift.
+  it("passes when a stack-specific artifact was never installed", async () => {
+    // A missing STACK artifact means that stack does not apply here, not
+    // drift. This is the exemption that must survive the universal-tree
+    // finding below — collapsing the two would warn every project about every
+    // other stack's guards.
+    await fs.outputFile(
+      stackShippedPath(lisaRoot, "expo", STACK_ONLY_ARTIFACT),
+      SHIPPED_GENERATED
+    );
+
     const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
     expect(check.status).toBe(OK);
-    expect(check.detail).not.toContain("Resolvable Lisa-owned artifact copies");
+    expect(check.detail).not.toContain(STACK_ONLY_ARTIFACT);
+  });
+
+  it("warns when a universal guard was never installed", async () => {
+    // Measured on scripts/lisa-floor-collisions.mjs (#2731): 13 caller repos
+    // had no copy, their CI job exited 0 on the absence, and the security
+    // check reported green having examined nothing. Doctor said nothing
+    // either, so there was no surface anywhere that named the problem.
+    await fs.remove(path.join(projectDir, GUARD));
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe(WARN);
+    expect(check.detail).toContain(GUARD);
+    expect(check.detail).toContain(NOT_INSTALLED);
+    // Must name the remedy: a warn an operator cannot act on gets filtered out.
+    expect(check.detail).toContain("npx lisa apply .");
+  });
+
+  it("does not confuse an uninstalled universal guard with an outdated one", async () => {
+    // The two have different remedies in principle and identical ones here,
+    // but reporting absence as "Outdated" tells the operator the gate ran on
+    // old logic when it did not run at all.
+    await fs.remove(path.join(projectDir, GUARD));
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.detail).not.toContain("Outdated");
+    expect(check.detail).not.toContain("keep yours");
+  });
+
+  it("keeps an uninstalled universal guard unassessed when .lisaignore names it", async () => {
+    // Declining an artifact on purpose is already expressible, and it must
+    // keep working — otherwise the only way to silence the new warn is to
+    // stop running doctor.
+    await fs.remove(path.join(projectDir, GUARD));
+    await fs.outputFile(
+      path.join(projectDir, ".lisaignore"),
+      "scripts/lisa-hooks/\n"
+    );
+
+    const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+    expect(check.status).toBe(OK);
+    expect(check.detail).toContain("not assessed (.lisaignore)");
+    expect(check.detail).not.toContain(NOT_INSTALLED);
   });
 
   it("warns when resolvable Lisa-owned artifact copies disagree", async () => {
@@ -196,7 +273,7 @@ describe("checkLisaOwnedArtifacts", () => {
 
   it("discovers newly shipped Lisa-owned artifacts from copy-overwrite sources", async () => {
     await fs.outputFile(
-      path.join(lisaRoot, "typescript", "copy-overwrite", GENERATED_ARTIFACT),
+      path.join(lisaRoot, "typescript", COPY_OVERWRITE, GENERATED_ARTIFACT),
       SHIPPED_GENERATED
     );
     await fs.outputFile(
@@ -267,6 +344,20 @@ describe("checkLisaOwnedArtifacts", () => {
       const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
 
       expect(check.status).toBe(OK);
+    });
+
+    it("does not report an uninstalled universal guard", async () => {
+      // Lisa is the SOURCE of these artifacts, not a consumer of them, and it
+      // installs only the few it runs on itself — 2 of the 11 scripts the
+      // universal tree ships. "Apply has not run" is a category error here,
+      // and nine permanent warn lines in Lisa's own doctor is how the whole
+      // check gets learned as noise.
+      await fs.remove(path.join(projectDir, GUARD));
+
+      const check = await checkLisaOwnedArtifacts(projectDir, lisaRoot);
+
+      expect(check.status).toBe(OK);
+      expect(check.detail).not.toContain(NOT_INSTALLED);
     });
 
     it("still reports a guard that genuinely drifted", async () => {


### PR DESCRIPTION
## What

Answers the question from #2731's follow-up: **does `lisa doctor` detect `scripts/lisa-floor-collisions.mjs` as missing?** No — and the skip is deliberate, so this does not just flip it.

Failing the CI gate closed was correct, but on its own it converts a silent green into a red that no tooling explains. 13 caller repos have no copy of that script; the operator's only route from red to fixed was tribal knowledge. This makes the red discoverable, so the repos self-heal on their next doctor or apply.

## The fence, and why it stays up

`src/cli/doctor-lisa-owned-artifacts.ts` returned `undefined` for every absent artifact, documented as:

> Only artifacts the project already has are considered: a missing one means the stack does not apply here, not that something drifted.

`shippedArtifacts` spans `all` plus every entry in `PROJECT_TYPE_ORDER`, so a project legitimately lacks most stacks' guards. Flipping absence to a warn wholesale would warn every project about every other stack's artifacts. That reasoning is sound and is preserved.

## The distinction that makes it safe

`Lisa.processProjectType("all")` runs unconditionally (`src/core/lisa.ts:308`) and every downstream loop is `["all", ...detectedTypes]`. An artifact shipped from `all/copy-overwrite/` therefore has **no stack it does not apply to** — so for that population, and only that population, absence is unambiguous: apply never ran, and the gate that calls the artifact is not running at all.

`scripts/lisa-floor-collisions.mjs` lives in `all/copy-overwrite/`.

Deliberately not worded "Outdated". The gate did not run on old logic; it did not run.

## Two exemptions preserved, both tested

- **`.lisaignore`** still reports not-assessed rather than not-installed. Declining an artifact on purpose has to keep working, or the only way to silence the new warn is to stop running doctor.
- **Lisa's own repository** is exempt. It is the *source* of these artifacts, not a consumer, and installs only 2 of the 11 scripts the universal tree ships. Nine permanent warn lines in Lisa's own doctor is exactly how a check gets learned as noise.

## Bite control

**RED against pre-fix `assessArtifact`, final tests:**

```
× warns when a universal guard was never installed 5ms
AssertionError: expected 'ok' to be 'warn' // Object.is equality
      Tests  1 failed | 15 passed (16)
```

**GREEN after:** `Tests 16 passed (16)`.

The other new tests pass in *both* states by design — they are guard rails, not bites. `passes when a stack-specific artifact was never installed`, `keeps an uninstalled universal guard unassessed when .lisaignore names it`, `does not report an uninstalled universal guard` (Lisa's own repo), and `does not confuse an uninstalled universal guard with an outdated one` all assert behaviour that was already true and must survive the change. Stating that plainly rather than presenting four passing tests as four bites.

## Empirical check on a real repo

Ran the check against a caller repo in the portfolio that has no installed copy (`lisaRoot` = this branch):

```
status=warn
Lisa-owned guards every project receives are not installed, so the CI gates that
call them run against nothing (run `npx lisa apply .` to install them):
scripts/check-state-classification.mjs, scripts/lib/invoked-as-script.mjs,
scripts/lisa-command-envelope.mjs, scripts/lisa-destructive-guard.mjs,
scripts/lisa-enforcement-fallback.sh, scripts/lisa-floor-collisions.mjs,
scripts/lisa-gates.mjs, scripts/lisa-hooks/block-direct-issue-create.sh, ...
```

That repo is missing **22** universal enforcement artifacts, not one — every hook guard included. A well-applied repo probed the same way returned a two-item list, so the check is not uniformly noisy: the length of the line tracks how far behind the project is.

**Caveat on those probes, stated because it inverts a reading:** they read the *working tree*, and the local checkouts are on stale feature branches (26–216 commits behind their remotes). They demonstrate the mechanism fires and names the remedy; they are **not** a fleet-adoption measurement. The adoption numbers in #2732 came from `git ls-tree` against each repo's remote default branch, which is the trustworthy surface.

## Verification

```
bun run typecheck  → clean
bun run lint       → 0 warnings, 0 errors
bun run test tests/unit/cli/ tests/unit/strategies/ tests/integration/lisa.test.ts
                   → 293 files, 6844 tests passed
bun run check:artifacts → manifest + hash ledger fresh (45 entries)
```

## Note on structure

The universal-tree helpers move to `src/cli/doctor-lisa-owned-universal.ts` for the `max-lines` budget, following the `safety-net-subst-fixtures.ts` precedent rather than adding a disable comment.

Test fixtures now start from a project that has run apply, holding every universal artifact at shipped bytes. An empty project directory is itself a finding now, so starting from one would stop a test attributing its result to the one thing it perturbed.

Work-Item: CodySwannGT/lisa#2737

🤖 Generated with Claude Code
