### PR TITLE
fix(postinstall): a failed template apply is now loud and durable, still non-fatal

### DIFF
--- a/all/copy-overwrite/scripts/lisa-postinstall.mjs
+++ b/all/copy-overwrite/scripts/lisa-postinstall.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
+/**
+ * lisa-postinstall — run the template apply on local install, and make its
+ * failure IMPOSSIBLE TO MISS.
+ *
+ * The previous postinstall was a one-liner:
+ *
+ *     [ -n "$CI" ] || node …/dist/index.js --yes --skip-git-check . 2>/dev/null || true
+ *
+ * Two independent silencers. `2>/dev/null` discarded WHY it failed and
+ * `|| true` discarded THAT it failed, so a project whose apply could not run
+ * received no template updates, no guardrail updates and no signal — install
+ * after install, indefinitely. Measured on a consumer: `lisa apply` aborted on
+ * a module-resolution failure before doing any work, and nothing anywhere said
+ * so. The repository had been silently frozen at whatever Lisa last managed to
+ * write.
+ *
+ * That is this codebase's recurring defect in its purest form: a control
+ * reporting success for work it no longer performs.
+ *
+ * ## Why the exit code stays 0
+ *
+ * Not an oversight, and not the same thing as the silence. A non-zero
+ * postinstall aborts `bun install` / `npm ci` outright, so a broken apply would
+ * stop a project installing its dependencies at all — strictly worse than a
+ * stale template, and it would strand the repository with no way to install the
+ * fix. #318 is the recorded incident behind the caution: a half-run apply left
+ * child stacks with the wrong TypeScript config.
+ *
+ * So the install still succeeds. What changes is that the failure becomes
+ * LOUD (the real error reaches the terminal) and DURABLE (a marker `lisa
+ * doctor` reads), instead of being thrown away.
+ *
+ * ## Why the marker lives under node_modules
+ *
+ * It describes the state of an INSTALL, not of the source tree, and it should
+ * not survive one. `node_modules` is already ignored by every consumer, so the
+ * marker cannot be committed by accident, and a clean reinstall re-tests the
+ * condition from scratch rather than inheriting a verdict from a tree that no
+ * longer exists.
+ * @module scripts/lisa-postinstall
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
+
+/** Where the failure marker lives, relative to the project root. */
+export const APPLY_FAILURE_MARKER = join(
+  "node_modules",
+  ".lisa",
+  "apply-failed.json"
+);
+
+/** The installed entry point the apply runs through. */
+const LISA_ENTRY = join(
+  "node_modules",
+  "@codyswann",
+  "lisa",
+  "dist",
+  "index.js"
+);
+
+/**
+ * Record that the apply failed, so something can report it later.
+ * @param {string} cwd Project root.
+ * @param {{status: number|null, output: string}} failure What happened.
+ * @returns {void}
+ */
+function recordFailure(cwd, failure) {
+  const path = join(cwd, APPLY_FAILURE_MARKER);
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(
+      path,
+      `${JSON.stringify(
+        {
+          failedAt: new Date().toISOString(),
+          exitCode: failure.status,
+          // Truncated: this is a signal that something is wrong plus enough to
+          // recognise it, not a log file. The full error already went to the
+          // terminal unredirected.
+          output: failure.output.slice(-4000),
+        },
+        null,
+        2
+      )}\n`
+    );
+  } catch {
+    // A marker we cannot write must not become a second failure mode. The
+    // banner below is still printed, so the operator is not left with nothing.
+  }
+}
+
+/**
+ * Clear a stale marker after a successful apply.
+ * @param {string} cwd Project root.
+ * @returns {void}
+ */
+function clearFailure(cwd) {
+  try {
+    rmSync(join(cwd, APPLY_FAILURE_MARKER), { force: true });
+  } catch {
+    // Nothing to do. A stale marker over-reports, which is the safe direction.
+  }
+}
+
+/**
+ * Run the template apply for a local install.
+ * Returns nothing. "The install never fails" is a CONTRACT of this module
+ * rather than a value it computes, and returning a constant 0 dressed it up as
+ * a decision the caller might act on. The entry point below exits 0
+ * unconditionally, which is the honest expression of the same promise.
+ * @param {string} [cwd] Project root.
+ * @param {NodeJS.ProcessEnv} [env] Environment.
+ * @returns {void}
+ */
+export function runPostinstall(cwd = process.cwd(), env = process.env) {
+  // CI never applies templates. Established philosophy, and the
+  // postinstall-ci-guard test pins it: a CI run must test the tree as
+  // committed, not a tree the install just rewrote.
+  if (env.CI) return;
+
+  if (!existsSync(join(cwd, LISA_ENTRY))) {
+    // Not installed yet, or a workspace layout that hoists elsewhere. Nothing
+    // to run and nothing to complain about — this is not the failure the
+    // marker is for.
+    return;
+  }
+
+  const child = spawnSync(
+    process.execPath,
+    [LISA_ENTRY, "--yes", "--skip-git-check", "."],
+    {
+      cwd,
+      env: { ...env, LISA_BOOTSTRAP: "1" },
+      encoding: "utf8",
+      // Inherited, NOT captured-and-discarded. The whole point.
+      stdio: ["ignore", "inherit", "pipe"],
+    }
+  );
+
+  const stderr = child.stderr ?? "";
+  if (stderr) process.stderr.write(stderr);
+
+  if (!child.error && child.status === 0) {
+    clearFailure(cwd);
+    return;
+  }
+
+  const output = child.error ? String(child.error.message) : stderr;
+  recordFailure(cwd, { status: child.status ?? null, output });
+
+  process.stderr.write(
+    [
+      "",
+      "  ⚠️  Lisa could not apply its templates to this project.",
+      "",
+      "  The install SUCCEEDED — your dependencies are fine. What did not happen",
+      "  is the template and guardrail update Lisa normally performs here, so",
+      "  this project is now frozen at whatever Lisa last managed to write.",
+      "",
+      "  This is reported rather than fatal on purpose: failing the install would",
+      "  stop the project installing dependencies at all, including the fix.",
+      "",
+      "  The error is printed above. Run `lisa doctor` for the recorded state, or",
+      "  re-run the apply directly to see it in isolation:",
+      "",
+      `      node ${LISA_ENTRY} --yes --skip-git-check .`,
+      "",
+    ].join("\n")
+  );
+}
+
+// Realpath-based rather than a URL string comparison: a raw comparison answers
+// "no" through a symlinked checkout, a git worktree, or a macOS /tmp path — all
+// of which this fleet runs in — and this module would then load, run nothing,
+// and exit 0. For a postinstall that is the worst possible silence, since it is
+// indistinguishable from the apply having succeeded.
+if (invokedAsScript(import.meta.url)) {
+  runPostinstall();
+  // Unconditionally 0. See the module header: a non-zero postinstall aborts the
+  // dependency install outright, which is strictly worse than a stale template
+  // and would strand the project with no way to install the fix.
+  process.exit(0);
+}

