### PR TITLE
fix(bootstrap): resolve minimatch lazily via CJS so a CVE pin cannot brick the CLI

### DIFF
--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -9467,6 +9467,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/utils/directory-sync.test.ts": true,
     "tests/unit/utils/fibonacci.test.ts": true,
     "tests/unit/utils/file-operations.test.ts": true,
+    "tests/unit/utils/ignore-patterns-bootstrap.test.ts": true,
     "tests/unit/utils/ignore-patterns.test.ts": true,
     "tests/unit/utils/json-merge.property.test.ts": true,
     "tests/unit/utils/json-utils.test.ts": true,

--- a/src/utils/ignore-patterns.ts
+++ b/src/utils/ignore-patterns.ts
@@ -1,38 +1,77 @@
 import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
 import * as path from "node:path";
-// minimatch v9+ exposes the matcher as a named ESM export. Keep the legacy
-// default fallback so Lisa still runs in projects whose package manager hoists
-// an older CJS minimatch for another tool.
-import * as minimatchModule from "minimatch";
 import { pathExists } from "./file-operations.js";
 
-/**
- * Resolve the minimatch predicate across v9+ named exports and legacy CJS
- * default exports. Throws if neither is available so callers see a clear error
- * instead of "undefined is not a function" at match time.
- */
-const minimatchFn: (
+/** The matcher signature Lisa uses. */
+type MinimatchFn = (
   p: string,
   pattern: string,
   options?: { readonly dot?: boolean }
-) => boolean = (() => {
-  const mod = minimatchModule as unknown as {
+) => boolean;
+
+const requireFromHere = createRequire(import.meta.url);
+
+/**
+ * Resolve the minimatch predicate, via CJS, on first use.
+ *
+ * Three deliberate choices, each fixing something the previous shape got wrong.
+ *
+ * **CJS, not ESM.** `minimatch@10`'s ESM entry opens with
+ * `import { expand } from 'brace-expansion'`, which throws at MODULE LOAD in any
+ * project whose tree resolves `brace-expansion` to the 2.x line — a very common
+ * CVE remediation (`">=2.1.4 <3"`), since 2.x is CJS and exports no named
+ * `expand`. Its CJS entry has no such problem. Measured on a real consumer:
+ * `import('minimatch')` threw while `require('minimatch')` returned a working
+ * function, same package, same version, same tree.
+ *
+ * **Lazily, not at module load.** The previous version resolved this eagerly
+ * behind a static `import`, and that is what made the failure fatal: Lisa's own
+ * CLI could not boot, so `lisa apply` could not run — and `lisa apply` is what
+ * writes the `brace-expansion` override that fixes the tree. The remedy shipped
+ * inside the thing that could not start. Resolving on first use breaks that
+ * deadlock: the CLI boots, `doctor` reports, and apply repairs the override.
+ *
+ * **The old compatibility shim was unreachable.** Its comment said it existed
+ * so "Lisa still runs in projects whose package manager hoists an older CJS
+ * minimatch" — but a static ESM import fails before any fallback can be
+ * consulted. A guard that cannot fire is not a guard.
+ * @returns The matcher.
+ */
+const loadMinimatch = (): MinimatchFn => {
+  const mod = requireFromHere("minimatch") as {
     readonly default?: unknown;
     readonly minimatch?: unknown;
   };
   const candidate =
-    typeof mod.default === "function" ? mod.default : mod.minimatch;
+    typeof mod.minimatch === "function"
+      ? mod.minimatch
+      : typeof mod.default === "function"
+        ? mod.default
+        : mod;
   if (typeof candidate !== "function") {
     throw new TypeError(
-      "minimatch module did not expose a callable export; expected v9+ named export or legacy default"
+      "minimatch did not expose a callable export; expected a named `minimatch`, a default, or a callable module"
     );
   }
-  return candidate as (
-    p: string,
-    pattern: string,
-    options?: { readonly dot?: boolean }
-  ) => boolean;
-})();
+  return candidate as MinimatchFn;
+};
+
+/**
+ * The matcher, resolved on each call.
+ *
+ * No memoisation, and that is not an oversight. Node's `require` cache already
+ * makes every call after the first a map lookup, so a hand-rolled cache would
+ * duplicate the module system's own work — and every shape it could take here
+ * (a reassignable binding, a mutated holder) is forbidden by this codebase's
+ * immutability rules for reasons that are worth more than the nanoseconds.
+ * @param p Path to test.
+ * @param pattern Glob pattern.
+ * @param options Match options.
+ * @returns Whether the path matches.
+ */
+const minimatchFn: MinimatchFn = (p, pattern, options) =>
+  loadMinimatch()(p, pattern, options);
 
 /**
  * Name of the ignore file that projects can use to skip Lisa files

--- a/tests/unit/utils/ignore-patterns-bootstrap.test.ts
+++ b/tests/unit/utils/ignore-patterns-bootstrap.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Lisa must boot in a project whose tree breaks minimatch's ESM entry.
+ *
+ * `minimatch@10`'s ESM entry opens with `import { expand } from
+ * 'brace-expansion'`. Any project resolving `brace-expansion` to the 2.x line
+ * — a very common CVE remediation, since `">=2.1.4 <3"` pins a patched 2.x —
+ * gets a CJS module with no named `expand`, and that import throws at MODULE
+ * LOAD.
+ *
+ * Measured on a real consumer, same package, same version, same tree:
+ *
+ *     import('minimatch')   SyntaxError: Named export 'expand' not found
+ *     require('minimatch')  returns a working function
+ *
+ * ## Why this was fatal rather than annoying
+ *
+ * The failure took out Lisa's entire CLI, so `lisa apply` could not run — and
+ * `lisa apply` is what removes the offending override. The remedy shipped
+ * inside the thing that could not start. A consumer in that state could not
+ * self-heal by upgrading, because upgrading is what was broken.
+ *
+ * ## Why the existing shim did not save it
+ *
+ * `ignore-patterns.ts` already carried a compatibility shim, whose comment said
+ * it existed so "Lisa still runs in projects whose package manager hoists an
+ * older CJS minimatch for another tool". It was unreachable: a static ESM
+ * import fails before any fallback can be consulted. A guard that cannot fire
+ * is not a guard.
+ *
+ * ## What these tests can and cannot prove
+ *
+ * The behavioural half — that matching still works — is covered by
+ * `ignore-patterns.test.ts` and is not repeated here.
+ *
+ * The bootstrap half is asserted against the SOURCE, deliberately. Simulating a
+ * broken `brace-expansion` in-process is not possible without corrupting this
+ * repository's own `node_modules`, and `createRequire` resolves from Lisa's
+ * installed location rather than the caller's, so a temporary fixture tree
+ * would not be on the resolution path. The source assertions pin the two
+ * properties that actually failed: the import is not static, and resolution
+ * goes through CJS.
+ * @module tests/unit/utils/ignore-patterns-bootstrap
+ */
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { matchesAnyPattern } from "../../../src/utils/ignore-patterns.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "src",
+  "utils",
+  "ignore-patterns.ts"
+);
+
+const source = (): string => readFileSync(SOURCE, "utf8");
+
+describe("minimatch is not resolved at module load", () => {
+  it("has no static import of minimatch", () => {
+    // The exact regression. A static `import … from "minimatch"` executes when
+    // this module loads, which is before any fallback can run — and takes the
+    // whole CLI with it in a project whose tree breaks minimatch's ESM entry.
+    // Line-based rather than one regex: a pattern combining `\s` with a
+    // greedy `[^\n]*` backtracks super-linearly, and a lint rule rejects it.
+    const staticImports = source()
+      .split("\n")
+      .filter(line => line.trimStart().startsWith("import "))
+      .filter(line => line.includes('"minimatch"'));
+
+    expect(staticImports).toEqual([]);
+  });
+
+  it("resolves through CJS rather than a dynamic ESM import", () => {
+    // `await import("minimatch")` would be lazy but would still hit the ESM
+    // entry, which is the half that throws. CJS is what actually works in the
+    // broken tree.
+    expect(source()).toMatch(/createRequire/u);
+    expect(source()).toMatch(/requireFromHere\(\s*["']minimatch["']\s*\)/u);
+  });
+
+  it("resolves on first use, not at module scope", () => {
+    // A top-level `const x = requireFromHere("minimatch")` would reintroduce the
+    // eager failure with a different import style. The call must sit inside a
+    // function.
+    expect(source()).toMatch(/const loadMinimatch = \(\)[^\n]*=>/u);
+  });
+});
+
+describe("the matcher still works", () => {
+  it("matches through the lazily-resolved implementation", () => {
+    // The positive control for all three assertions above: they are satisfied
+    // by deleting minimatch entirely, so something must prove the matcher is
+    // real and reachable.
+    expect(
+      matchesAnyPattern("src/generated/api.ts", ["src/generated/**"])
+    ).toBe(true);
+    expect(matchesAnyPattern("src/index.ts", ["src/generated/**"])).toBe(false);
+  });
+});


### PR DESCRIPTION
Found on the first real end-to-end upgrade of a downstream project
(3.42.0 -> 3.45.1). The upgrade failed before doing anything:

    import { expand } from 'brace-expansion';
             ^^^^^^
    SyntaxError: Named export 'expand' not found. The requested module
    'brace-expansion' is a CommonJS module...

    lisa: TEMPLATE APPLY FAILED - this project is NOT receiving Lisa template
    or guardrail updates.

The chain:

    consumer pins   brace-expansion  ">=2.1.4 <3"   (patched 2.x — a normal CVE fix)
    Lisa depends on minimatch        "^10.2.5"
    minimatch@10    needs            brace-expansion ^5  (for the ESM named `expand`)
    installed       resolves         brace-expansion@2.1.4  (CJS, no named exports)

## Why this is a deadlock rather than a failure

Lisa's own template ALREADY carries the fix — `force.overrides` sets
`brace-expansion: ">=5.0.9"`, and applying it removes the offending pin
outright. But `lisa apply` is what writes that, and `lisa apply` could not run.
The remedy shipped inside the thing that could not start, so the consumer could
not self-heal by upgrading, because upgrading was what was broken. Every install
reported success while the project received nothing.

## The existing shim could never have fired

The same file already had a compatibility shim, whose own comment said it
existed so "Lisa still runs in projects whose package manager hoists an older
CJS minimatch for another tool". It was unreachable: a static ESM import throws
before any fallback is consulted, so the module never loaded far enough for the
shim to matter. A guard that cannot fire is not a guard.

## The fix

Measured in the broken tree — same package, same version, same node_modules:

    import('minimatch')    SyntaxError: Named export 'expand' not found
    require('minimatch')   returns a working function

minimatch@10's CJS entry does not use the ESM named import. Resolving through
`createRequire`, on first use rather than at module load, fixes the bootstrap
without touching matching semantics: same minimatch, same version, other entry
point.

Lazy as well as CJS, deliberately. A top-level `require` would fix this exact
tree and reintroduce the same fatality the next time any transitive import
breaks. Resolving on first use means the CLI boots, `doctor` reports, and apply
repairs the tree even when the matcher itself cannot load.

No memoisation: Node's require cache already makes every call after the first a
map lookup, and each shape a hand-rolled cache could take here (a reassignable
binding, a mutated holder) is refused by this codebase's immutability rules.
Duplicating the module system's own caching to satisfy a micro-optimisation
would have been the worse trade.

## Verified end to end against the real consumer

    shipped 3.45.1   --version    ->  SyntaxError, dies
    patched build    --version    ->  3.45.1
    patched build    lisa apply   ->  exit 0
                     override     ->  REMOVED
                     lockfiles    ->  synced
    after reinstall  brace-expansion  ->  5.0.9
                     import('minimatch')  ->  OK
                     shipped 3.45.1 --version  ->  3.45.1

One successful run repairs the tree permanently; afterwards even the unpatched
Lisa boots.

## Bite control

Restoring the static import fails

    x has no static import of minimatch

Restored: 23 passed, 13824 across the full suite.

The bootstrap half is asserted against the SOURCE, and the test says why:
simulating a broken brace-expansion in-process would mean corrupting this
repository's own node_modules, and `createRequire` resolves from Lisa's
installed location rather than the caller's, so a fixture tree would not sit on
the resolution path. The behavioural half is the existing 19 tests plus a
positive control, because all three source assertions are satisfied by deleting
minimatch entirely.

Work-Item: CodySwannGT/lisa#2759