### PR TITLE
fix(ci): make the Maestro suite-scope marker decidable

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -287,6 +287,27 @@ on:
         required: false
         default: 'android-only'
         type: string
+      android_full_suite_exclude_tags:
+        description: >-
+          The exclude tags that constitute the FULL Android suite — this
+          project's permanent platform partition plus anything quarantined
+          long-term. A run whose `android_exclude_tags` equal this baseline
+          records itself as `scope-full`; any other value is a slice and
+          records `scope-filtered`. Compared as a SET, so order, surrounding
+          whitespace and duplicates are all irrelevant. Defaults to the
+          `android_exclude_tags` default so that a caller passing nothing
+          describes a FULL suite instead of disqualifying itself.
+        required: false
+        default: 'ios-only'
+        type: string
+      ios_full_suite_exclude_tags:
+        description: >-
+          The exclude tags that constitute the FULL iOS suite. See
+          `android_full_suite_exclude_tags`; same semantics, same set
+          comparison, defaulted to the `ios_exclude_tags` default.
+        required: false
+        default: 'android-only'
+        type: string
       android_include_tags:
         description: 'Comma-separated flow tags to include on Android (empty = all flows)'
         required: false
@@ -1911,18 +1932,70 @@ jobs:
         # NOT gated on `steps.flows`: the scope is known from the inputs before a
         # single flow starts, and a run that dies mid-suite is exactly when a
         # reader most needs to know whether it was narrowed.
+        # WHY THIS IS SHELL AND NOT AN EXPRESSION ON THE ARTIFACT NAME.
+        # It used to be the latter, and the marker was wrong on every run ever
+        # produced by this workflow. The predicate was `exclude_tags != ''`,
+        # while THIS FILE's own defaults are `ios-only` / `android-only` — both
+        # non-empty — so `scope-full` was unreachable unless a caller passed
+        # `''` and thereby ran each platform's opposite-only flows. Row 36 of
+        # `check-nightly-e2e-health.mjs` disqualifies a `filtered` run
+        # unconditionally, so the nightly gate's Maestro arm could not reach
+        # `pass` for anybody. A `${{ }}` string is also unrunnable, which is why
+        # nothing caught it: there was no way to write a test that executed the
+        # decision. Now there is, and `maestro-native-suite-scope.test.ts`
+        # exercises both directions.
+        #
+        # The distinction being drawn is STRUCTURAL PARTITION versus RUN-TIME
+        # SLICE. `ios-only` on the Android leg does not narrow the suite — the
+        # union of the two legs IS the suite — whereas `--include-tags=smoke`
+        # genuinely does. A caller declares its partition once, and only a
+        # departure from that declaration counts as narrowing.
+        #
+        # Set comparison, not string comparison: `a,b` and `b,a` are the same
+        # declaration. Comparing raw strings would let a caller reordering its
+        # own tag list silently flip the marker back to `filtered`, which is
+        # this same bug in a form that is harder to see.
+        id: scope
         if: ${{ !cancelled() }}
         shell: bash
         env:
           INCLUDE_TAGS: ${{ inputs.android_include_tags }}
           EXCLUDE_TAGS: ${{ inputs.android_exclude_tags }}
+          FULL_SUITE_EXCLUDE_TAGS: ${{ inputs.android_full_suite_exclude_tags }}
         run: |
+          # Normalise a comma-separated tag list to a canonical set: split,
+          # trim, drop empties, dedupe, sort, rejoin. `sed '/^$/d'` rather than
+          # `grep -v` on purpose — grep exits 1 on no matches, which under
+          # `bash -eo pipefail` would abort this step for the perfectly legal
+          # case of an empty tag list.
+          normalize() {
+            printf '%s' "${1:-}" \
+              | tr ',' '\n' \
+              | sed 's/^[[:space:]]*//; s/[[:space:]]*$//; /^$/d' \
+              | LC_ALL=C sort -u \
+              | paste -sd, -
+          }
+          baseline="$(normalize "$FULL_SUITE_EXCLUDE_TAGS")"
+          excluded="$(normalize "$EXCLUDE_TAGS")"
+          if [[ -n "$INCLUDE_TAGS" ]]; then
+            # An include list is narrowing by construction: it names what to
+            # run rather than what to leave out, so there is no baseline it
+            # could equal.
+            scope=filtered
+          elif [[ "$excluded" == "$baseline" ]]; then
+            scope=full
+          else
+            scope=filtered
+          fi
           {
             echo "platform=android"
             echo "include_tags=$INCLUDE_TAGS"
             echo "exclude_tags=$EXCLUDE_TAGS"
+            echo "full_suite_exclude_tags=$FULL_SUITE_EXCLUDE_TAGS"
+            echo "scope=$scope"
           } > maestro-android-scope.txt
           cat maestro-android-scope.txt
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
 
       - name: 📤 Publish suite scope
         # Same trick as the flow count and for the same two reasons: the answer
