### PR TITLE
fix(hooks): write a jira-cli config only when the tracker is jira

### DIFF
--- a/plugins/lisa-agy/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-analyze-claude-remote/SKILL.md
@@ -28,7 +28,7 @@ This skill ships in the base Lisa plugin and is distributed to every host projec
 discover requirements **dynamically from the repo** rather than assuming Lisa-repo specifics. It
 audits two layers together:
 
-- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh`, rule injection),
+- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh` — tracker-gated, rule injection),
   the configured `tracker`/`source`, and the CLIs/MCP/env those imply.
 - **The host project's needs** — its own package manager, build/test tooling, app runtime
   dependencies, CI-assumed binaries, and project-scoped MCP servers.
@@ -71,7 +71,9 @@ Group the findings as:
    runs, whether it is headless-safe, whether it needs network or write access to system paths,
    and whether it fits the cloud setup-script time budget (~5 minutes for environment caching;
    `SessionStart` hooks re-run every session and must be fast). Lisa's `install-pkgs.sh` and
-   `setup-jira-cli.sh` are the usual headline items.
+   `setup-jira-cli.sh` are the usual headline items. Note that `setup-jira-cli.sh` is gated on
+   `tracker: "jira"` — on a project using another tracker it exits immediately and needs no
+   environment at all, so do not report its JIRA env vars as required there.
 
 3. **External CLIs / binaries** — scan hooks, `scripts/`, committed skills/commands, and
    `.github/workflows/` for invoked binaries that a base cloud image likely lacks. Assume node,
@@ -256,7 +258,7 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
-- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart.)
+- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart — but only when `.lisa.config*.json` sets `tracker: "jira"`; on any other tracker the hook is a no-op.)
 - Acquire: `https://id.atlassian.com/manage-profile/security/api-tokens`.
 - Access: the API token inherits the Atlassian user's permissions — the user must have Browse/Create/Edit/Transition on the target project. An unscoped token suffices for jira-cli; a scoped token must cover the JIRA project read/write operations.
 

--- a/plugins/lisa-copilot/hooks/setup-jira-cli.sh
+++ b/plugins/lisa-copilot/hooks/setup-jira-cli.sh
@@ -3,6 +3,13 @@
 # Writes the JIRA CLI config file from environment variables.
 # Runs on SessionStart so the config is available for every session.
 #
+# Gated on the project's configured tracker: this only writes anything when
+# `.lisa.config*.json` declares `tracker: "jira"`. A project on Linear or GitHub
+# Issues has no use for a jira-cli config, and writing one made a false implicit
+# claim about which tracker the project runs on. The gate fails closed — an
+# unreadable or absent tracker writes nothing — because Lisa treats a missing
+# `tracker` as unconfigured rather than as a jira default (see lisa-tracker-read).
+#
 # Required env vars (must be created in your Claude Code Web environment):
 #   JIRA_INSTALLATION - cloud or local
 #   JIRA_SERVER       - Atlassian instance URL (falls back to .lisa.config*.json atlassian.site)
@@ -41,6 +48,11 @@ read_lisa_config() {
 
   printf '%s' "${value}"
 }
+
+# Tracker gate: do nothing unless this project actually runs on JIRA.
+if [[ "$(read_lisa_config '.tracker')" != "jira" ]]; then
+  exit 0
+fi
 
 if [[ -z "${JIRA_SERVER:-}" ]]; then
   ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"

--- a/plugins/lisa-copilot/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-analyze-claude-remote/SKILL.md
@@ -28,7 +28,7 @@ This skill ships in the base Lisa plugin and is distributed to every host projec
 discover requirements **dynamically from the repo** rather than assuming Lisa-repo specifics. It
 audits two layers together:
 
-- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh`, rule injection),
+- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh` — tracker-gated, rule injection),
   the configured `tracker`/`source`, and the CLIs/MCP/env those imply.
 - **The host project's needs** — its own package manager, build/test tooling, app runtime
   dependencies, CI-assumed binaries, and project-scoped MCP servers.
@@ -71,7 +71,9 @@ Group the findings as:
    runs, whether it is headless-safe, whether it needs network or write access to system paths,
    and whether it fits the cloud setup-script time budget (~5 minutes for environment caching;
    `SessionStart` hooks re-run every session and must be fast). Lisa's `install-pkgs.sh` and
-   `setup-jira-cli.sh` are the usual headline items.
+   `setup-jira-cli.sh` are the usual headline items. Note that `setup-jira-cli.sh` is gated on
+   `tracker: "jira"` — on a project using another tracker it exits immediately and needs no
+   environment at all, so do not report its JIRA env vars as required there.
 
 3. **External CLIs / binaries** — scan hooks, `scripts/`, committed skills/commands, and
    `.github/workflows/` for invoked binaries that a base cloud image likely lacks. Assume node,
@@ -256,7 +258,7 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
-- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart.)
+- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart — but only when `.lisa.config*.json` sets `tracker: "jira"`; on any other tracker the hook is a no-op.)
 - Acquire: `https://id.atlassian.com/manage-profile/security/api-tokens`.
 - Access: the API token inherits the Atlassian user's permissions — the user must have Browse/Create/Edit/Transition on the target project. An unscoped token suffices for jira-cli; a scoped token must cover the JIRA project read/write operations.
 