--- a/src/cli/doctor-apply-failure.ts
+++ b/src/cli/doctor-apply-failure.ts
@@ -1,0 +1,140 @@
+/**
+ * Doctor check: report that the last local `lisa apply` failed.
+ *
+ * The postinstall apply is deliberately non-fatal — a non-zero postinstall
+ * aborts `bun install` / `npm ci`, which would stop a project installing its
+ * dependencies at all, including the fix. That caution is correct and stays.
+ *
+ * What was wrong is that it was also SILENT. The previous one-liner ended in
+ * `2>/dev/null || true`: two independent silencers, discarding why it failed
+ * and that it failed. A project whose apply could not run therefore received no
+ * template updates, no guardrail updates and no signal — install after install,
+ * indefinitely. Measured on a consumer: the apply aborted on a module
+ * resolution failure before doing any work, and the repository had been frozen
+ * at whatever Lisa last managed to write, with every install reporting success.
+ *
+ * So the failure is now recorded, and this check is what reads it. Non-fatal
+ * and observable, rather than non-fatal and invisible.
+ *
+ * ## Why `warn` and not `fail`
+ *
+ * The project is not broken; it is STALE, and it may have been stale for a
+ * long time before anyone looked. Failing doctor would make every affected
+ * repository red simultaneously on the release that ships this, which buries
+ * the signal in exactly the population that needs to read it. A warning that
+ * names the marker and the command is actionable; a wall of red is not.
+ * @module cli/doctor-apply-failure
+ */
+
+import { readFile } from "node:fs/promises";
+import * as path from "node:path";
+
+import type { DoctorCheck } from "./doctor.js";
+
+/** Where the postinstall records a failed apply. */
+export const APPLY_FAILURE_MARKER = path.join(
+  "node_modules",
+  ".lisa",
+  "apply-failed.json"
+);
+
+const CHECK_NAME = "Template apply (postinstall)";
+
+/** The recorded shape of a failed apply. */
+export interface ApplyFailure {
+  failedAt?: string;
+  exitCode?: number | null;
+  output?: string;
+}
+
+/**
+ * The first line of the recorded error, for a one-line detail.
+ *
+ * The marker holds a tail of the real output, which is frequently a stack
+ * trace. A doctor detail that printed all of it would push every other check
+ * off the screen, and the full text is already on disk at a named path.
+ * @param failure The recorded failure.
+ * @returns A short cause, or an empty string when nothing was recorded.
+ */
+export function summariseCause(failure: ApplyFailure): string {
+  const lines = String(failure.output ?? "")
+    .split("\n")
+    .map(line => line.trim())
+    .filter(Boolean);
+  // Prefer a line that names an error over the first line, which is often a
+  // banner or a blank-ish prefix from whatever tool failed.
+  const named = lines.find(line => /error|cannot|failed|not found/i.test(line));
+  return named ?? lines[0] ?? "";
+}
+
+/**
+ * Read the recorded failure, or null when the marker cannot be parsed.
+ * @param marker Absolute path to the marker file.
+ * @returns The parsed failure, or null.
+ */
+async function readMarker(marker: string): Promise<string | undefined> {
+  try {
+    return await readFile(marker, "utf8");
+  } catch {
+    // ENOENT is the healthy case and is indistinguishable here from any other
+    // read error. Both mean "no recorded failure to report", and a project
+    // whose marker cannot be read at all is covered by the parse branch below.
+    return undefined;
+  }
+}
+
+/**
+ * Parse a recorded failure, or null when the text is not readable JSON.
+ * @param raw The marker file contents.
+ * @returns The parsed failure, or null.
+ */
+function parseMarker(raw: string): ApplyFailure | null {
+  try {
+    return JSON.parse(raw) as ApplyFailure;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Report whether the last local apply failed.
+ * @param targetPath Project root.
+ * @returns The doctor check result.
+ */
+export async function checkApplyFailure(
+  targetPath: string
+): Promise<DoctorCheck> {
+  const marker = path.join(targetPath, APPLY_FAILURE_MARKER);
+  const raw = await readMarker(marker);
+  if (raw === undefined) {
+    return {
+      name: CHECK_NAME,
+      status: "ok",
+      detail: "The last local template apply completed",
+    };
+  }
+
+  const failure = parseMarker(raw);
+  if (failure === null) {
+    // An unreadable marker still means a failure was recorded. Reading it as
+    // "no problem" would reintroduce the silence this check exists to end.
+    return {
+      name: CHECK_NAME,
+      status: "warn",
+      detail:
+        `A failed template apply is recorded at ${APPLY_FAILURE_MARKER}, but the marker could not be read. ` +
+        `This project is not receiving template or guardrail updates. Re-run the apply to see the error.`,
+    };
+  }
+
+  const cause = summariseCause(failure);
+  const when = failure.failedAt ? ` at ${failure.failedAt}` : "";
+  return {
+    name: CHECK_NAME,
+    status: "warn",
+    detail:
+      `The local template apply FAILED${when}, so this project is frozen at whatever Lisa last wrote — ` +
+      `no template or guardrail updates are reaching it.${cause ? ` Cause: ${cause}` : ""} ` +
+      `Full output: ${APPLY_FAILURE_MARKER}. The install itself is fine; re-run the apply to fix it.`,
+  };
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -22,6 +22,7 @@ import { checkRepositoryReadiness } from "./doctor-readiness.js";
 import { checkReusableWorkflowRefs } from "./doctor-reusable-workflow-refs.js";
 import { checkWorkerEpoch } from "./doctor-worker-epoch.js";
 import { checkSerializeLegsContract } from "./doctor-serialize-legs-contract.js";
+import { checkApplyFailure } from "./doctor-apply-failure.js";
 import { checkSkipJobsMigration } from "./doctor-skip-jobs-migration.js";
 import { checkTraceabilityGate } from "./doctor-traceability-gate.js";
 import { checkWorktreeHygiene } from "./doctor-worktree-hygiene.js";
@@ -361,6 +362,7 @@ export async function runDoctor(
     // edits a caller workflow there and gets it wrong is silent
     // (CodySwannGT/lisa#2719).
     await checkSkipJobsMigration(resolvedTarget),
+    await checkApplyFailure(resolvedTarget),
     await checkProjectType(resolvedTarget),
     await checkInstructionFiles(resolvedTarget),
     // Runs AFTER the instruction-files check because that check performs the

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -328,6 +328,10 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "8e0bdb491dfaea04e88be1c1e2c6cc7cd34fa4ca18adddf5fecc43d7de8ffded",
     "a630bde6cddae283776b8d34763a3642edbea8096d583a90ec6d43a9588ca8a6",
   ]),
+  "scripts/lisa-postinstall.mjs": Object.freeze([
+    "98fe3adf3192a72f40eb75757193ce866f0a6123387377f6041e54d938df8d96",
+    "ceb4af32ef545b73300f63e591235d2aa041a55e1ddb64c1ce84cbf6ecc67ef8",
+  ]),
   "scripts/lisa-reconcile-policy.mjs": Object.freeze([
     "3c062d0b79961a9a93a822507e893dcdaa71d65d735557727d20464c2489d812",
     "4b383ff960d7da53e0dd46e37632ef55c5a38b004fb4aabfe91a25a9fe02d88f",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -38,6 +38,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "18e63683064305dab1200456896cbb9384ab35ee6bc51d3789ffbba46d1b1081",
     "all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs":
       "ce4bc224a102e3ac2bc29d8f2038eefd619129d4639c25954c93f05011f7f977",
+    "all/copy-overwrite/scripts/lisa-postinstall.mjs":
+      "98fe3adf3192a72f40eb75757193ce866f0a6123387377f6041e54d938df8d96",
     "all/copy-overwrite/scripts/lisa-reconcile-policy.mjs":
       "3c062d0b79961a9a93a822507e893dcdaa71d65d735557727d20464c2489d812",
     "all/copy-overwrite/scripts/lisa-run-gates.mjs":
@@ -2387,7 +2389,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/merge/.oxlintrc.json":
       "9504c20db80470c242c4ffe8cccad6951ed8141dfb5bf6503053e0b2712ab276",
     "typescript/package-lisa/package.lisa.json":
-      "43211ab68ee990afde4b20abf7f8c1420a1c46fdced273f015d1cb7d6e082133",
+      "e8336a88085654354652d7c0139187a6cbf17d0152bb970cbb36dacc2e2f1e98",
     "ui/README.md":
       "deeb35e767ea5dd2883268835ea3ad21cbad9fa63ec8d8ff5e200f0e2a7d2751",
     "ui/index.html":
@@ -2545,6 +2547,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-overwrite/scripts/lisa-hooks/parity-safety-net.sh": true,
     "all/copy-overwrite/scripts/lisa-hooks/sonar-secrets.sh": true,
     "all/copy-overwrite/scripts/lisa-lint-staged-preflight.mjs": true,
+    "all/copy-overwrite/scripts/lisa-postinstall.mjs": true,
     "all/copy-overwrite/scripts/lisa-reconcile-policy.mjs": true,
     "all/copy-overwrite/scripts/lisa-run-gates.mjs": true,
     "all/copy-overwrite/scripts/lisa-schema-validate.mjs": true,
@@ -8251,6 +8254,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/cli/check-learnings-budget-cmd.ts": true,
     "src/cli/cross-pollinate-cmd.ts": true,
     "src/cli/cross-pollinate-nudge.ts": true,
+    "src/cli/doctor-apply-failure.ts": true,
     "src/cli/doctor-apply-freshness.ts": true,
     "src/cli/doctor-kane.ts": true,
     "src/cli/doctor-learnings-ledger.ts": true,
@@ -8747,6 +8751,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/claude/claude-md-installer.test.ts": true,
     "tests/unit/cli/apply.test.ts": true,
     "tests/unit/cli/check-learnings-budget-cmd.test.ts": true,
+    "tests/unit/cli/doctor-apply-failure.test.ts": true,
     "tests/unit/cli/doctor-apply-freshness.test.ts": true,
     "tests/unit/cli/doctor-kane.test.ts": true,
     "tests/unit/cli/doctor-learnings-ledger.test.ts": true,
@@ -9123,6 +9128,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/lisa-github-repo-settings.test.ts": true,
     "tests/unit/scripts/lisa-github-rulesets.test.ts": true,
     "tests/unit/scripts/lisa-owned-hash-ledger.test.ts": true,
+    "tests/unit/scripts/lisa-postinstall.test.ts": true,
     "tests/unit/scripts/lisa-reconcile-policy-fixtures.ts": true,
     "tests/unit/scripts/lisa-reconcile-policy-units.test.ts": true,
     "tests/unit/scripts/lisa-reconcile-policy-verdicts.test.ts": true,

--- a/tests/unit/cli/doctor-apply-failure.test.ts
+++ b/tests/unit/cli/doctor-apply-failure.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Doctor surfaces a failed template apply.
+ *
+ * The postinstall records the failure; this is what makes anyone aware of it.
+ * Without this half, the marker is just another thing nobody reads, and the
+ * project stays silently frozen exactly as before.
+ * @module tests/unit/cli/doctor-apply-failure
+ */
+
+import * as fs from "fs-extra";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  APPLY_FAILURE_MARKER,
+  checkApplyFailure,
+  summariseCause,
+} from "../../../src/cli/doctor-apply-failure.js";
+
+/**
+ * A project root, optionally carrying a recorded failure.
+ * @param contents Marker file contents, or undefined for none.
+ * @returns The project root.
+ */
+async function project(contents?: string): Promise<string> {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-doctor-apply-"));
+  if (contents !== undefined) {
+    const file = path.join(root, APPLY_FAILURE_MARKER);
+    await fs.ensureDir(path.dirname(file));
+    await fs.writeFile(file, contents);
+  }
+  return root;
+}
+
+describe("checkApplyFailure", () => {
+  it("reports ok when no failure is recorded", async () => {
+    const check = await checkApplyFailure(await project());
+
+    expect(check.status).toBe("ok");
+  });
+
+  it("warns, naming the cause, when a failure is recorded", async () => {
+    const check = await checkApplyFailure(
+      await project(
+        JSON.stringify({
+          failedAt: "2026-08-19T12:00:00Z",
+          exitCode: 1,
+          output: "Error: Cannot find package 'brace-expansion'",
+        })
+      )
+    );
+
+    expect(check.status).toBe("warn");
+    expect(check.detail).toContain("brace-expansion");
+    expect(check.detail).toContain(APPLY_FAILURE_MARKER);
+  });
+
+  it("still warns when the marker cannot be parsed", async () => {
+    // The absent-case rule applied to a corrupt file. A marker exists, so a
+    // failure happened; reading an unparseable one as "no problem" would
+    // reintroduce exactly the silence this check exists to end.
+    const check = await checkApplyFailure(await project("{ not json"));
+
+    expect(check.status).toBe("warn");
+  });
+
+  it("warns even when the record carries no output at all", async () => {
+    const check = await checkApplyFailure(await project("{}"));
+
+    expect(check.status).toBe("warn");
+  });
+});
+
+describe("summariseCause", () => {
+  it("prefers a line that names an error over the first line", () => {
+    // Real output usually opens with a banner. Leading with that would make
+    // every warning look identical and tell the reader nothing.
+    expect(
+      summariseCause({
+        output: "> lisa@1.0.0 apply\n\nError: Cannot find package 'x'\n  at …",
+      })
+    ).toBe("Error: Cannot find package 'x'");
+  });
+
+  it("falls back to the first line when nothing names an error", () => {
+    expect(summariseCause({ output: "something unusual\nsecond" })).toBe(
+      "something unusual"
+    );
+  });
+
+  it("returns empty for no output", () => {
+    expect(summariseCause({})).toBe("");
+  });
+});

--- a/tests/unit/config/postinstall-ci-guard.test.ts
+++ b/tests/unit/config/postinstall-ci-guard.test.ts
@@ -15,7 +15,13 @@ import * as path from "node:path";
 
 const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 const CI_GUARD_PREFIX = '[ -n "$CI" ] ||';
-const LISA_MARKER = "node_modules/@codyswann/lisa/dist/index.js";
+// The PACKAGE, not one entry point inside it. Keyed on
+// `dist/index.js`, this constant stopped matching the moment the
+// postinstall moved to a script under the same package — and the loop
+// below `continue`s on no match, so every assertion silently stopped
+// running and the suite still reported green. A guard that identifies its
+// subject too narrowly disables itself when the subject moves.
+const LISA_MARKER = "node_modules/@codyswann/lisa/";
 const LISA_BOOTSTRAP_PREFIX = "LISA_BOOTSTRAP=1 node";
 const EXPO_PACKAGE_TEMPLATE = "expo/package-lisa/package.lisa.json";
 const TYPESCRIPT_PACKAGE_TEMPLATE = "typescript/package-lisa/package.lisa.json";
@@ -73,14 +79,27 @@ describe("package.lisa.json templates guard Lisa postinstall with CI-skip prefix
       const forcePostinstall = template.force?.scripts?.postinstall;
       const defaultsPostinstall = template.defaults?.scripts?.postinstall;
 
+      let asserted = 0;
       for (const script of [forcePostinstall, defaultsPostinstall]) {
         if (typeof script !== "string") continue;
         if (!script.includes(LISA_MARKER)) continue;
+        asserted += 1;
         // If the template defines a Lisa postinstall at all, it MUST be
         // CI-guarded. Lisa already relies on PR diffs for drift detection;
         // silently re-applying templates in CI creates race conditions.
         expect(script.startsWith(CI_GUARD_PREFIX)).toBe(true);
         expect(script).toContain(LISA_BOOTSTRAP_PREFIX);
+      }
+
+      // The absent case. A template that declares a postinstall this test
+      // cannot RECOGNISE is the dangerous state: the loop above asserts
+      // nothing and the case reports green. So when a postinstall exists at
+      // all, it must have been recognised.
+      const declared = [forcePostinstall, defaultsPostinstall].filter(
+        script => typeof script === "string"
+      );
+      if (declared.length > 0) {
+        expect(asserted).toBeGreaterThan(0);
       }
     }
   );

--- a/tests/unit/scripts/lisa-postinstall.test.ts
+++ b/tests/unit/scripts/lisa-postinstall.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The postinstall apply: non-fatal, but never silent.
+ *
+ * The behaviour being protected is a pair that used to be conflated. The apply
+ * must NOT fail the install — a non-zero postinstall aborts `bun install` /
+ * `npm ci`, stopping a project installing its dependencies at all, including
+ * whatever would fix the apply. That caution is correct.
+ *
+ * What was wrong is that it was also invisible. The old one-liner ended in
+ * `2>/dev/null || true`, discarding both the reason and the fact. Measured on a
+ * consumer: the apply aborted before doing any work, and the repository sat
+ * frozen at whatever Lisa last wrote while every install reported success.
+ *
+ * So these tests assert BOTH halves, because either one alone is a regression:
+ * the exit code stays 0, and a failure leaves a durable record.
+ *
+ * A real child process is used rather than a mock. The thing under test is what
+ * happens when a spawned apply exits non-zero, and a mocked spawn would be
+ * asserting the mock.
+ * @module tests/unit/scripts/lisa-postinstall
+ */
+
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  APPLY_FAILURE_MARKER,
+  runPostinstall,
+} from "../../../all/copy-overwrite/scripts/lisa-postinstall.mjs";
+
+/**
+ * A project root with a stand-in Lisa entry point.
+ * @param behaviour What the fake apply should do.
+ * @returns The project root.
+ */
+function project(behaviour: "succeed" | "fail" | "absent"): string {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-postinstall-"));
+  if (behaviour !== "absent") {
+    const dir = path.join(root, "node_modules", "@codyswann", "lisa", "dist");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      path.join(dir, "index.js"),
+      behaviour === "fail"
+        ? "console.error(\"Cannot find package 'brace-expansion'\");\nprocess.exit(1);\n"
+        : "process.exit(0);\n"
+    );
+  }
+  return root;
+}
+
+/** The recorded marker, or null. */
+function marker(root: string): Record<string, unknown> | null {
+  const file = path.join(root, APPLY_FAILURE_MARKER);
+  return existsSync(file)
+    ? (JSON.parse(readFileSync(file, "utf8")) as Record<string, unknown>)
+    : null;
+}
+
+describe("the install never fails", () => {
+  it.each(["succeed", "fail", "absent"] as const)(
+    "does not throw when the apply would %s",
+    behaviour => {
+      // The half that must not regress. Anything that propagates out of here
+      // fails the postinstall, which aborts the dependency install and strands
+      // the project with no way to install the fix. The entry point's
+      // unconditional `process.exit(0)` is asserted separately, end to end.
+      expect(() => runPostinstall(project(behaviour), {})).not.toThrow();
+    }
+  );
+});
+
+describe("a failure is recorded", () => {
+  it("writes a marker naming the exit code and the cause", () => {
+    const root = project("fail");
+    runPostinstall(root, {});
+    const recorded = marker(root);
+
+    expect(recorded).not.toBeNull();
+    expect(recorded?.exitCode).toBe(1);
+    expect(String(recorded?.output)).toContain("brace-expansion");
+    expect(typeof recorded?.failedAt).toBe("string");
+  });
+
+  it("writes NO marker when the apply succeeds", () => {
+    const root = project("succeed");
+    runPostinstall(root, {});
+
+    expect(marker(root)).toBeNull();
+  });
+
+  it("clears a stale marker once the apply succeeds again", () => {
+    // Without this, a project that fixed its apply keeps reporting broken
+    // forever — and a warning nobody can clear is one everybody learns to
+    // ignore.
+    const root = project("succeed");
+    mkdirSync(path.dirname(path.join(root, APPLY_FAILURE_MARKER)), {
+      recursive: true,
+    });
+    writeFileSync(path.join(root, APPLY_FAILURE_MARKER), "{}\n");
+
+    runPostinstall(root, {});
+
+    expect(marker(root)).toBeNull();
+  });
+});
+
+describe("cases that are not failures", () => {
+  it("does nothing under CI, and records nothing", () => {
+    // CI must test the tree as committed, not one the install just rewrote.
+    const root = project("fail");
+
+    expect(() => runPostinstall(root, { CI: "true" })).not.toThrow();
+    expect(marker(root)).toBeNull();
+  });
+
+  it("records nothing when Lisa is not installed", () => {
+    // Absence of the entry point is a workspace layout or an install ordering,
+    // not a broken apply. Recording it would cry wolf on every fresh clone.
+    const root = project("absent");
+
+    expect(() => runPostinstall(root, {})).not.toThrow();
+    expect(marker(root)).toBeNull();
+  });
+});
+
+describe("the entry point exits 0, end to end", () => {
+  it("exits 0 even when the apply fails", () => {
+    // The contract the unit tests above can only approach. `runPostinstall`
+    // returning nothing is not the same promise as the PROCESS exiting 0, and
+    // the process exit code is what `bun install` actually reads. Asserting it
+    // requires running the file as a program.
+    const script = fileURLToPath(
+      new URL(
+        "../../../all/copy-overwrite/scripts/lisa-postinstall.mjs",
+        import.meta.url
+      )
+    );
+    const root = project("fail");
+
+    const run = spawnSync(process.execPath, [script], {
+      cwd: root,
+      encoding: "utf8",
+      env: { PATH: process.env.PATH ?? "" },
+    });
+
+    expect(run.status).toBe(0);
+    // And it was not silent about it — the whole point.
+    expect(run.stderr).toContain("could not apply its templates");
+  });
+});

