### PR TITLE
fix(format): exempt every managed script from the host format gate, not one

### DIFF
--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2289,7 +2289,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/.nvmrc":
       "0775c6feb7638122e8b68d611cd709bf270f7b5adb5d0d2baa9afab8a6c0fc42",
     "typescript/copy-overwrite/.prettierignore":
-      "eb7778d31dc0ee67cdcb7d843c8cce4cc46d96a7faab14f8d1e313b7a62048a3",
+      "ad396cd6e71ab6500f955442c7d4b172e55af46c378ffdc1e7f5e9c58dbb6a40",
     "typescript/copy-overwrite/.prettierrc.json":
       "a20621f79a064486fba53cc0ea3000a2ece3f312ff38495c6a6606a27d2a727c",
     "typescript/copy-overwrite/.versionrc":
@@ -8900,6 +8900,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/jest-base.test.ts": true,
     "tests/unit/config/jest-expo.test.ts": true,
     "tests/unit/config/js-yaml-security-floor.test.ts": true,
+    "tests/unit/config/managed-scripts-prettierignore.test.ts": true,
     "tests/unit/config/mjs-gate-off-stays-honest.test.ts": true,
     "tests/unit/config/oxlint-expo.test.ts": true,
     "tests/unit/config/oxlint-jsdoc-parity.test.ts": true,