--- a/plugins/lisa-cursor/hooks/setup-jira-cli.sh
+++ b/plugins/lisa-cursor/hooks/setup-jira-cli.sh
@@ -3,6 +3,13 @@
 # Writes the JIRA CLI config file from environment variables.
 # Runs on SessionStart so the config is available for every session.
 #
+# Gated on the project's configured tracker: this only writes anything when
+# `.lisa.config*.json` declares `tracker: "jira"`. A project on Linear or GitHub
+# Issues has no use for a jira-cli config, and writing one made a false implicit
+# claim about which tracker the project runs on. The gate fails closed — an
+# unreadable or absent tracker writes nothing — because Lisa treats a missing
+# `tracker` as unconfigured rather than as a jira default (see lisa-tracker-read).
+#
 # Required env vars (must be created in your Claude Code Web environment):
 #   JIRA_INSTALLATION - cloud or local
 #   JIRA_SERVER       - Atlassian instance URL (falls back to .lisa.config*.json atlassian.site)
@@ -41,6 +48,11 @@ read_lisa_config() {
 
   printf '%s' "${value}"
 }
+
+# Tracker gate: do nothing unless this project actually runs on JIRA.
+if [[ "$(read_lisa_config '.tracker')" != "jira" ]]; then
+  exit 0
+fi
 
 if [[ -z "${JIRA_SERVER:-}" ]]; then
   ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"

--- a/plugins/lisa-cursor/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-analyze-claude-remote/SKILL.md
@@ -28,7 +28,7 @@ This skill ships in the base Lisa plugin and is distributed to every host projec
 discover requirements **dynamically from the repo** rather than assuming Lisa-repo specifics. It
 audits two layers together:
 
-- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh`, rule injection),
+- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh` — tracker-gated, rule injection),
   the configured `tracker`/`source`, and the CLIs/MCP/env those imply.
 - **The host project's needs** — its own package manager, build/test tooling, app runtime
   dependencies, CI-assumed binaries, and project-scoped MCP servers.
@@ -71,7 +71,9 @@ Group the findings as:
    runs, whether it is headless-safe, whether it needs network or write access to system paths,
    and whether it fits the cloud setup-script time budget (~5 minutes for environment caching;
    `SessionStart` hooks re-run every session and must be fast). Lisa's `install-pkgs.sh` and
-   `setup-jira-cli.sh` are the usual headline items.
+   `setup-jira-cli.sh` are the usual headline items. Note that `setup-jira-cli.sh` is gated on
+   `tracker: "jira"` — on a project using another tracker it exits immediately and needs no
+   environment at all, so do not report its JIRA env vars as required there.
 
 3. **External CLIs / binaries** — scan hooks, `scripts/`, committed skills/commands, and
    `.github/workflows/` for invoked binaries that a base cloud image likely lacks. Assume node,
@@ -256,7 +258,7 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
-- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart.)
+- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart — but only when `.lisa.config*.json` sets `tracker: "jira"`; on any other tracker the hook is a no-op.)
 - Acquire: `https://id.atlassian.com/manage-profile/security/api-tokens`.
 - Access: the API token inherits the Atlassian user's permissions — the user must have Browse/Create/Edit/Transition on the target project. An unscoped token suffices for jira-cli; a scoped token must cover the JIRA project read/write operations.
 

--- a/plugins/lisa/.codex-plugin/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-analyze-claude-remote/SKILL.md
@@ -28,7 +28,7 @@ This skill ships in the base Lisa plugin and is distributed to every host projec
 discover requirements **dynamically from the repo** rather than assuming Lisa-repo specifics. It
 audits two layers together:
 
-- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh`, rule injection),
+- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh` — tracker-gated, rule injection),
   the configured `tracker`/`source`, and the CLIs/MCP/env those imply.
 - **The host project's needs** — its own package manager, build/test tooling, app runtime
   dependencies, CI-assumed binaries, and project-scoped MCP servers.
@@ -71,7 +71,9 @@ Group the findings as:
    runs, whether it is headless-safe, whether it needs network or write access to system paths,
    and whether it fits the cloud setup-script time budget (~5 minutes for environment caching;
    `SessionStart` hooks re-run every session and must be fast). Lisa's `install-pkgs.sh` and
-   `setup-jira-cli.sh` are the usual headline items.
+   `setup-jira-cli.sh` are the usual headline items. Note that `setup-jira-cli.sh` is gated on
+   `tracker: "jira"` — on a project using another tracker it exits immediately and needs no
+   environment at all, so do not report its JIRA env vars as required there.
 
 3. **External CLIs / binaries** — scan hooks, `scripts/`, committed skills/commands, and
    `.github/workflows/` for invoked binaries that a base cloud image likely lacks. Assume node,