--- a/typescript/package-lisa/package.lisa.json
+++ b/typescript/package-lisa/package.lisa.json
@@ -65,7 +65,7 @@
     },
     "scripts": {
       "build": "tsc",
-      "postinstall": "[ -n \"$CI\" ] || LISA_BOOTSTRAP=1 node node_modules/@codyswann/lisa/dist/index.js --yes --skip-git-check . 2>/dev/null || true",
+      "postinstall": "[ -n \"$CI\" ] || LISA_BOOTSTRAP=1 node node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-postinstall.mjs || true",
       "test:integration": "vitest run tests/integration"
     },
     "engines": {


### PR DESCRIPTION
The postinstall discarded both halves of its own failure:

    [ -n "$CI" ] || LISA_BOOTSTRAP=1 node .../dist/index.js ... 2>/dev/null || true
                                                              ^^^^^^^^^^^^ why
                                                                           ^^^^^^^ that

A project whose apply could not run therefore received no template updates, no
guardrail updates and no signal — install after install, indefinitely, frozen at
whatever Lisa last managed to write while every install reported success.

Measured on a consumer during an unrelated migration: the apply aborted on a
module-resolution failure BEFORE doing any work, and nothing anywhere said so.
The agent only noticed because it was watching for churn that never arrived.

Same defect class as the floor-collision gate exiting 0 on a missing script and
the traceability gate warning "is NOT enforced" and then exiting 0: a control
reporting success for work it no longer performs.

## The exit code deliberately stays 0

Not an oversight, and not the same thing as the silence. A non-zero postinstall
aborts `bun install` / `npm ci`, so a broken apply would stop a project
installing its dependencies AT ALL — including whatever would fix the apply.
#318 is the recorded incident behind the caution. Fatal is worse than stale.

So the install still succeeds; the failure becomes LOUD (the real error reaches
the terminal, unredirected, under an explicit banner) and DURABLE (a marker
`lisa doctor` reads and reports with the cause named).

The marker lives under `node_modules` on purpose: it describes the state of an
INSTALL, not of the source tree. It cannot be committed by accident, and a clean
reinstall re-tests the condition instead of inheriting a verdict from a tree that
no longer exists. A successful apply clears it — a warning nobody can clear is
one everybody learns to ignore.

## The adjacent finding, which this change caused and then caught

`postinstall-ci-guard.test.ts` identified its subject by one entry-point path:

    const LISA_MARKER = "node_modules/@codyswann/lisa/dist/index.js";
    if (!script.includes(LISA_MARKER)) continue;

Moving the postinstall to a different file INSIDE THE SAME PACKAGE made the
marker stop matching, so the loop continued, every assertion silently stopped
running, and the suite still reported 31 passed. I introduced that and only
caught it because the pass looked too easy for a guard I had just moved.

Two fixes: the marker now identifies the PACKAGE rather than one entry point,
and the case asserts a floor — when a postinstall exists at all, it must have
been RECOGNISED. "Matched nothing" can no longer read as "everything passed".

Bite control on the hardened test: restoring the narrow marker now fails
("either omits postinstall or prefixes it with the CI guard") where before it
passed silently. The CI guard itself is unchanged and still enforced verbatim.

Work-Item: CodySwannGT/lisa#2745