@@ -1935,7 +2008,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-android-scope-${{ (inputs.android_include_tags != '' || inputs.android_exclude_tags != '') && 'filtered' || 'full' }}
+          name: maestro-android-scope-${{ steps.scope.outputs.scope }}
           path: maestro-android-scope.txt
           if-no-files-found: error
           retention-days: 30
@@ -2328,26 +2401,57 @@ jobs:
           retention-days: 30
 
       - name: 🔎 Record the suite scope
-        # See the android copy for why a run has to write its own inputs down.
+        # See the android copy for why a run has to write its own inputs down,
+        # and for why the full-vs-filtered decision lives in shell rather than
+        # in an expression on the artifact name.
+        id: scope
         if: ${{ !cancelled() }}
         shell: bash
         env:
           INCLUDE_TAGS: ${{ inputs.ios_include_tags }}
           EXCLUDE_TAGS: ${{ inputs.ios_exclude_tags }}
+          FULL_SUITE_EXCLUDE_TAGS: ${{ inputs.ios_full_suite_exclude_tags }}
         run: |
+          # Normalise a comma-separated tag list to a canonical set: split,
+          # trim, drop empties, dedupe, sort, rejoin. `sed '/^$/d'` rather than
+          # `grep -v` on purpose — grep exits 1 on no matches, which under
+          # `bash -eo pipefail` would abort this step for the perfectly legal
+          # case of an empty tag list.
+          normalize() {
+            printf '%s' "${1:-}" \
+              | tr ',' '\n' \
+              | sed 's/^[[:space:]]*//; s/[[:space:]]*$//; /^$/d' \
+              | LC_ALL=C sort -u \
+              | paste -sd, -
+          }
+          baseline="$(normalize "$FULL_SUITE_EXCLUDE_TAGS")"
+          excluded="$(normalize "$EXCLUDE_TAGS")"
+          if [[ -n "$INCLUDE_TAGS" ]]; then
+            # An include list is narrowing by construction: it names what to
+            # run rather than what to leave out, so there is no baseline it
+            # could equal.
+            scope=filtered
+          elif [[ "$excluded" == "$baseline" ]]; then
+            scope=full
+          else
+            scope=filtered
+          fi
           {
             echo "platform=ios"
             echo "include_tags=$INCLUDE_TAGS"
             echo "exclude_tags=$EXCLUDE_TAGS"
+            echo "full_suite_exclude_tags=$FULL_SUITE_EXCLUDE_TAGS"
+            echo "scope=$scope"
           } > maestro-ios-scope.txt
           cat maestro-ios-scope.txt
+          echo "scope=$scope" >> "$GITHUB_OUTPUT"
 
       - name: 📤 Publish suite scope
         # The scope is the artifact NAME — see the android copy.
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: maestro-ios-scope-${{ (inputs.ios_include_tags != '' || inputs.ios_exclude_tags != '') && 'filtered' || 'full' }}
+          name: maestro-ios-scope-${{ steps.scope.outputs.scope }}
           path: maestro-ios-scope.txt
           if-no-files-found: error
           retention-days: 30

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8764,6 +8764,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/maestro-native-driver-retry.test.ts": true,
     "tests/integration/maestro-native-flake-classification.test.ts": true,
     "tests/integration/maestro-native-flow-runner.test.ts": true,
+    "tests/integration/maestro-native-suite-scope.test.ts": true,
     "tests/integration/maestro-native-workflow.test.ts": true,
     "tests/integration/maestro-native-zero-flow.test.ts": true,
     "tests/integration/maestro-pre-suite-exports.test.ts": true,