@@ -256,7 +258,7 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
-- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart.)
+- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart — but only when `.lisa.config*.json` sets `tracker: "jira"`; on any other tracker the hook is a no-op.)
 - Acquire: `https://id.atlassian.com/manage-profile/security/api-tokens`.
 - Access: the API token inherits the Atlassian user's permissions — the user must have Browse/Create/Edit/Transition on the target project. An unscoped token suffices for jira-cli; a scoped token must cover the JIRA project read/write operations.
 

--- a/plugins/lisa/hooks/setup-jira-cli.sh
+++ b/plugins/lisa/hooks/setup-jira-cli.sh
@@ -3,6 +3,13 @@
 # Writes the JIRA CLI config file from environment variables.
 # Runs on SessionStart so the config is available for every session.
 #
+# Gated on the project's configured tracker: this only writes anything when
+# `.lisa.config*.json` declares `tracker: "jira"`. A project on Linear or GitHub
+# Issues has no use for a jira-cli config, and writing one made a false implicit
+# claim about which tracker the project runs on. The gate fails closed — an
+# unreadable or absent tracker writes nothing — because Lisa treats a missing
+# `tracker` as unconfigured rather than as a jira default (see lisa-tracker-read).
+#
 # Required env vars (must be created in your Claude Code Web environment):
 #   JIRA_INSTALLATION - cloud or local
 #   JIRA_SERVER       - Atlassian instance URL (falls back to .lisa.config*.json atlassian.site)
@@ -41,6 +48,11 @@ read_lisa_config() {
 
   printf '%s' "${value}"
 }
+
+# Tracker gate: do nothing unless this project actually runs on JIRA.
+if [[ "$(read_lisa_config '.tracker')" != "jira" ]]; then
+  exit 0
+fi
 
 if [[ -z "${JIRA_SERVER:-}" ]]; then
   ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"

--- a/plugins/lisa/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/lisa/skills/lisa-analyze-claude-remote/SKILL.md
@@ -28,7 +28,7 @@ This skill ships in the base Lisa plugin and is distributed to every host projec
 discover requirements **dynamically from the repo** rather than assuming Lisa-repo specifics. It
 audits two layers together:
 
-- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh`, rule injection),
+- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh` — tracker-gated, rule injection),
   the configured `tracker`/`source`, and the CLIs/MCP/env those imply.
 - **The host project's needs** — its own package manager, build/test tooling, app runtime
   dependencies, CI-assumed binaries, and project-scoped MCP servers.
@@ -71,7 +71,9 @@ Group the findings as:
    runs, whether it is headless-safe, whether it needs network or write access to system paths,
    and whether it fits the cloud setup-script time budget (~5 minutes for environment caching;
    `SessionStart` hooks re-run every session and must be fast). Lisa's `install-pkgs.sh` and
-   `setup-jira-cli.sh` are the usual headline items.
+   `setup-jira-cli.sh` are the usual headline items. Note that `setup-jira-cli.sh` is gated on
+   `tracker: "jira"` — on a project using another tracker it exits immediately and needs no
+   environment at all, so do not report its JIRA env vars as required there.
 
 3. **External CLIs / binaries** — scan hooks, `scripts/`, committed skills/commands, and
    `.github/workflows/` for invoked binaries that a base cloud image likely lacks. Assume node,
@@ -256,7 +258,7 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
-- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart.)
+- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart — but only when `.lisa.config*.json` sets `tracker: "jira"`; on any other tracker the hook is a no-op.)
 - Acquire: `https://id.atlassian.com/manage-profile/security/api-tokens`.
 - Access: the API token inherits the Atlassian user's permissions — the user must have Browse/Create/Edit/Transition on the target project. An unscoped token suffices for jira-cli; a scoped token must cover the JIRA project read/write operations.
 

--- a/plugins/src/base/hooks/setup-jira-cli.sh
+++ b/plugins/src/base/hooks/setup-jira-cli.sh
@@ -3,6 +3,13 @@
 # Writes the JIRA CLI config file from environment variables.
 # Runs on SessionStart so the config is available for every session.
 #
+# Gated on the project's configured tracker: this only writes anything when
+# `.lisa.config*.json` declares `tracker: "jira"`. A project on Linear or GitHub
+# Issues has no use for a jira-cli config, and writing one made a false implicit
+# claim about which tracker the project runs on. The gate fails closed — an
+# unreadable or absent tracker writes nothing — because Lisa treats a missing
+# `tracker` as unconfigured rather than as a jira default (see lisa-tracker-read).
+#
 # Required env vars (must be created in your Claude Code Web environment):
 #   JIRA_INSTALLATION - cloud or local
 #   JIRA_SERVER       - Atlassian instance URL (falls back to .lisa.config*.json atlassian.site)
@@ -41,6 +48,11 @@ read_lisa_config() {
 
   printf '%s' "${value}"
 }
+
+# Tracker gate: do nothing unless this project actually runs on JIRA.
+if [[ "$(read_lisa_config '.tracker')" != "jira" ]]; then
+  exit 0
+fi
 
 if [[ -z "${JIRA_SERVER:-}" ]]; then
   ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"

