### PR TITLE
docs(nightly-e2e): a rename deadlocks only where the context is required

### DIFF
--- a/.github/workflows/nightly-e2e-health.yml
+++ b/.github/workflows/nightly-e2e-health.yml
@@ -260,13 +260,31 @@ permissions:
   pull-requests: read
 
 jobs:
-  # This job's name is HALF of the required status-check context. GitHub composes
-  # the check-run name as `<caller job name> / <this job name>`, and the ruleset
-  # must require that composite string byte for byte, emoji included. Rename
-  # either half alone and GitHub waits forever for a context nobody reports —
-  # which does not de-gate the branch, it DEADLOCKS every PR into it.
+  # This job's name is HALF of the status-check context. GitHub composes the
+  # check-run name as `<caller job name> / <this job name>`, and a ruleset that
+  # requires it must name that composite string byte for byte, emoji included.
   # `tests/integration/nightly-e2e-health-workflow.test.ts` pins this name, the
   # caller template's job name, and the ruleset's `context` against each other.
+  #
+  # RENAMING EITHER HALF FAILS TWO DIFFERENT WAYS, and which one you get depends
+  # on something not visible from this file — whether a ruleset actually
+  # requires the context. Both are bad; only one is loud.
+  #
+  #   required      GitHub waits forever for a context nobody reports. That does
+  #                 not de-gate the branch, it DEADLOCKS every PR into it.
+  #   NOT required  the gate silently stops reporting and nothing blocks. The
+  #                 branch is now ungated while everyone reads the workflow and
+  #                 believes otherwise.
+  #
+  # Do not assume the first. Measured on a consumer 2026-08-19: ZERO of that
+  # repository's 20 required contexts, across two rulesets, matched /nightly/i,
+  # while its workflows described the gate as blocking. Check before asserting:
+  #
+  #   gh api repos/<owner>/<repo>/rulesets --jq '.[].id' | while read id; do
+  #     gh api repos/<owner>/<repo>/rulesets/$id \
+  #       --jq '.rules[]?|select(.type=="required_status_checks")
+  #             |.parameters.required_status_checks[]?.context'
+  #   done
   gate:
     name: 🌙 Gate
     runs-on: ubuntu-latest

--- a/expo/create-only/.github/workflows/nightly-e2e-health.yml
+++ b/expo/create-only/.github/workflows/nightly-e2e-health.yml
@@ -87,9 +87,19 @@ concurrency:
 jobs:
   # This job's `name:` is HALF of the required status-check context; the other
   # half is the reusable's job name (`🌙 Gate`). GitHub composes them as
-  # `🌙 Nightly E2E Health / 🌙 Gate`. Renaming either half silently stops the
-  # gate reporting, which DEADLOCKS every PR into the protected branch until
-  # someone edits the ruleset. Pin both strings in a test.
+  # `🌙 Nightly E2E Health / 🌙 Gate`. Pin both strings in a test.
+  #
+  # Renaming either half fails two different ways, and which one you get depends
+  # on whether a ruleset actually requires that context — which this file cannot
+  # see. If it IS required, the context is never reported and every PR into the
+  # protected branch DEADLOCKS until someone edits the ruleset. If it is NOT,
+  # the gate silently stops reporting and nothing blocks at all, leaving the
+  # branch ungated while this file still reads as though it were gated.
+  #
+  # Do not assume the first. Measured on a consumer 2026-08-19: zero of its 20
+  # required contexts matched /nightly/i while its workflows described the gate
+  # as blocking. Verify with `gh api repos/<owner>/<repo>/rulesets` before
+  # describing this context as required anywhere.
   health:
     name: 🌙 Nightly E2E Health
     # PIN AN IMMUTABLE REF. `@main` is not a supported pin for a merge gate: the

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -235,7 +235,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/create-only/.github/workflows/nightly-e2e-bypass-reaper.yml":
       "db78a1012a00cf4e8b023a67bb57566ae85cf790c3856f3e299636c766f0c242",
     "expo/create-only/.github/workflows/nightly-e2e-health.yml":
-      "e703c02a5d4359674dd8bbc98f1699585dec61024eb176ef11a314590c2a4fca",
+      "bdade3ffa508c43e2c04c8942a68b74225907a8aad830e7bffb87fe8354e0ed9",
     "expo/create-only/.github/workflows/nightly-e2e-report.yml":
       "a3eeeeeab2956e59ae1fd143b30bedcb0bb7180bc9e6a87aab3c8c1467bbc2ec",
     "expo/create-only/.github/workflows/playwright-e2e.yml":


### PR DESCRIPTION
Both the reusable and the seeded caller told the reader that renaming either
half of the gate's check-name DEADLOCKS every PR. That is true only where a
ruleset actually requires the context — something neither file can see, and
neither mentioned.

Where it is not required the failure is the opposite, and quieter:

    required      the context is never reported; every PR deadlocks.  Loud.
    NOT required  the gate silently stops reporting and nothing blocks.
                  The branch is ungated while the file still reads as gated.

The shipped text named only the loud one, so a reader renaming a job on a repo
without the requirement gets the silent failure having just been told the
failure mode is unmissable.

Measured on a consumer: 20 required contexts across two rulesets, ZERO matching
/nightly/i, while its workflows described the gate as blocking. Both pull
requests in that repo's migration merged with both nightly contexts red — direct
evidence it is advisory there today.

That repo's OLDER gate file already carried the correct caveat, in as many
words. Someone had found this and fixed it locally, and Lisa's newer caller
reintroduced the claim — so the two now contradict each other about the same
context name in the same repository.

Same defect class the nightly gate exists to catch: a control describing a
boundary it does not have. The assertion is what stops anyone re-checking it,
so the fix states the condition, names both failure modes, and ships the API
call that settles the question.

Found by an agent that then CORRECTED ITSELF twice unprompted — first on the
count (20, not the 21 I had repeated back), then on the scope, having initially
reported both files as wrong before reading far enough to find the older one
already fixed. The narrower finding is the more useful one.

Work-Item: CodySwannGT/lisa#2757