--- a/tests/unit/config/managed-scripts-prettierignore.test.ts
+++ b/tests/unit/config/managed-scripts-prettierignore.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Every managed script Lisa ships into a host's `scripts/` is exempt from the
+ * host's format gate.
+ *
+ * Lisa formats its scripts in Lisa's own Prettier style. Host projects run
+ * varying Prettier configs, so a managed script fails their `prettier --check .`
+ * through no fault of theirs — and reformatting it locally does not help: the
+ * next `lisa apply` replaces the file, so host and Lisa reformat it against each
+ * other forever.
+ *
+ * The exemption used to be one hand-added line, added when `lisa-mutation.mjs`
+ * happened to bite someone. Measured 2026-08-19, **23 of the 24 shipped scripts
+ * were uncovered**, and a consumer's version bump went red on
+ * `scripts/check-e2e-coverage.mjs`.
+ *
+ * So the list is no longer maintained by incident. This test derives the shipped
+ * set from the delivery directories and fails when one is missing, which means
+ * adding a managed script and forgetting the exemption is caught here rather
+ * than in somebody's pull request three weeks later.
+ *
+ * ## Why enumerated rather than globbed
+ *
+ * `scripts/check-*.mjs` would cover every shipped `check-` script in one line —
+ * and would also silence a HOST's own `check-something.mjs`. A host file that
+ * silently stops being formatted is a worse outcome than a managed file that
+ * stays formatted, so the exemption names exactly what Lisa ships.
+ * @module tests/unit/config/managed-scripts-prettierignore
+ */
+
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+const PRETTIERIGNORE = path.join(
+  REPO_ROOT,
+  "typescript",
+  "copy-overwrite",
+  ".prettierignore"
+);
+
+/**
+ * The delivery directories that seed a host's `scripts/`.
+ * @returns Absolute directory paths that exist.
+ */
+function scriptDirs(): string[] {
+  return readdirSync(REPO_ROOT, { withFileTypes: true })
+    .filter(stack => stack.isDirectory())
+    .flatMap(stack =>
+      ["copy-overwrite", "copy-contents"].map(lane =>
+        path.join(REPO_ROOT, stack.name, lane, "scripts")
+      )
+    )
+    .filter(dir => existsSync(dir));
+}
+
+/**
+ * Every `.mjs` script any stack delivers into a host's `scripts/` directory.
+ * @returns Script basenames, sorted.
+ */
+function shippedScripts(): string[] {
+  const found = scriptDirs().flatMap(dir =>
+    readdirSync(dir).filter(entry => entry.endsWith(".mjs"))
+  );
+  return [...new Set(found)].toSorted((a, b) => a.localeCompare(b));
+}
+
+/**
+ * The `scripts/` entries the shipped ignore file declares.
+ * @returns Script basenames named by the ignore file.
+ */
+function ignoredScripts(): string[] {
+  return readFileSync(PRETTIERIGNORE, "utf8")
+    .split("\n")
+    .map(line => line.trim())
+    .filter(line => line.startsWith("scripts/") && line.endsWith(".mjs"))
+    .map(line => line.slice("scripts/".length));
+}
+
+describe("managed scripts are exempt from the host format gate", () => {
+  it("finds the shipped scripts at all", () => {
+    // The absent-case rule. Every assertion below is derived from this list, so
+    // a discovery bug — a renamed delivery directory, a changed lane name —
+    // would make them pass by comparing nothing to nothing. A green run that
+    // measured zero scripts is the failure mode this suite exists to prevent.
+    expect(shippedScripts().length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("exempts every script Lisa ships into scripts/", () => {
+    const ignored = new Set(ignoredScripts());
+    const missing = shippedScripts().filter(name => !ignored.has(name));
+
+    expect(missing).toEqual([]);
+  });
+
+  it("exempts nothing Lisa does not ship", () => {
+    // The mirror, and not redundant: an exemption for a file Lisa no longer
+    // ships silences a HOST file of that name. The list must shrink as well as
+    // grow.
+    const shipped = new Set(shippedScripts());
+    const stale = ignoredScripts().filter(name => !shipped.has(name));
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/typescript/copy-overwrite/.prettierignore
+++ b/typescript/copy-overwrite/.prettierignore
@@ -42,10 +42,47 @@ amplify
 # No-op for projects without an OpenCode mirror.
 .opencode
 
-# Lisa ships scripts/lisa-mutation.mjs as a managed helper, formatted in Lisa's
-# own Prettier style (single quotes). Host projects run varying Prettier configs
-# (commonly the default double-quote style), so the managed script would trip
-# their `prettier --check .` gate through no fault of the host. Keep it out of
-# the format gate. The rails counterpart (scripts/lisa-mutation.sh) is already
-# covered by the *.sh rule above. No-op for projects without it.
+# Lisa ships managed helper scripts into scripts/, formatted in Lisa's own
+# Prettier style. Host projects run varying Prettier configs, so a managed
+# script trips their `prettier --check .` gate through no fault of the host —
+# and reformatting it locally does not help either: copy-overwrite replaces the
+# file on the next `lisa apply`, so the host and Lisa would reformat it against
+# each other forever.
+#
+# This was previously one hand-added line for scripts/lisa-mutation.mjs, added
+# when that file happened to bite someone. Measured 2026-08-19: 13 of the 14
+# other shipped scripts were uncovered, and a consumer's bump went red on
+# scripts/check-e2e-coverage.mjs. Enumerating them one incident at a time means
+# every new managed script reintroduces the same failure. The set is now
+# enumerated in full and a test derives the shipped list and fails when one is
+# missing — or when one is listed that Lisa no longer ships, which would silence
+# a HOST file of that name. Enumerated rather than globbed on purpose:
+# scripts/check-*.mjs would cover every shipped check- script in one line, and
+# would also stop formatting a host'"'"'s own check-something.mjs.
+#
+# The rails counterpart (scripts/lisa-mutation.sh) is already covered by the
+# *.sh rule above. All no-ops for projects without these files.
+scripts/bdd-matrix.mjs
+scripts/check-bdd-coverage.mjs
+scripts/check-e2e-coverage.mjs
+scripts/check-nightly-e2e-health.mjs
+scripts/check-skipped-required-checks.mjs
+scripts/check-state-classification.mjs
+scripts/check-threshold-ratchet.mjs
+scripts/check-verification-coverage.mjs
+scripts/classify-maestro-failures.mjs
+scripts/lisa-command-envelope.mjs
+scripts/lisa-destructive-guard.mjs
+scripts/lisa-environment-prepare.mjs
+scripts/lisa-floor-collisions.mjs
+scripts/lisa-gates.mjs
+scripts/lisa-lint-staged-preflight.mjs
 scripts/lisa-mutation.mjs
+scripts/lisa-postinstall.mjs
+scripts/lisa-reconcile-policy.mjs
+scripts/lisa-run-gates.mjs
+scripts/lisa-schema-validate.mjs
+scripts/lisa-test-node.mjs
+scripts/lisa-work-item.mjs
+scripts/threshold-ratchet-compare.mjs
+scripts/threshold-ratchet-families.mjs


### PR DESCRIPTION
Lisa ships managed helper scripts into a host's `scripts/`, formatted in Lisa's
own Prettier style. Hosts run varying Prettier configs, so a managed script
fails their `prettier --check .` through no fault of theirs — and reformatting
it locally does not help, because copy-overwrite replaces the file on the next
apply and the two then reformat it against each other forever.

The shipped `.prettierignore` carried ONE exemption, `scripts/lisa-mutation.mjs`,
added when that file happened to bite someone. Measured today:

    shipped .mjs scripts into scripts/   24
    exempted                              1
    uncovered                            23

Surfaced when a consumer's version bump went red on Check Formatting against
`scripts/check-e2e-coverage.mjs` — a file Lisa had written into that repo.

A list maintained by incident cannot work here: every new managed script
reintroduces the failure, it surfaces in a consumer's pull request rather than
in Lisa, and the person who hits it has no reason to connect a formatting error
in `scripts/` to a delivery lane.

So the exemption is enumerated in full and a test derives the shipped set from
the delivery directories, failing when one is missing. It asserts the mirror
too — nothing exempted that Lisa no longer ships — because a stale entry
silences a HOST file of that name. And it asserts a floor, so a renamed
delivery directory fails rather than comparing an empty set to an empty set.

ENUMERATED RATHER THAN GLOBBED, deliberately. `scripts/check-*.mjs` would cover
every shipped check- script in one line, and would also stop formatting a host's
own `check-something.mjs`. A host file that silently stops being formatted is a
worse outcome than a managed file that stays formatted.

Bite control: dropping `scripts/check-e2e-coverage.mjs` from the ignore fails

    x exempts every script Lisa ships into scripts/

Restored: 3 passed, 13811 across the full suite.

Work-Item: CodySwannGT/lisa#2748