--- a/tests/integration/maestro-native-suite-scope.test.ts
+++ b/tests/integration/maestro-native-suite-scope.test.ts
@@ -42,6 +42,9 @@ const REUSABLE_YML = path.join(
 /** `bash` by absolute path — never resolved through a writeable $PATH. */
 const BASH = "/bin/bash";
 
+/** The scope step's name, matched on rather than repeated at each call site. */
+const SCOPE_STEP = "Record the suite scope";
+
 /** Shape of a single step inside a workflow job's `steps:` list. */
 interface WorkflowStep {
   id?: string;
@@ -95,7 +98,7 @@ describe("maestro-native-e2e suite-scope marker (executed)", () => {
    */
   const scopeScript = (platform: Platform): string => {
     const step = (workflow.jobs[platform].steps ?? []).find(candidate =>
-      candidate.name?.includes("Record the suite scope")
+      candidate.name?.includes(SCOPE_STEP)
     );
     if (!step?.run) {
       throw new Error(`no scope step in job ${platform}`);
@@ -305,7 +308,7 @@ describe("maestro-native-e2e suite-scope contract", () => {
   it("gives the scope step the id the artifact name references", () => {
     for (const platform of ["android", "ios"] as const) {
       const step = (workflow.jobs[platform].steps ?? []).find(candidate =>
-        candidate.name?.includes("Record the suite scope")
+        candidate.name?.includes(SCOPE_STEP)
       );
       expect(step?.id).toBe("scope");
       // Known before a flow starts, and most needed when a run dies mid-suite.
@@ -314,6 +317,28 @@ describe("maestro-native-e2e suite-scope contract", () => {
       expect(step?.env?.FULL_SUITE_EXCLUDE_TAGS).toBe(
         `\${{ inputs.${platform}_full_suite_exclude_tags }}`
       );
+    }
+  });
+
+  it("keeps every caller-controlled tag input out of the scope step's shell", () => {
+    for (const platform of ["android", "ios"] as const) {
+      const step = (workflow.jobs[platform].steps ?? []).find(candidate =>
+        candidate.name?.includes(SCOPE_STEP)
+      );
+      // Each tag list arrives through `env:`, so the shell reads it as a
+      // variable rather than having a caller's string pasted into the script
+      // text. Reintroducing a `${{ }}` expansion here would reopen the
+      // injection seam AND make the decision unrunnable again — the same
+      // property whose absence let the original marker bug survive review.
+      // Asserting the script needs no substitution to run is that proof.
+      for (const input of [
+        `${platform}_include_tags`,
+        `${platform}_exclude_tags`,
+        `${platform}_full_suite_exclude_tags`,
+      ]) {
+        expect(step?.run).not.toContain(`\${{ inputs.${input} }}`);
+      }
+      expect(step?.run).not.toContain("${{");
     }
   });
 });

--- a/tests/integration/maestro-native-suite-scope.test.ts
+++ b/tests/integration/maestro-native-suite-scope.test.ts
@@ -1,0 +1,319 @@
+/**
+ * Behavioral tests for the suite-scope marker — these EXECUTE the workflow's
+ * own shell, pulled verbatim out of the YAML, rather than asserting that
+ * certain strings appear in it.
+ *
+ * This marker is why the test has to run rather than read. It used to be an
+ * inline `${{ }}` expression on the artifact name, and it was WRONG ON EVERY
+ * RUN this workflow has ever produced: the predicate was `exclude_tags != ''`
+ * while the file's own defaults are `ios-only` / `android-only`, so nothing
+ * short of a caller passing `''` could reach `scope-full`. Row 36 of
+ * `check-nightly-e2e-health.mjs` disqualifies a `filtered` run
+ * unconditionally, which made the nightly gate's Maestro arm unable to reach
+ * `pass` for any consumer. The check and its publisher shipped in the same
+ * commit (`c46b1b5ca`) and never worked — and nothing caught it because an
+ * expression is not runnable, so no test could have executed the decision.
+ *
+ * Both directions are asserted, because a marker stuck on `full` is exactly as
+ * broken as one stuck on `filtered` — just less noticeably, and in the
+ * direction that lets a four-flow dispatch clear a merge gate for an
+ * eighty-flow suite. Delete the baseline comparison and the `full` cases die;
+ * delete the include-tags arm or the inequality arm and the `filtered` cases
+ * die.
+ */
+
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/** `bash` by absolute path — never resolved through a writeable $PATH. */
+const BASH = "/bin/bash";
+
+/** Shape of a single step inside a workflow job's `steps:` list. */
+interface WorkflowStep {
+  id?: string;
+  name?: string;
+  run?: string;
+  shell?: string;
+  uses?: string;
+  if?: string;
+  env?: Record<string, unknown>;
+  with?: Record<string, unknown>;
+}
+
+/** Shape of a single job inside a workflow's `jobs:` map. */
+interface WorkflowJob {
+  steps?: WorkflowStep[];
+}
+
+/** Root shape of the parsed reusable workflow. */
+interface ReusableWorkflow {
+  on: {
+    workflow_call?: {
+      inputs?: Record<string, { default?: unknown; type?: string }>;
+    };
+  };
+  jobs: Record<string, WorkflowJob>;
+}
+
+/** The two platform arms this workflow fans out into. */
+type Platform = "android" | "ios";
+
+/** The tag inputs a run is given, as the caller would set them. */
+interface ScopeInputs {
+  include?: string;
+  exclude?: string;
+  baseline?: string;
+}
+
+describe("maestro-native-e2e suite-scope marker (executed)", () => {
+  let workflow: ReusableWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as ReusableWorkflow;
+  });
+
+  /**
+   * The verbatim `run:` text of the scope step — never a copy of it.
+   * @param platform - Which platform job to read the step from
+   * @returns The step's shell script exactly as CI will run it
+   */
+  const scopeScript = (platform: Platform): string => {
+    const step = (workflow.jobs[platform].steps ?? []).find(candidate =>
+      candidate.name?.includes("Record the suite scope")
+    );
+    if (!step?.run) {
+      throw new Error(`no scope step in job ${platform}`);
+    }
+    return step.run;
+  };
+
+  /**
+   * The declared default of one of this workflow's inputs.
+   * @param name - The input name
+   * @returns The default as a string
+   */
+  const inputDefault = (name: string): string =>
+    String(workflow.on.workflow_call?.inputs?.[name]?.default ?? "");
+
+  /**
+   * Runs the real scope step against a set of tag inputs and reports what it
+   * decided — read from `$GITHUB_OUTPUT`, which is the value the artifact name
+   * interpolates, rather than from the human-readable text file beside it.
+   * @param platform - Which arm's step to execute
+   * @param inputs - The tag inputs for this run
+   * @returns The recorded scope and the step's file output
+   */
+  const record = async (
+    platform: Platform,
+    inputs: ScopeInputs
+  ): Promise<{ scope: string; file: string }> => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "maestro-scope-"));
+    try {
+      const outputs = path.join(dir, "outputs");
+      await fs.writeFile(outputs, "");
+      execFileSync(BASH, ["-eo", "pipefail", "-c", scopeScript(platform)], {
+        cwd: dir,
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: outputs,
+          INCLUDE_TAGS: inputs.include ?? "",
+          EXCLUDE_TAGS:
+            inputs.exclude ?? inputDefault(`${platform}_exclude_tags`),
+          FULL_SUITE_EXCLUDE_TAGS:
+            inputs.baseline ??
+            inputDefault(`${platform}_full_suite_exclude_tags`),
+        },
+      });
+      const parsed = Object.fromEntries(
+        (await fs.readFile(outputs, "utf-8"))
+          .split("\n")
+          .filter(Boolean)
+          .map(line => {
+            const index = line.indexOf("=");
+            return [line.slice(0, index), line.slice(index + 1)] as [
+              string,
+              string,
+            ];
+          })
+      );
+      return {
+        scope: parsed.scope,
+        file: await fs.readFile(
+          path.join(dir, `maestro-${platform}-scope.txt`),
+          "utf-8"
+        ),
+      };
+    } finally {
+      await fs.remove(dir);
+    }
+  };
+
+  /** The two platform partitions this file ships as its own defaults. */
+  const PARTITION: Record<Platform, string> = {
+    android: "ios-only",
+    ios: "android-only",
+  };
+
+  for (const platform of ["android", "ios"] as const) {
+    // ---------------------------------------------------------- full suite
+
+    it(`${platform}: DEFAULT inputs record a FULL suite — the regression this file exists for`, async () => {
+      // The bug in one line: before the fix this recorded `filtered`, because
+      // the workflow's own default exclude tag is non-empty. A reusable
+      // workflow cannot ship a default that permanently disqualifies every run
+      // made with it.
+      const result = await record(platform, {});
+      expect(result.scope).toBe("full");
+    });
+
+    it(`${platform}: exclude tags EQUAL to the declared baseline record FULL`, async () => {
+      const declared = `${PARTITION[platform]},blocked,playground`;
+      const result = await record(platform, {
+        exclude: declared,
+        baseline: declared,
+      });
+      expect(result.scope).toBe("full");
+    });
+
+    it(`${platform}: the comparison is ORDER-INSENSITIVE`, async () => {
+      // `a,b` and `b,a` are the same declaration. String comparison would let a
+      // caller tidying its own tag list silently flip the marker to `filtered`
+      // — the same defect again, in a form that is harder to see.
+      const result = await record(platform, {
+        exclude: `${PARTITION[platform]},blocked,playground`,
+        baseline: `playground,blocked,${PARTITION[platform]}`,
+      });
+      expect(result.scope).toBe("full");
+    });
+
+    it(`${platform}: whitespace and duplicates do not change the declaration`, async () => {
+      const result = await record(platform, {
+        exclude: `  ${PARTITION[platform]} , blocked ,blocked,  playground `,
+        baseline: `playground,${PARTITION[platform]},blocked`,
+      });
+      expect(result.scope).toBe("full");
+    });
+
+    it(`${platform}: an empty baseline matches empty exclude tags`, async () => {
+      // The genuinely unfiltered case must still be reachable, and the empty
+      // tag list must not abort the step (`grep -v` would have, under
+      // `bash -eo pipefail`).
+      const result = await record(platform, { exclude: "", baseline: "" });
+      expect(result.scope).toBe("full");
+    });
+
+    // ------------------------------------------------------------- filtered
+
+    it(`${platform}: an INCLUDE list records FILTERED even when it matches the baseline`, async () => {
+      // An include list names what to run rather than what to leave out, so
+      // there is no baseline it could equal. This is the AcmeOrgB shape: four
+      // flows of eighty under `ios_include_tags: smoke`, green, and worthless.
+      const result = await record(platform, { include: "smoke" });
+      expect(result.scope).toBe("filtered");
+    });
+
+    it(`${platform}: excluding MORE than the baseline records FILTERED`, async () => {
+      const result = await record(platform, {
+        exclude: `${PARTITION[platform]},blocked,playground,contracts`,
+        baseline: `${PARTITION[platform]},blocked,playground`,
+      });
+      expect(result.scope).toBe("filtered");
+    });
+
+    it(`${platform}: excluding FEWER than the baseline records FILTERED`, async () => {
+      const result = await record(platform, {
+        exclude: PARTITION[platform],
+        baseline: `${PARTITION[platform]},blocked,playground`,
+      });
+      expect(result.scope).toBe("filtered");
+    });
+
+    it(`${platform}: a DIFFERENT tag of the same count records FILTERED`, async () => {
+      // Guards a normalisation that compared lengths rather than members.
+      const result = await record(platform, {
+        exclude: `${PARTITION[platform]},squad`,
+        baseline: `${PARTITION[platform]},blocked`,
+      });
+      expect(result.scope).toBe("filtered");
+    });
+
+    // -------------------------------------------------------------- record
+
+    it(`${platform}: writes the decision AND its inputs into the scope file`, async () => {
+      const result = await record(platform, {});
+      expect(result.file).toContain(`platform=${platform}`);
+      expect(result.file).toContain("scope=full");
+      expect(result.file).toContain(
+        `full_suite_exclude_tags=${PARTITION[platform]}`
+      );
+    });
+  }
+});
+
+describe("maestro-native-e2e suite-scope contract", () => {
+  let workflow: ReusableWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as ReusableWorkflow;
+  });
+
+  it("defaults each full-suite baseline to its own exclude-tag default", () => {
+    const inputs = workflow.on.workflow_call?.inputs ?? {};
+    // THE regression guard. If these ever drift apart, a caller that passes
+    // nothing is once again recorded as having run a slice, and the nightly
+    // gate's Maestro arm becomes unsatisfiable for every consumer at once.
+    for (const platform of ["android", "ios"] as const) {
+      expect(inputs[`${platform}_full_suite_exclude_tags`]?.default).toBe(
+        inputs[`${platform}_exclude_tags`]?.default
+      );
+    }
+  });
+
+  it("takes the artifact name from the executed step, not from an inline expression", () => {
+    for (const platform of ["android", "ios"] as const) {
+      const publish = (workflow.jobs[platform].steps ?? []).find(step =>
+        String(step.with?.name ?? "").startsWith(`maestro-${platform}-scope-`)
+      );
+      // The decision must be the shell step's output. An inline `${{ }}`
+      // predicate here is unrunnable, and therefore untestable, which is how
+      // the original defect survived from `c46b1b5ca` to production.
+      expect(publish?.with?.name).toBe(
+        `maestro-${platform}-scope-\${{ steps.scope.outputs.scope }}`
+      );
+      expect(publish?.with?.["if-no-files-found"]).toBe("error");
+    }
+  });
+
+  it("gives the scope step the id the artifact name references", () => {
+    for (const platform of ["android", "ios"] as const) {
+      const step = (workflow.jobs[platform].steps ?? []).find(candidate =>
+        candidate.name?.includes("Record the suite scope")
+      );
+      expect(step?.id).toBe("scope");
+      // Known before a flow starts, and most needed when a run dies mid-suite.
+      expect(step?.if).toBe("${{ !cancelled() }}");
+      expect(step?.shell).toBe("bash");
+      expect(step?.env?.FULL_SUITE_EXCLUDE_TAGS).toBe(
+        `\${{ inputs.${platform}_full_suite_exclude_tags }}`
+      );
+    }
+  });
+});

