### PR TITLE
feat(environment): a setup seam before the verbs, at every preparation site

### DIFF
--- a/.github/workflows/environment-prepare.yml
+++ b/.github/workflows/environment-prepare.yml
@@ -81,6 +81,26 @@ on:
         required: false
         default: true
         type: boolean
+      setup_command:
+        description: >-
+          Shell command run after dependencies are installed and BEFORE the
+          facade verbs, in the same job.
+
+          Exists because the target environment is not always a runtime
+          argument. A project may materialise it as a build-time fact — copying
+          a gitignored `.env.local`, exporting a profile — and its
+          `environment:reset` then refuses unless that file agrees with
+          `--env`. That refusal is correct: the underlying sweeper defaults to
+          a real environment when the file is absent, so "no target named" must
+          never be read as "the default one". Without this seam the job checks
+          out, installs, and runs a verb that has no way to know what it is
+          pointed at.
+
+          The direct analogue of `playwright_setup_command`, and needed for the
+          same reason.
+        required: false
+        default: ''
+        type: string
       timeout_minutes:
         description: >-
           Ceiling for this job. Deliberately tight: it gates an entire suite, so
@@ -167,6 +187,12 @@ jobs:
             bun) bun install --frozen-lockfile ;;
             *) echo "::error::unsupported package manager: $PACKAGE_MANAGER"; exit 1 ;;
           esac
+
+      - name: 🔧 Prepare setup command
+        # Runs BEFORE the verbs, after the install — the point at which a
+        # build-time environment selection can still be materialised.
+        if: ${{ inputs.setup_command != '' }}
+        run: ${{ inputs.setup_command }}
 
       - name: 🧼 Prepare the environment
         env:

--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -382,6 +382,26 @@ on:
         required: false
         default: true
         type: boolean
+      prepare_setup_command:
+        description: >-
+          Shell command run after dependencies are installed and BEFORE the
+          facade verbs, in the same job.
+
+          Exists because the target environment is not always a runtime
+          argument. A project may materialise it as a build-time fact — copying
+          a gitignored `.env.local`, exporting a profile — and its
+          `environment:reset` then refuses unless that file agrees with
+          `--env`. That refusal is correct: the underlying sweeper defaults to
+          a real environment when the file is absent, so "no target named" must
+          never be read as "the default one". Without this seam the job checks
+          out, installs, and runs a verb that has no way to know what it is
+          pointed at.
+
+          The direct analogue of `playwright_setup_command`, and needed for the
+          same reason.
+        required: false
+        default: ''
+        type: string
       prepare_timeout_minutes:
         description: >-
           Ceiling for the between-legs preparation job. Tight on purpose: it
@@ -1065,6 +1085,12 @@ jobs:
               ;;
           esac
 
+      - name: 🔧 Prepare setup command
+        # Runs BEFORE the verbs, after the install — the point at which a
+        # build-time environment selection can still be materialised.
+        if: ${{ inputs.prepare_environment != '' && inputs.prepare_setup_command != '' }}
+        run: ${{ inputs.prepare_setup_command }}
+
       - name: 🧼 Prepare the environment
         # Runs BEFORE pre_suite_command, deliberately. Preparation returns the
         # environment to a known state; a project's own command then layers
@@ -1517,6 +1543,12 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: 🔧 Prepare setup command
+        # Runs BEFORE the verbs, after the install — the point at which a
+        # build-time environment selection can still be materialised.
+        if: ${{ inputs.prepare_environment != '' && inputs.prepare_between_legs && inputs.serialize_platform_legs && needs.preflight.outputs.run_ios == 'true' && needs.preflight.outputs.run_android == 'true' && needs.leg_order.result == 'success' && inputs.prepare_setup_command != '' }}
+        run: ${{ inputs.prepare_setup_command }}
 
       - name: 🧼 Prepare the environment for the Android leg
         if: ${{ inputs.prepare_environment != '' && inputs.prepare_between_legs && inputs.serialize_platform_legs && needs.preflight.outputs.run_ios == 'true' && needs.preflight.outputs.run_android == 'true' && needs.leg_order.result == 'success' }}

--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -121,6 +121,26 @@ on:
         required: false
         default: reset,reseed
         type: string