--- a/plugins/src/base/skills/lisa-analyze-claude-remote/SKILL.md
+++ b/plugins/src/base/skills/lisa-analyze-claude-remote/SKILL.md
@@ -28,7 +28,7 @@ This skill ships in the base Lisa plugin and is distributed to every host projec
 discover requirements **dynamically from the repo** rather than assuming Lisa-repo specifics. It
 audits two layers together:
 
-- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh`, rule injection),
+- **Lisa's needs** — startup hooks (`install-pkgs.sh`, `setup-jira-cli.sh` — tracker-gated, rule injection),
   the configured `tracker`/`source`, and the CLIs/MCP/env those imply.
 - **The host project's needs** — its own package manager, build/test tooling, app runtime
   dependencies, CI-assumed binaries, and project-scoped MCP servers.
@@ -71,7 +71,9 @@ Group the findings as:
    runs, whether it is headless-safe, whether it needs network or write access to system paths,
    and whether it fits the cloud setup-script time budget (~5 minutes for environment caching;
    `SessionStart` hooks re-run every session and must be fast). Lisa's `install-pkgs.sh` and
-   `setup-jira-cli.sh` are the usual headline items.
+   `setup-jira-cli.sh` are the usual headline items. Note that `setup-jira-cli.sh` is gated on
+   `tracker: "jira"` — on a project using another tracker it exits immediately and needs no
+   environment at all, so do not report its JIRA env vars as required there.
 
 3. **External CLIs / binaries** — scan hooks, `scripts/`, committed skills/commands, and
    `.github/workflows/` for invoked binaries that a base cloud image likely lacks. Assume node,
@@ -256,7 +258,7 @@ unsuffixed `…_TOKEN`/`…_KEY` is the simplest to set in a single-account rout
 
 ### JIRA — `tracker: jira`
 - Headless substrate: `jira-cli` + curl (Basic auth). The acli and Atlassian-MCP tiers need prior interactive/OAuth auth → not viable headless.
-- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart.)
+- Env: `JIRA_API_TOKEN`, `JIRA_SERVER` (e.g. `https://acme.atlassian.net`), `JIRA_LOGIN` (account email), `JIRA_PROJECT` (default project key); optional `JIRA_INSTALLATION` (default `cloud`), `JIRA_BOARD`. (`setup-jira-cli.sh` writes the jira-cli config from these on SessionStart — but only when `.lisa.config*.json` sets `tracker: "jira"`; on any other tracker the hook is a no-op.)
 - Acquire: `https://id.atlassian.com/manage-profile/security/api-tokens`.
 - Access: the API token inherits the Atlassian user's permissions — the user must have Browse/Create/Edit/Transition on the target project. An unscoped token suffices for jira-cli; a scoped token must cover the JIRA project read/write operations.
 

--- a/src/codex/scripts/setup-jira-cli.sh
+++ b/src/codex/scripts/setup-jira-cli.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Lisa-managed Codex hook script (SessionStart).
 # Writes jira-cli configuration from environment variables when available.
+# Gated on `tracker: "jira"` in .lisa.config*.json — a project on another tracker
+# gets nothing. Fails closed when the tracker is absent or unreadable.
 set -euo pipefail
 
 # Drain the hook envelope before any config-dependent early return.
@@ -24,6 +26,11 @@ read_lisa_config() {
 
   printf '%s' "${value}"
 }
+
+# Tracker gate: do nothing unless this project actually runs on JIRA.
+if [[ "$(read_lisa_config '.tracker')" != "jira" ]]; then
+  exit 0
+fi
 
 if [[ -z "${JIRA_SERVER:-}" ]]; then
   ATLASSIAN_SITE="$(read_lisa_config '.atlassian.site')"

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -719,7 +719,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/secrets-preflight.sh":
       "cdc638627e5769770aefb061ea0ddfacc1888a8eab3a5fade6c43129a2d3ff6e",
     "plugins/src/base/hooks/setup-jira-cli.sh":
-      "a675f6b17ce7f0d6b9fb7daeba6d2bc59bcb48ef79b034076ea73b2b1e72ee09",
+      "b55988c2a9a74c4dda08f85c269d34527555cac8f023f6ffea6fd20e2498b7c6",
     "plugins/src/base/hooks/shell-write-nudge.sh":
       "69839af423f8792b1e52c71097316c3264425553031627c0a2f9409a9d5becd0",
     "plugins/src/base/hooks/sonar-secrets.sh":
@@ -987,7 +987,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-agent-ready/SKILL.md":
       "f65e5e866bc476ba2b40e4fb29e6754bdd5824e1f0706f28d4f2beb2af0faf53",
     "plugins/src/base/skills/lisa-analyze-claude-remote/SKILL.md":
-      "a5863836b8fa9d67825d048e1c2fc086d3df95de33cf110129488959b83cb4b5",
+      "67f49097e7ffefbdaf3e81a27adeb9b78721d4ad25e9beb1df2d99c0e53e1e3d",
     "plugins/src/base/skills/lisa-atlassian-access/SKILL.md":
       "6366ccce961217d1c7bcac4dad9c2293ee4dcc395b27c142a3b59c62f00b685c",
     "plugins/src/base/skills/lisa-atlassian-access/scripts/markdown-to-adf.mjs":