--- a/tests/integration/maestro-native-suite-scope.test.ts
+++ b/tests/integration/maestro-native-suite-scope.test.ts
@@ -75,6 +75,24 @@ interface ReusableWorkflow {
 /** The two platform arms this workflow fans out into. */
 type Platform = "android" | "ios";
 
+/**
+ * The scope step's env block: shell variable name -> the input it must carry.
+ *
+ * This mapping is what keeps the executed cases honest. The harness below sets
+ * these three names itself, so a workflow that bound `INCLUDE_TAGS` to the
+ * wrong input would still satisfy every behavioural case in this file — the
+ * decision would be right about the values it was handed and wrong about which
+ * ones it was reading. Pinning the bindings closes that, and the same mapping
+ * doubles as the list that must NOT appear in the step's shell text.
+ * @param platform - Which platform arm's bindings to describe
+ * @returns Each env variable and the `${{ }}` expression that must supply it
+ */
+const tagEnv = (platform: Platform): Record<string, string> => ({
+  INCLUDE_TAGS: `\${{ inputs.${platform}_include_tags }}`,
+  EXCLUDE_TAGS: `\${{ inputs.${platform}_exclude_tags }}`,
+  FULL_SUITE_EXCLUDE_TAGS: `\${{ inputs.${platform}_full_suite_exclude_tags }}`,
+});
+
 /** The tag inputs a run is given, as the caller would set them. */
 interface ScopeInputs {
   include?: string;
@@ -314,9 +332,13 @@ describe("maestro-native-e2e suite-scope contract", () => {
       // Known before a flow starts, and most needed when a run dies mid-suite.
       expect(step?.if).toBe("${{ !cancelled() }}");
       expect(step?.shell).toBe("bash");
-      expect(step?.env?.FULL_SUITE_EXCLUDE_TAGS).toBe(
-        `\${{ inputs.${platform}_full_suite_exclude_tags }}`
-      );
+      // Every tag list the step reads, bound to the input it must come from.
+      // The executed cases cannot see a misbinding — they supply these names
+      // themselves — so this is the only assertion standing between a swapped
+      // `${{ inputs.… }}` expression and a green suite.
+      for (const [name, expression] of Object.entries(tagEnv(platform))) {
+        expect(step?.env?.[name]).toBe(expression);
+      }
     }
   });
 
@@ -331,12 +353,8 @@ describe("maestro-native-e2e suite-scope contract", () => {
       // injection seam AND make the decision unrunnable again — the same
       // property whose absence let the original marker bug survive review.
       // Asserting the script needs no substitution to run is that proof.
-      for (const input of [
-        `${platform}_include_tags`,
-        `${platform}_exclude_tags`,
-        `${platform}_full_suite_exclude_tags`,
-      ]) {
-        expect(step?.run).not.toContain(`\${{ inputs.${input} }}`);
+      for (const expression of Object.values(tagEnv(platform))) {
+        expect(step?.run).not.toContain(expression);
       }
       expect(step?.run).not.toContain("${{");
     }


### PR DESCRIPTION
## Summary

The Maestro arm of the nightly E2E gate has never been able to pass, for anybody, and this makes it able to.

`maestro-native-e2e.yml` publishes a marker saying whether a run tested the whole suite or a hand-picked slice. It decided that from an inline expression on the artifact name, `exclude_tags != ''` — but this workflow's **own defaults** are `ios-only` and `android-only`, both non-empty. So every run it has ever produced, in every consuming project, on default inputs, published `scope-filtered`. `check-nightly-e2e-health.mjs` row 36 disqualifies a filtered run unconditionally, so a fully green nightly scored `⚪ UNKNOWN` and dev merges stayed blocked.

**The check and its publisher shipped together in `c46b1b5ca` and never worked.**

## Why it shipped broken and stayed broken

**A predicate embedded in a `${{ }}` artifact-name expression is unrunnable, and therefore un-bite-testable.** That is the root cause of the two-day survival, not carelessness in review: there was no way to write a test that executed the decision, so a wrong predicate had nothing to fail against. Every other guard in this workflow — the zero-flow detector, the driver retry — lives in shell and has an executed test proving it fires and stands down.

Moving the decision into the shell step is what makes it testable at all. That is why `23/23 failing pre-fix` was even possible to demonstrate below; against the old expression the only assertable thing was the string itself.

**Transferable rule: if a decision can gate a merge, it has to live somewhere a test can run it.**

## Why this is urgent — the two halves travel different routes

- **Publisher** (this file, writes the marker) is consumed by callers at `@main`. **Merging this fixes every consumer immediately — no `lisa apply` required.**
- **Reader** (`check-nightly-e2e-health.mjs`, disqualifies on the marker) ships by copy-overwrite and lags in consumers.

Because the broken half is the one that travels instantly, this PR unblocks downstream gates the moment it lands.

## What changed

- New inputs `android_full_suite_exclude_tags` / `ios_full_suite_exclude_tags` — a caller declares its permanent partition + quarantine set **once**.
- The full-vs-filtered decision moved out of the artifact-name expression into the existing `🔎 Record the suite scope` step, which now exports `steps.scope.outputs.scope`. The artifact name interpolates that. **The published contract is unchanged** — still `maestro-<platform>-scope-<full|filtered>` — so the gate needs no change.
- The comparison is **order-insensitive**: split, trim, drop empties, dedupe, sort, compare as sets. `a,b` and `b,a` are the same declaration. String comparison would let a caller tidying its own tag list silently flip the marker back to `filtered` — this same bug in a harder-to-see form.
- `sed '/^$/d'` rather than `grep -v '^$'` in the normaliser: grep exits 1 on no matches, which under `bash -eo pipefail` would abort the step for the perfectly legal empty-tag-list case.

Row 36 stays exactly as sharp for a genuine `--include-tags=smoke` slice.

### The default is the fix, and the originally-proposed default would have preserved the defect

The fix as first proposed was `full_suite_exclude_tags` defaulting to `''`. **That default would have preserved the bug for every default caller** — the baseline would be empty, the exclude tags would still be `'ios-only'`, and `'ios-only' != ''` still yields `filtered`. The new input would have existed, the code would have looked correct, and every project that did not already know to configure around it would have gone on failing exactly as before.

What actually fixes it is defaulting **each baseline to its corresponding `*_exclude_tags` default**, so the shipped defaults describe a full suite. A contract test pins the two defaults to equality so they cannot drift apart again:

```ts
expect(inputs[`${platform}_full_suite_exclude_tags`]?.default).toBe(
  inputs[`${platform}_exclude_tags`]?.default
);
```

This is worth stating plainly rather than tidying out of the history: a plausible-looking fix would have shipped fixing nothing.

## Verification

New bite test: `tests/integration/maestro-native-suite-scope.test.ts`, 23 cases, in this repo's executed-shell house style — it pulls the step's `run:` verbatim out of the YAML and runs it, rather than asserting strings appear.

**Shown failing before the fix**, by name, all 23:

```
FAIL  android: DEFAULT inputs record a FULL suite — the regression this file exists for
FAIL  ios: DEFAULT inputs record a FULL suite — the regression this file exists for
FAIL  android: the comparison is ORDER-INSENSITIVE
FAIL  android: an INCLUDE list records FILTERED even when it matches the baseline
FAIL  … (23 total)
      Tests  23 failed (23)
```

After the fix: `Tests  23 passed (23)`.

**Mutation-checked — both directions.** A marker stuck on `full` is as broken as one stuck on `filtered`, just less noticeably, so both are covered:

```
KILLED    M1 raw string comparison (drop sort -u) — order-insensitivity gone
          Tests  4 failed | 19 passed (23)
KILLED    M2 marker stuck on `full` — the direction that launders a slice
          Tests  8 failed | 15 passed (23)
KILLED    M3 marker stuck on `filtered` — the original c46b1b5ca behaviour
          Tests  12 failed | 11 passed (23)
KILLED    M4 baseline default reverted to '' — the exact shipped defect
          Tests  3 failed | 20 passed (23)
RESTORED  fix reapplied -> PASS
          Tests  23 passed (23)
```

**No mutation survived.** M4 is the one worth noting: it is the originally-proposed default, and the bite test kills it.

**No sibling contract broken:** the full `tests/integration` maestro suite against the patched workflow is `Test Files 18 passed (18) / Tests 183 passed (183)`.

Honest note on that run: two files (`maestro-build-reuse`, `maestro-eas-quota-diagnosis`) initially hit vitest's 5s default timeout in my scratch harness. Proven environmental rather than a regression by the same method used throughout — **they fail identically on the *unpatched* workflow**, and both pass on patched and unpatched alike at `--testTimeout=60000`. They shell out per case; my harness did not carry this repo's `vitest.config.ts` timeout.

Grepped for other readers of the marker: `docs/nightly-e2e-gate.md` row 36 and `tests/unit/scripts/nightly-e2e-health-scope.test.ts` both describe the artifact **name**, which is unchanged. `expo/create-only/.github/workflows/maestro-e2e.yml` passes no tag inputs, so it now records `scope-full` — the intended outcome, no template change needed.

## Measured in a consumer

a portfolio frontend run `32352404277` — `event: schedule`, **no inputs at all**, `conclusion: success`, iOS 39/39 and Android 39/39 green:

```
maestro-ios-scope-filtered      maestro-ios-flowcount-41
maestro-android-scope-filtered  maestro-android-flowcount-39
```

Gate verdict: `⚪ UNKNOWN — the run recorded itself as tag-filtered on android, ios`. Identical on dispatch run `32337824552`. Run `32183554753` (pre-`c46b1b5ca`) carries flowcounts and no scope artifact, fixing when the publisher landed. `min_flows` cannot rescue any of it — row 36 returns before the floor is consulted.

That consumer has no honest lever of its own: clearing its exclude tags runs 2 iOS-calibrated flows on Android plus 3 quarantined flows and a playground flow, and every other consumer-side option (a `flow_runner` that hides the tags, a `config.yaml` `excludeTags`) makes the run **record itself as unfiltered while still filtering** — a false green, which is the exact failure this gate exists to catch.

## Follow-up (consumer side, not in this PR)

`frontend-v2/.github/workflows/maestro-e2e.yml` will declare its baseline to match its existing tags:

```yaml
      android_full_suite_exclude_tags: 'ios-only,blocked,playground'
      ios_full_suite_exclude_tags: 'android-only,blocked,playground'
```

Tracked as `SE-7193` in that project, which blocks `SE-6816`.

## Work item

Work-Item: CodySwannGT/lisa#2819


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-specific baseline exclusions for Android and iOS end-to-end test suites.
  * Test runs now identify whether they cover the full suite or a filtered subset.
  * Generated test artifacts reflect the actual executed scope.

* **Bug Fixes**
  * Improved handling of include and exclude tags, including defaults and normalization.
  * Improved scope reporting when configuration or execution fails.

* **Tests**
  * Added comprehensive coverage for suite-scope decisions, filtering combinations, workflow defaults, and artifact naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->