+      prepare_setup_command:
+        description: >-
+          Shell command run after dependencies are installed and BEFORE the
+          facade verbs, in the same job.
+
+          Exists because the target environment is not always a runtime
+          argument. A project may materialise it as a build-time fact — copying
+          a gitignored `.env.local`, exporting a profile — and its
+          `environment:reset` then refuses unless that file agrees with
+          `--env`. That refusal is correct: the underlying sweeper defaults to
+          a real environment when the file is absent, so "no target named" must
+          never be read as "the default one". Without this seam the job checks
+          out, installs, and runs a verb that has no way to know what it is
+          pointed at.
+
+          The direct analogue of `playwright_setup_command`, and needed for the
+          same reason.
+        required: false
+        default: ''
+        type: string
       prepare_timeout_minutes:
         description: >-
           Ceiling for the preparation job. Tight on purpose: it gates the whole
@@ -200,6 +220,12 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: 🔧 Prepare setup command
+        # Runs BEFORE the verbs, after the install — the point at which a
+        # build-time environment selection can still be materialised.
+        if: ${{ inputs.prepare_environment != '' && inputs.prepare_setup_command != '' }}
+        run: ${{ inputs.prepare_setup_command }}
 
       - name: 🧼 Prepare the environment
         if: ${{ inputs.prepare_environment != '' }}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8725,6 +8725,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/oxlint-worktree-resolution.test.ts": true,
     "tests/integration/playwright-caller-template.test.ts": true,
     "tests/integration/playwright-e2e-workflow.test.ts": true,
+    "tests/integration/prepare-setup-command.test.ts": true,
     "tests/integration/quality-gate-e2e-browser.test.ts": true,
     "tests/integration/quality-gate-facade-fixture.ts": true,
     "tests/integration/quality-gate-facade.test.ts": true,

--- a/tests/integration/prepare-setup-command.test.ts
+++ b/tests/integration/prepare-setup-command.test.ts
@@ -1,0 +1,120 @@
+/**
+ * The environment-preparation setup seam runs BEFORE the verbs, everywhere.
+ *
+ * Why the seam exists: the target environment is not always a runtime argument.
+ * A project may materialise it as a build-time fact — copying a gitignored
+ * `.env.local`, exporting a profile — and its `environment:reset` then refuses
+ * unless that file agrees with `--env`. The refusal is correct: the sweeper
+ * underneath defaults to a real environment when the file is absent, so "no
+ * target named" must never resolve to "the default one". Without a seam, the
+ * job checks out, installs, and runs a verb that cannot know what it is aimed
+ * at — so the repo ships a preparation that can only fail.
+ *
+ * Why ORDER is the thing asserted: a setup command placed after the verbs is
+ * not a smaller version of this feature, it is a no-op that looks like the
+ * feature. It would run, succeed, and change nothing, and the failure it was
+ * added to prevent would still happen — with a configured input sitting in the
+ * caller implying otherwise.
+ *
+ * All four preparation sites are covered together, because the seam is only
+ * useful if it exists at every one. A caller that sets it and silently gets it
+ * at three of four is worse than not having it.
+ * @module tests/integration/prepare-setup-command
+ */
+
+import yaml from "js-yaml";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const WORKFLOWS = path.resolve(__dirname, "..", "..", ".github", "workflows");
+
+const MAESTRO = "maestro-native-e2e.yml";
+
+/** Every job that prepares an environment, and the workflow it lives in. */
+const PREPARE_SITES = [
+  ["environment-prepare.yml", "prepare"],
+  ["playwright-e2e.yml", "prepare"],
+  [MAESTRO, "pre_suite"],
+  [MAESTRO, "inter_leg_prepare"],
+] as const;
+
+const SETUP_STEP = "Prepare setup command";
+const VERB_STEP = "🧼 Prepare the environment";
+
+/**
+ * The step names of one job.
+ * @param file Workflow filename.
+ * @param job Job key.
+ * @returns Ordered step names.
+ */
+function stepNames(file: string, job: string): string[] {
+  const doc = yaml.load(readFileSync(path.join(WORKFLOWS, file), "utf8")) as {
+    jobs: Record<string, { steps: { name: string }[] }>;
+  };
+  return doc.jobs[job].steps.map(step => step.name);
+}
+
+describe("the preparation setup seam", () => {
+  it.each(PREPARE_SITES.map(site => [`${site[0]}:${site[1]}`, ...site]))(
+    "%s runs the setup command before the verbs",
+    (_label, file, job) => {
+      const names = stepNames(file, job);
+      const setupAt = names.findIndex(name => name.includes(SETUP_STEP));
+      const verbAt = names.findIndex(name => name.startsWith(VERB_STEP));
+
+      // Both must exist. A missing verb step would make the ordering assertion
+      // pass vacuously against -1.
+      expect(setupAt).toBeGreaterThanOrEqual(0);
+      expect(verbAt).toBeGreaterThanOrEqual(0);
+      expect(setupAt).toBeLessThan(verbAt);
+    }
+  );
+
+  it.each(PREPARE_SITES.map(site => [`${site[0]}:${site[1]}`, ...site]))(
+    "%s runs the setup command after dependencies are installed",
+    (_label, file, job) => {
+      // The command frequently needs the project's own tooling. Placing it
+      // before the install would make the common case fail for a reason that
+      // has nothing to do with what it is trying to do.
+      const names = stepNames(file, job);
+      const installAt = names.findIndex(name => name.includes("Install"));
+      const setupAt = names.findIndex(name => name.includes(SETUP_STEP));
+
+      expect(installAt).toBeGreaterThanOrEqual(0);
+      expect(setupAt).toBeGreaterThan(installAt);
+    }
+  );
+
+  it("covers every preparation site the workflows declare", () => {
+    // The absent-case rule. If a new preparation site is added and not listed
+    // here, every assertion above still passes while the new site has no
+    // coverage at all. This fails instead.
+    const declared = new Set(
+      PREPARE_SITES.map(([file, job]) => `${file}:${job}`)
+    );
+    const found = new Set<string>();
+
+    for (const file of [
+      "environment-prepare.yml",
+      "playwright-e2e.yml",
+      MAESTRO,
+    ]) {
+      const doc = yaml.load(
+        readFileSync(path.join(WORKFLOWS, file), "utf8")
+      ) as {
+        jobs: Record<string, { steps?: { name: string }[] }>;
+      };
+      for (const [job, body] of Object.entries(doc.jobs)) {
+        if ((body.steps ?? []).some(step => step.name?.startsWith(VERB_STEP))) {
+          found.add(`${file}:${job}`);
+        }
+      }
+    }
+
+    const byName = (a: string, b: string) => a.localeCompare(b);
+    expect([...found].toSorted(byName)).toEqual([...declared].toSorted(byName));
+  });
+});