@@ -9064,6 +9064,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/opencode/manifest.test.ts": true,
     "tests/unit/opencode/mcp-installer.test.ts": true,
     "tests/unit/opencode/parity-safety-net-plugin.test.ts": true,
+    "tests/unit/opencode/session-bootstrap-jira-gate.test.ts": true,
     "tests/unit/opencode/settings-installer.test.ts": true,
     "tests/unit/opencode/skills-installer.test.ts": true,
     "tests/unit/scripts/ast-grep-enforcement.test.ts": true,

--- a/src/opencode/plugin-templates/lisa-session-bootstrap.ts
+++ b/src/opencode/plugin-templates/lisa-session-bootstrap.ts
@@ -4,7 +4,8 @@
  * OpenCode runs a plugin's factory function once when it loads the plugin at
  * session start, which is the natural home for Lisa's Codex SessionStart hooks:
  *   - install-pkgs.sh   → install dependencies when node_modules is missing
- *   - setup-jira-cli.sh → write jira-cli config from environment variables
+ *   - setup-jira-cli.sh → write jira-cli config from environment variables, only
+ *     when the project's configured tracker is jira
  *
  * Both are fully fail-open (wrapped in try/catch) so a package-manager or
  * filesystem hiccup never bricks OpenCode startup, mirroring the Codex scripts.
@@ -61,6 +62,10 @@ export const LisaSessionBootstrap = async ({
   }
 
   // setup-jira-cli: write jira-cli config from environment variables and non-secret Lisa config.
+  // Gated on `tracker: "jira"` — a project on Linear or GitHub Issues has no use
+  // for a jira-cli config, and writing one made a false implicit claim about the
+  // project's tracker. Fails closed: an absent tracker writes nothing, because
+  // Lisa treats a missing `tracker` as unconfigured, not as a jira default.
   try {
     const readLisaConfig = (path: string[]) => {
       for (const file of [".lisa.config.local.json", ".lisa.config.json"]) {
@@ -82,6 +87,7 @@ export const LisaSessionBootstrap = async ({
       }
       return undefined;
     };
+    if (readLisaConfig(["tracker"]) !== "jira") return {};
     const atlassianSite = readLisaConfig(["atlassian", "site"]);
     const server =
       process.env.JIRA_SERVER ??

--- a/tests/unit/opencode/session-bootstrap-jira-gate.test.ts
+++ b/tests/unit/opencode/session-bootstrap-jira-gate.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Runtime contract tests for the tracker gate in OpenCode's session-bootstrap
+ * plugin. The fixture copies the template exactly as installHooks does, then
+ * invokes the plugin factory under Bun against a throwaway worktree.
+ */
+import { spawnSync } from "node:child_process";
+import * as fs from "fs-extra";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
+
+const TEMPLATE_DIR = path.join(
+  process.cwd(),
+  "src",
+  "opencode",
+  "plugin-templates"
+);
+const BUN_PATH = spawnSync("/usr/bin/which", ["bun"], {
+  encoding: "utf8",
+}).stdout.trim();
+const SITE = "example.atlassian.net";
+const PROJECT_KEY = "LISA";
+const LOGIN = "bot@example.com";
+const LISA_CONFIG = ".lisa.config.json";
+
+describe("OpenCode session-bootstrap jira-cli tracker gate", () => {
+  let tempDir: string;
+  let pluginPath: string;
+  let worktree: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+    pluginPath = path.join(tempDir, "lisa-session-bootstrap.ts");
+    worktree = path.join(tempDir, "worktree");
+    await fs.copy(
+      path.join(TEMPLATE_DIR, "lisa-session-bootstrap.ts"),
+      pluginPath
+    );
+    await fs.ensureDir(worktree);
+    // Keep the install-pkgs arm inert: no package.json means nothing to install.
+    await fs.ensureDir(path.join(worktree, "node_modules"));
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  /**
+   * Run the bootstrap plugin factory under Bun against the fixture worktree.
+   * @param env - Extra environment variables for the plugin process.
+   */
+  const bootstrap = (env: NodeJS.ProcessEnv): void => {
+    const program = `
+      const imported = await import(${JSON.stringify("file://PLACEHOLDER")}.replace("PLACEHOLDER", process.env.PLUGIN_PATH));
+      await imported.LisaSessionBootstrap({
+        $: () => Promise.resolve(),
+        worktree: process.env.TEST_WORKTREE,
+      });
+    `;
+    // Build the environment from scratch rather than inheriting: an ambient
+    // JIRA_SERVER/JIRA_PROJECT on the developer's machine would otherwise decide
+    // the outcome. Empty strings are not equivalent to absent here — the
+    // template resolves env vars with `??`, which only falls through on
+    // undefined.
+    const result = spawnSync(BUN_PATH, ["-e", program], {
+      encoding: "utf8",
+      env: {
+        HOME: process.env.HOME,
+        PATH: process.env.PATH,
+        PLUGIN_PATH: pluginPath,
+        TEST_WORKTREE: worktree,
+        ...env,
+      },
+    });
+    expect(result.status).toBe(0);
+  };
+
+  /**
+   * Whether the plugin wrote a jira-cli config into the fixture worktree.
+   * @returns True when `.lisa/jira-cli/.config.yml` exists.
+   */
+  const configExists = (): Promise<boolean> =>
+    fs.pathExists(path.join(worktree, ".lisa", "jira-cli", ".config.yml"));
+
+  it("skips the jira-cli config write when the tracker is not jira", async () => {
+    await fs.writeJson(path.join(worktree, LISA_CONFIG), {
+      atlassian: { site: SITE },
+      jira: { project: PROJECT_KEY },
+      tracker: "linear",
+    });
+
+    bootstrap({ JIRA_LOGIN: LOGIN });
+
+    expect(await configExists()).toBe(false);
+  });
+
+  it("skips the jira-cli config write when no tracker is configured", async () => {
+    await fs.writeJson(path.join(worktree, LISA_CONFIG), {
+      atlassian: { site: SITE },
+      jira: { project: PROJECT_KEY },
+    });
+
+    bootstrap({ JIRA_LOGIN: LOGIN });
+
+    expect(await configExists()).toBe(false);
+  });
+
+  it("writes the jira-cli config when the tracker is jira", async () => {
+    await fs.writeJson(path.join(worktree, LISA_CONFIG), {
+      atlassian: { site: SITE },
+      jira: { project: PROJECT_KEY },
+      tracker: "jira",
+    });
+
+    bootstrap({ JIRA_LOGIN: LOGIN });
+
+    expect(await configExists()).toBe(true);
+  });
+});

--- a/tests/unit/scripts/setup-jira-cli-config.test.ts
+++ b/tests/unit/scripts/setup-jira-cli-config.test.ts
@@ -6,6 +6,10 @@ import { cleanupTempDir, createTempDir } from "../../helpers/test-utils.js";
 
 const repoRoot = path.resolve(import.meta.dirname, "../../..");
 const SAFE_COMMAND_PATH = "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin";
+const SITE = "example.atlassian.net";
+const PROJECT_KEY = "LISA";
+const LOGIN = "bot@example.com";
+const LISA_CONFIG = ".lisa.config.json";
 const setupJiraCli = path.join(
   repoRoot,
   "plugins",
@@ -33,32 +37,35 @@ describe("setup-jira-cli hook config fallback", () => {
   });
 
   it("uses Lisa config for non-secret Jira values when env vars are missing", async () => {
-    await fs.writeJson(path.join(projectDir, ".lisa.config.json"), {
-      atlassian: { site: "example.atlassian.net" },
-      jira: { project: "LISA" },
+    await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
+      atlassian: { site: SITE },
+      jira: { project: PROJECT_KEY },
+      tracker: "jira",
     });
 
-    await runHook({ JIRA_LOGIN: "bot@example.com" });
+    await runHook({ JIRA_LOGIN: LOGIN });
 
     await expectJiraConfig([
       "server: https://example.atlassian.net",
-      "login: bot@example.com",
+      `login: ${LOGIN}`,
       "project: LISA",
     ]);
   });
 
   it("keeps env vars ahead of local and global Lisa config", async () => {
-    await fs.writeJson(path.join(projectDir, ".lisa.config.json"), {
+    await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
       atlassian: { site: "global.atlassian.net" },
       jira: { project: "GLOBAL" },
+      tracker: "jira",
     });
     await fs.writeJson(path.join(projectDir, ".lisa.config.local.json"), {
       atlassian: { site: "local.atlassian.net" },
       jira: { project: "LOCAL" },
+      tracker: "jira",
     });
 
     await runHook({
-      JIRA_LOGIN: "bot@example.com",
+      JIRA_LOGIN: LOGIN,
       JIRA_PROJECT: "ENV",
       JIRA_SERVER: "https://env.atlassian.net",
     });
@@ -101,3 +108,116 @@ describe("setup-jira-cli hook config fallback", () => {
     }
   }
 });
+
+/**
+ * Every shell implementation of the SessionStart hook. The Claude plugin source
+ * fans out to the Cursor and Copilot variants verbatim; Codex ships its own
+ * hand-maintained twin. Both must gate identically or the tracker gate is only
+ * half real.
+ */
+const trackerGateScripts = [
+  ["claude plugin hook", setupJiraCli],
+  [
+    "codex hook script",
+    path.join(repoRoot, "src", "codex", "scripts", "setup-jira-cli.sh"),
+  ],
+] as const;
+
+describe.each(trackerGateScripts)(
+  "setup-jira-cli tracker gate (%s)",
+  (_label, scriptPath) => {
+    let tempDir: string;
+    let homeDir: string;
+    let projectDir: string;
+
+    beforeEach(async () => {
+      tempDir = await createTempDir();
+      homeDir = path.join(tempDir, "home");
+      projectDir = path.join(tempDir, "project");
+      await fs.ensureDir(homeDir);
+      await fs.ensureDir(projectDir);
+    });
+
+    afterEach(async () => {
+      await cleanupTempDir(tempDir);
+    });
+
+    it("skips the jira-cli config write when the tracker is not jira", async () => {
+      await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
+        atlassian: { site: SITE },
+        jira: { project: PROJECT_KEY },
+        tracker: "linear",
+      });
+
+      await runHook({ JIRA_LOGIN: LOGIN });
+
+      expect(await configExists()).toBe(false);
+    });
+
+    it("skips the jira-cli config write when no tracker is configured", async () => {
+      await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
+        atlassian: { site: SITE },
+        jira: { project: PROJECT_KEY },
+      });
+
+      await runHook({ JIRA_LOGIN: LOGIN });
+
+      expect(await configExists()).toBe(false);
+    });
+
+    it("writes the jira-cli config when the tracker is jira", async () => {
+      await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
+        atlassian: { site: SITE },
+        jira: { project: PROJECT_KEY },
+        tracker: "jira",
+      });
+
+      await runHook({ JIRA_LOGIN: LOGIN });
+
+      expect(await configExists()).toBe(true);
+    });
+
+    it("honors a local-config tracker override over the committed tracker", async () => {
+      await fs.writeJson(path.join(projectDir, LISA_CONFIG), {
+        atlassian: { site: SITE },
+        jira: { project: PROJECT_KEY },
+        tracker: "jira",
+      });
+      await fs.writeJson(path.join(projectDir, ".lisa.config.local.json"), {
+        tracker: "github",
+      });
+
+      await runHook({ JIRA_LOGIN: LOGIN });
+
+      expect(await configExists()).toBe(false);
+    });
+
+    /**
+     * Execute the hook under test inside the temporary project.
+     * @param env - Environment variables to expose to the hook process.
+     */
+    function runHook(env: NodeJS.ProcessEnv) {
+      const result = spawnSync("/bin/bash", [scriptPath], {
+        cwd: projectDir,
+        encoding: "utf8",
+        env: {
+          HOME: homeDir,
+          PATH: SAFE_COMMAND_PATH,
+          ...env,
+        },
+        input: "{}\n",
+      });
+      expect(result.status).toBe(0);
+    }
+
+    /**
+     * Whether the hook wrote a jira-cli config into the temporary project.
+     * @returns True when `.lisa/jira-cli/.config.yml` exists.
+     */
+    function configExists(): Promise<boolean> {
+      return fs.pathExists(
+        path.join(projectDir, ".lisa", "jira-cli", ".config.yml")
+      );
+    }
+  }
+);