### PR DESCRIPTION
The environment verbs ran with nowhere to select the target first, so a project
whose environment is a BUILD-TIME fact could not use `prepare_environment` at
all. The job checked out, installed, and ran a verb that had no way to know what
it was aimed at.

Measured on a consumer: its `environment:reset` refuses unless a gitignored
`.env.local` selects an `EXPO_PUBLIC_ENV` agreeing with `--env`. That file is
not tracked, and the prepare job never wrote it.

The refusal is correct and stays. The sweeper underneath defaults to a real
environment when the file is absent, so "no target named" must never be read as
"the default one" — the same fail-closed property the rest of this facade has.
Which left the caller wired correctly, the verb behaving correctly, and the run
able only to fail, because there was nowhere to put the one command that would
have made it work.

So: `setup_command` on `environment-prepare.yml`, `prepare_setup_command` on the
two suite workflows, run after the install and before the verbs, at all four
preparation sites — `prepare`, `prepare`, `pre_suite`, `inter_leg_prepare`. The
direct analogue of `playwright_setup_command`, needed for the same reason.

ORDER IS THE WHOLE FEATURE. A setup command placed after the verbs is not a
smaller version of this; it is a no-op that looks like the feature. It would
run, succeed, change nothing, and the failure it exists to prevent would still
happen — with a configured input in the caller implying otherwise. So the test
asserts the ORDER rather than the presence, at every site, and separately that
it lands after the install (the command usually needs the project's tooling).

ALL FOUR SITES OR NONE. A caller that sets the input and silently gets it at
three of four is worse off than one that never had it, so a third test derives
the preparation sites from the workflows and fails when one is not covered —
adding a fifth site without the seam is caught here rather than by whoever
configures it.

Bite control: moving the seam after the verb in one workflow fails

    x environment-prepare.yml:prepare runs the setup command before the verbs

Restored: 9 passed, 13820 across the full suite.

Work-Item: CodySwannGT/lisa#2752