--- a/wiki/architecture/lisa-hook-per-agent-ship-list.md
+++ b/wiki/architecture/lisa-hook-per-agent-ship-list.md
@@ -49,7 +49,7 @@ Each script under `plugins/src/base/hooks/`:
 | `inject-flow-context.sh` | SubagentStart polyfill injecting flow context into sub-agents | Claude + Codex (Codex 0.125.0 now supports SubagentStart per refreshed `reference-codex-hooks-capabilities` memory). **STRIP on Cursor / agy / Copilot** (Copilot has no SubagentStart; Cursor unverified; SubagentStart is not in agy's universal ship-list). |
 | `install-pkgs.sh` | SessionStart(startup) installer ensuring required CLIs are present | universal — every agent's first session |
 | ~~`notify-ntfy.sh`~~ | ~~Stop notification via ntfy.sh~~ | **RETIRED (ticket-1054)** — removed from Lisa's source entirely (the script, the base `Stop` hook entry, the Codex hook def, and every per-agent ship-list). It was emitting a `No such file or directory` Stop-hook error and is no longer used. |
-| `setup-jira-cli.sh` | SessionStart sets up `acli` JIRA CLI auth from settings | universal |
+| `setup-jira-cli.sh` | SessionStart writes the `jira-cli` config from JIRA env vars + `.lisa.config*.json`; no-op unless `tracker: "jira"` | universal |
 | `debug-hook.sh` | Debug helper | **exclude from every per-agent variant by default** (it is a development helper, not a production hook). Wave 3 contract: generator scripts skip any `*debug*.sh`. |
 | `ticket-sync-reminder.sh` | Reminder hook (event TBD — used in some flows) | **unregistered in `plugin.json`** — verify whether the file is intentionally idle or invoked by a non-plugin code path before classifying. Wave 3 contract: generator scripts skip it until classification is resolved. |
 | `track-plan-sessions.sh` | Plan session tracking | **unregistered in `plugin.json`** — same as `ticket-sync-reminder.sh`. Skip in generators until classified. |


### PR DESCRIPTION
## What

`setup-jira-cli` ran on every session in every project, whatever tracker the project used. A project on `tracker: "linear"` got `.lisa/jira-cli/.config.yml` written at every session start. This gates all three implementations on the project's configured tracker.

Nothing was breaking. The hook fails open when `JIRA_SERVER` or `JIRA_LOGIN` is absent, so what it cost was not an outage but a false implicit claim about which tracker the project runs on, written into the project root where an agent would read it and believe it.

## Why gate rather than delete

The hook's *output* is orphaned — nothing in this repo reads `.lisa/jira-cli/.config.yml`, and the one script that consumes a jira-cli config (`lisa-jira-evidence/scripts/post-evidence.sh`) reads `~/.config/.jira/.config.yml` and hard-errors telling you to run `jira init` if it is missing. Nothing sets `JIRA_CONFIG_FILE` anywhere.

But the *tool* is alive and maintained: `scripts/claude-remote-setup.sh` installs the `jira` binary when `tracker=jira`, `src/cli/remote-environment-catalog.ts` declares `JIRA_SERVER`/`JIRA_LOGIN` as active requirements "used by jira-cli" under the same condition, `post-evidence.sh` still shells out to `jira issue move`, and `lisa-analyze-claude-remote` documents this hook as the headless mechanism that configures it.

So the intent is live and the write path is misdirected — mixed evidence, and gating is the conservative resolution. The path mismatch is a separate defect and is deliberately left alone here; see below.

## Surfaces

Three implementations, gated identically — otherwise the gate is only half real:

| Surface | File |
| --- | --- |
| Claude (source; fans out verbatim to Cursor + Copilot) | `plugins/src/base/hooks/setup-jira-cli.sh` |
| Codex (hand-maintained twin) | `src/codex/scripts/setup-jira-cli.sh` |
| OpenCode (session-bootstrap plugin) | `src/opencode/plugin-templates/lisa-session-bootstrap.ts` |

Antigravity (agy) has no `SessionStart` event and has never shipped this hook — `per-agent-hook-filter.mjs` and the ship-list wiki both record that as a documented gap. Nothing there to gate. Generated variants (`plugins/lisa`, `plugins/lisa-cursor`, `plugins/lisa-copilot`) come from `bun run build:plugins`, not hand edits.

No hook was added or removed, so every hook-count and ordered-array assertion across the per-agent generators is unchanged.

## Fail-closed, deliberately

An absent `tracker` writes nothing. Lisa treats a missing `tracker` as unconfigured rather than as a JIRA default — `lisa-tracker-read` stops and reports `"No tracker configured in .lisa.config.json"` rather than assuming one. `jq` is a hard requirement of `claude-remote-setup.sh` (`require jq`), so the config-read path the gate depends on is available wherever this hook matters.

## Tests

New: `tests/unit/opencode/session-bootstrap-jira-gate.test.ts`, and a `describe.each` tracker-gate block in `tests/unit/scripts/setup-jira-cli-config.test.ts` covering both shell implementations.

Pre-fix RED, checked by name:

```
FAIL tests/unit/scripts/setup-jira-cli-config.test.ts > setup-jira-cli tracker gate (claude plugin hook) > skips the jira-cli config write when the tracker is not jira
FAIL tests/unit/scripts/setup-jira-cli-config.test.ts > setup-jira-cli tracker gate (codex hook script) > skips the jira-cli config write when the tracker is not jira
FAIL tests/unit/scripts/setup-jira-cli-config.test.ts > ... > skips the jira-cli config write when no tracker is configured   (both scripts)
FAIL tests/unit/scripts/setup-jira-cli-config.test.ts > ... > honors a local-config tracker override over the committed tracker   (both scripts)
FAIL tests/unit/opencode/session-bootstrap-jira-gate.test.ts > ... > skips the jira-cli config write when the tracker is not jira
FAIL tests/unit/opencode/session-bootstrap-jira-gate.test.ts > ... > skips the jira-cli config write when no tracker is configured
AssertionError: expected true to be false
```

The three `writes the jira-cli config when the tracker is jira` cases passed pre-fix and still pass — they pin that this does not break JIRA projects.

The two pre-existing fallback tests now declare `tracker: "jira"` in their fixtures. They assert exactly the resolution behavior they always did; no assertion was weakened.

Post-fix: 13/13 green in those two files; full suite green.

## Found and deliberately left alone

**The config path does not match any reader.** The hook writes `<project>/.lisa/jira-cli/.config.yml`, but jira-cli looks in `$HOME/.config/.jira/.config.yml` (or wherever `JIRA_CONFIG_FILE` points, which nothing sets), and `post-evidence.sh` reads the `$HOME` path directly. So even on a JIRA project this hook's output is read by nobody. Fixing that is a behavior change nobody asked for and is out of scope here; it wants its own ticket.

**`read_lisa_config` resolves relative to the process cwd, not `PROJECT_DIR`.** Pre-existing in both shell scripts. The gate reuses the same helper so its behavior stays uniform with the existing `atlassian.site` / `jira.project` fallbacks; changing the resolution base would silently alter those too.

Work-Item: CodySwannGT/lisa#2764

🤖 Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Jira CLI configuration is now created only for projects explicitly using Jira.
  * Non-Jira, missing, or unreadable tracker settings safely skip Jira setup without writing configuration.
  * Local tracker settings correctly take precedence over committed configuration.

* **Documentation**
  * Clarified tracker-specific Jira setup behavior and environment requirements.

* **Tests**
  * Added coverage for Jira, non-Jira, missing, and overridden tracker configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->