### PR TITLE
fix(guard): catch the host-name shape that was 100% of the live problem

### DIFF
--- a/.agents/rules/never-name-downstream-projects.md
+++ b/.agents/rules/never-name-downstream-projects.md
@@ -40,15 +40,76 @@ Two, both of which stay out of published artifacts:
 ## How this is enforced
 
 `tests/unit/core/no-downstream-project-names.test.ts` scans every tracked file
-in required CI. It detects the **shape** rather than a list of names — a guard
-enumerating the clients would publish the very list it protects — by
-allowlisting orgs that are legitimately public and flagging everything else. A
-newly onboarded downstream project is therefore caught without anyone
-remembering to add it.
+in required CI, using two detectors that catch different things.
+
+**Shape detection** flags any `github.com/owner/repo` or workflow `uses:` whose
+org is not in `PUBLIC_ORGS`. Its value is reach: a newly onboarded downstream
+project is caught without anyone remembering to add it. It deliberately does
+**not** match bare `a/b` in prose, because that shape collides with file paths,
+date fractions and option syntax, and a guard with false positives gets
+switched off.
+
+**Known-name detection** flags a name wherever it is spelled — in a sentence, a
+code comment, or a local absolute path — with no URL in front of it and no
+slash in it at all. This was added because the shape detector was measured
+reporting **zero** violations on a tree that had **189**, in 28 files, one of
+them in `src/` and so in the published npm tarball. The blind spot was not a
+rounding error; it was the whole live problem.
+
+A known list has no false-positive problem to trade against: `2026/08/20`,
+`src/core/index.ts` and `--flag=a/b` are not names, so they cannot match. The
+objection to a list was different — a plaintext denylist in a public repository
+publishes exactly what it protects — and it is answered by storing **truncated
+salted digests** instead of names, in `src/core/downstream-names.ts`. Be honest
+about what that buys: it prevents *enumeration*, not *confirmation*. Nobody can
+read the list; anyone holding a specific guess can test it. That is inherent to
+any in-tree denylist, and truncation blunts it by leaving thousands of
+preimages per digest.
+
+### Adding a name
+
+```sh
+node -e 'const{createHash}=require("crypto");const n=process.argv[1].toLowerCase().replace(/[^a-z0-9]+/g,"");console.log(`"${n.length}:${createHash("sha256").update("lisa/downstream-name/v1").update(n).digest("hex").slice(0,10)}",`)' 'The Name'
+```
+
+Paste the line into `HOST_NAME_ENTRIES` and keep the array sorted. Names shorter
+than five characters are refused: a three-character entry matches an initialism
+somewhere in almost any repository, which hands back the false-positive problem
+the list exists to avoid.
+
+A name too sensitive to appear even as a digest goes in the
+`LISA_DOWNSTREAM_NAMES` environment variable instead, comma-separated. State the
+cost plainly when choosing that: an environment variable absent from required CI
+means the guard bites locally and not in CI, so out-of-tree is the weaker
+placement, not the stronger one.
 
 If the check fails on a legitimate vendor, add the org to `PUBLIC_ORGS` in
 `src/core/downstream-references.ts`. That list is safe to publish; a list of
-clients would not be.
+host projects would not be.
+
+### What the list does not yet cover
+
+Two further identity shapes are present in this repository and are **not** in
+the list, because arming them is a several-hundred-file rewrite and therefore an
+owner decision rather than a cleanup:
+
+- **Host repository names without the org** — roughly 490 occurrences across
+  about 110 files. The 2026-08-17 cleanup anonymised the org half and kept the
+  repo half. That is defensible, since the org is the identifying half, but the
+  scope section above covers repository names too, so the current state is a
+  convention this rule does not actually sanction. Either the rule should say so
+  explicitly or those occurrences should go.
+- **A host tracker's project-key prefix** — 110 occurrences across 52 files,
+  entrenched as the generic example key inside BDD grammar fixtures and schema
+  examples, where it is load-bearing test data. It reads as an anonymous
+  placeholder, which is almost certainly why it survived. Scrubbing it means
+  touching fixtures.
+
+Neither is a paste-a-digest job. The tracker prefix is three characters, below
+the minimum length for good reason. The repository names are generic English
+compounds that would fire on ordinary prose in any repository that used the same
+word for its own directory. Arming either one means deciding what to rewrite
+first, not adding a line to an array.
 
 ## Why the rule alone was not enough
 

--- a/docs/nightly-e2e-gate.md
+++ b/docs/nightly-e2e-gate.md
@@ -1073,7 +1073,7 @@ Until this shipped, every issue the reporter filed said, unconditionally:
 > Pull requests into `dev` are blocked until this suite is green again.
 
 That was a hardcoded assertion about somebody else's branch ruleset, and it was
-**measurably false**. `GET /repos/TunnlAI/frontend/rules/branches/dev` returns
+**measurably false**. `GET /repos/AcmeOrgB/frontend/rules/branches/dev` returns
 twelve required contexts and not one of them matches this gate. The suite
 blocked nothing — while people applied audited `nightly-e2e-bypass` labels to
 clear a gate that was not gating, spending the audit trail the label exists to
@@ -1118,8 +1118,8 @@ single-job reimplementation publishes the bare `🌙 Nightly E2E Health` and tha
 is the same gate. Nothing looser: a substring test would match
 `🌙 Nightly E2E Health (advisory)`.
 
-**This is a knowing divergence from both prior implementations.** TunnlAI's
-`describe-nightly-e2e-requiredness.mjs` and geminisportsai's
+**This is a knowing divergence from both prior implementations.** AcmeOrgB's
+`describe-nightly-e2e-requiredness.mjs` and acmeorga's
 `report-nightly-e2e.mjs` each compare the full context string exactly
 (`contexts.includes(context)`), and each documents that choice against the
 looser alternative of searching for `"nightly"`. They are right that a substring

--- a/plans/completed/delightful-napping-lemon/rails-stack.md
+++ b/plans/completed/delightful-napping-lemon/rails-stack.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Lisa currently supports JavaScript/TypeScript ecosystems: `typescript`, `expo`, `nestjs`, `cdk`, `npm-package`. This plan adds a `rails` stack to govern Ruby on Rails projects, with Qualis (`~/workspace/qualis/app`) as the first downstream target.
+Lisa currently supports JavaScript/TypeScript ecosystems: `typescript`, `expo`, `nestjs`, `cdk`, `npm-package`. This plan adds a `rails` stack to govern Ruby on Rails projects, with AcmeOrgC (`~/workspace/acmeorgc/app`) as the first downstream target.
 
 **Plan type:** Epic (30+ new files, source code changes, downstream integration)
 
@@ -14,7 +14,7 @@ Lisa currently supports JavaScript/TypeScript ecosystems: `typescript`, `expo`, 
 2. **`all/` pack is safe** — `CLAUDE.md` and `.claude/rules/lisa.md` are JS-specific and get overridden by `rails/copy-overwrite/` versions. 5 JS-specific skills also overridden. All TS-specific config files (`.prettierrc.json`, `eslint.*`, `jest.*`, `tsconfig.*`) live in `typescript/copy-overwrite/` and won't be deployed.
 3. **Gemfile governance via `eval_gemfile`** — Lisa manages `rails/copy-overwrite/Gemfile.lisa` (governance gems with `~>` version constraints). A `rails/copy-contents/Gemfile` appends `eval_gemfile "Gemfile.lisa"` to the project's Gemfile with `# BEGIN/END: AI GUARDRAILS` markers.
 4. **Lefthook hooks**: pre-commit runs RuboCop (staged files) + bundler-audit (fast). pre-push runs `bundle exec rspec` + `bundle exec brakeman` (moved from pre-commit per security review — Brakeman is slow on large codebases). commit-msg validates conventional commit format.
-5. **RSpec-only pack** — Pack ships with RSpec as standard. Qualis Minitest-to-RSpec migration is a **separate follow-up plan**. Minitest projects should add `lefthook.yml` to `.lisaignore` to skip the pre-push hook until migration.
+5. **RSpec-only pack** — Pack ships with RSpec as standard. AcmeOrgC Minitest-to-RSpec migration is a **separate follow-up plan**. Minitest projects should add `lefthook.yml` to `.lisaignore` to skip the pre-push hook until migration.
 6. **`quality.yml` is create-only** — Each project configures its own database services and CI environment. Lisa provides a starting template.
 7. **`sonar-project.properties` is create-only** — Projects customize SonarQube project keys.
 8. **`coding-philosophy.md` from `all/` kept for MVP** — Principles are universal even though examples are TS. Ruby-specific version is a future enhancement.
@@ -92,7 +92,7 @@ rails/
 - `tests/integration/lisa.test.ts` — Append Rails stack integration tests
 - `tests/helpers/test-utils.ts` — Add `createRailsProject()` helper + extend `createMockLisaDir()` for rails/ pack
 
-### Qualis Downstream (in `~/workspace/qualis/app`)
+### AcmeOrgC Downstream (in `~/workspace/acmeorgc/app`)
 
 - Remove duplicate gems from Gemfile (brakeman, rubocop-rails, rubocop-performance, rubocop-rails-omakase)
 - Remove overcommit gem from Gemfile
@@ -545,18 +545,18 @@ describe("DetectorRegistry") // append to existing
 }
 ```
 
-### Task 9: Build and dry-run against Qualis
+### Task 9: Build and dry-run against AcmeOrgC
 
 **Type:** Task
 
-**Description:** Build Lisa locally and run against Qualis to verify output:
+**Description:** Build Lisa locally and run against AcmeOrgC to verify output:
 1. `bun run build` in Lisa repo
-2. `bun run dev -- ~/workspace/qualis/app --dry-run` to preview changes
+2. `bun run dev -- ~/workspace/acmeorgc/app --dry-run` to preview changes
 3. Verify: Rails detected, CLAUDE.md is Rails-specific, .rubocop.yml deployed, lefthook.yml deployed, Gemfile.lisa deployed, Gemfile gets eval_gemfile, .overcommit.yml marked for deletion, NO TS artifacts
 
 **Acceptance Criteria:**
 - [ ] Lisa builds without errors
-- [ ] Dry-run detects "rails" type for Qualis
+- [ ] Dry-run detects "rails" type for AcmeOrgC
 - [ ] No TypeScript artifacts in dry-run output
 
 **Verification:**
@@ -567,25 +567,25 @@ describe("DetectorRegistry") // append to existing
   "skills": [],
   "verification": {
     "type": "manual-check",
-    "command": "bun run build && bun run dev -- ~/workspace/qualis/app --dry-run 2>&1 | grep -i 'rails'",
+    "command": "bun run build && bun run dev -- ~/workspace/acmeorgc/app --dry-run 2>&1 | grep -i 'rails'",
     "expected": "Build succeeds, dry-run shows Rails detected"
   }
 }
 ```
 
-### Task 10: Qualis downstream — clean up Gemfile and install
+### Task 10: AcmeOrgC downstream — clean up Gemfile and install
 
 **Type:** Task
 
-**Description:** In `~/workspace/qualis/app`:
-1. Run `bun run dev -- ~/workspace/qualis/app --yes` from Lisa repo to apply templates
-2. Remove duplicate gems from Qualis Gemfile (brakeman, rubocop-rails, rubocop-performance already in Gemfile.lisa)
+**Description:** In `~/workspace/acmeorgc/app`:
+1. Run `bun run dev -- ~/workspace/acmeorgc/app --yes` from Lisa repo to apply templates
+2. Remove duplicate gems from AcmeOrgC Gemfile (brakeman, rubocop-rails, rubocop-performance already in Gemfile.lisa)
 3. Remove `rubocop-rails-omakase` gem (replaced by Lisa's .rubocop.yml)
 4. Remove `overcommit` gem
-5. Run `cd ~/workspace/qualis/app && bundle install`
+5. Run `cd ~/workspace/acmeorgc/app && bundle install`
 
 **Acceptance Criteria:**
-- [ ] Lisa templates applied to Qualis
+- [ ] Lisa templates applied to AcmeOrgC
 - [ ] Duplicate gems removed from Gemfile
 - [ ] overcommit gem removed
 - [ ] `bundle install` succeeds
@@ -598,20 +598,20 @@ describe("DetectorRegistry") // append to existing
   "skills": [],
   "verification": {
     "type": "manual-check",
-    "command": "cd ~/workspace/qualis/app && bundle check",
+    "command": "cd ~/workspace/acmeorgc/app && bundle check",
     "expected": "The Gemfile's dependencies are satisfied"
   }
 }
 ```
 
-### Task 11: Qualis downstream — migrate Overcommit to Lefthook
+### Task 11: AcmeOrgC downstream — migrate Overcommit to Lefthook
 
 **Type:** Task
 
-**Description:** In `~/workspace/qualis/app`:
-1. Uninstall overcommit: `cd ~/workspace/qualis/app && overcommit --uninstall` (if overcommit binary available, otherwise manually remove `.git/hooks/overcommit-hook`)
-2. Install lefthook: `cd ~/workspace/qualis/app && bundle exec lefthook install`
-3. Verify pre-commit hooks work: `cd ~/workspace/qualis/app && bundle exec lefthook run pre-commit`
+**Description:** In `~/workspace/acmeorgc/app`:
+1. Uninstall overcommit: `cd ~/workspace/acmeorgc/app && overcommit --uninstall` (if overcommit binary available, otherwise manually remove `.git/hooks/overcommit-hook`)
+2. Install lefthook: `cd ~/workspace/acmeorgc/app && bundle exec lefthook install`
+3. Verify pre-commit hooks work: `cd ~/workspace/acmeorgc/app && bundle exec lefthook run pre-commit`
 
 **Note:** `.overcommit.yml` should already be deleted by Lisa's `deletions.json`. Verify it's gone.
 
@@ -629,26 +629,26 @@ describe("DetectorRegistry") // append to existing
   "skills": [],
   "verification": {
     "type": "manual-check",
-    "command": "cd ~/workspace/qualis/app && ls .overcommit.yml 2>&1; bundle exec lefthook run pre-commit 2>&1 | tail -3",
+    "command": "cd ~/workspace/acmeorgc/app && ls .overcommit.yml 2>&1; bundle exec lefthook run pre-commit 2>&1 | tail -3",
     "expected": ".overcommit.yml not found; lefthook pre-commit runs (may show rubocop output)"
   }
 }
 ```
 
-### Task 12: Qualis downstream — preserve project-specific CLAUDE.md content
+### Task 12: AcmeOrgC downstream — preserve project-specific CLAUDE.md content
 
 **Type:** Task
 
-**Description:** In `~/workspace/qualis/app`:
+**Description:** In `~/workspace/acmeorgc/app`:
 1. Lisa has already overwritten CLAUDE.md with Rails governance version
 2. The original CLAUDE.md content (Docker setup, architecture docs, AWS access, deployment) was committed in git before Lisa ran
-3. Retrieve the original content: `cd ~/workspace/qualis/app && git show HEAD~1:CLAUDE.md` (or from git history)
+3. Retrieve the original content: `cd ~/workspace/acmeorgc/app && git show HEAD~1:CLAUDE.md` (or from git history)
 4. Move relevant sections to `.claude/rules/PROJECT_RULES.md` (create-only, Lisa won't overwrite)
 5. Organize content under clear headings: Local Development, Architecture, Deployment, Environment Variables
 
 **Acceptance Criteria:**
 - [ ] CLAUDE.md contains Rails governance rules (from Lisa)
-- [ ] `.claude/rules/PROJECT_RULES.md` contains Qualis-specific operational docs
+- [ ] `.claude/rules/PROJECT_RULES.md` contains AcmeOrgC-specific operational docs
 - [ ] No content lost from original CLAUDE.md
 
 **Verification:**
@@ -659,22 +659,22 @@ describe("DetectorRegistry") // append to existing
   "skills": [],
   "verification": {
     "type": "manual-check",
-    "command": "cd ~/workspace/qualis/app && grep 'bundle exec rubocop' CLAUDE.md && grep -c 'Docker\\|ECS\\|deployment' .claude/rules/PROJECT_RULES.md",
+    "command": "cd ~/workspace/acmeorgc/app && grep 'bundle exec rubocop' CLAUDE.md && grep -c 'Docker\\|ECS\\|deployment' .claude/rules/PROJECT_RULES.md",
     "expected": "CLAUDE.md has rubocop reference; PROJECT_RULES.md has Docker/deployment content"
   }
 }
 ```
 
-### Task 13: Qualis downstream — verify and commit
+### Task 13: AcmeOrgC downstream — verify and commit
 
 **Type:** Task
 
-**Description:** In `~/workspace/qualis/app`:
+**Description:** In `~/workspace/acmeorgc/app`:
 1. Run `bundle exec rubocop` — may have violations from existing code (expected, not blocking)
 2. Run `bundle exec brakeman --no-pager` — verify it runs (may have findings)
 3. Run `bundle exec lefthook run pre-commit` — verify hooks execute
 4. Create a branch, commit all changes, push
-5. Note: Qualis uses Minitest, so `bundle exec rspec` will fail (no spec/ tests yet). This is expected per design decision #5.
+5. Note: AcmeOrgC uses Minitest, so `bundle exec rspec` will fail (no spec/ tests yet). This is expected per design decision #5.
 
 **Acceptance Criteria:**
 - [ ] RuboCop runs without errors (violations OK)
@@ -690,7 +690,7 @@ describe("DetectorRegistry") // append to existing
   "skills": [],
   "verification": {
     "type": "manual-check",
-    "command": "cd ~/workspace/qualis/app && bundle exec brakeman --no-pager 2>&1 | tail -3",
+    "command": "cd ~/workspace/acmeorgc/app && bundle exec brakeman --no-pager 2>&1 | tail -3",
     "expected": "Brakeman runs and produces output (findings OK)"
   }
 }
@@ -946,10 +946,10 @@ Tasks 2-7 (implementation) ─── can run in parallel after Task 1
 Task 8 (integration tests) ─── blocked by Tasks 2-7
 
 Task 9 (build + dry-run) ─── blocked by Task 8
-Task 10 (Qualis Gemfile) ─── blocked by Task 9
-Task 11 (Qualis Lefthook) ─── blocked by Task 10
-Task 12 (Qualis CLAUDE.md) ─── blocked by Task 10
-Task 13 (Qualis verify) ─── blocked by Tasks 11, 12
+Task 10 (AcmeOrgC Gemfile) ─── blocked by Task 9
+Task 11 (AcmeOrgC Lefthook) ─── blocked by Task 10
+Task 12 (AcmeOrgC CLAUDE.md) ─── blocked by Task 10
+Task 13 (AcmeOrgC verify) ─── blocked by Tasks 11, 12
 
 Tasks 14-17 (reviews) ─── blocked by Task 13, can run in parallel
 Task 18 (implement suggestions) ─── blocked by Tasks 14-17
@@ -973,7 +973,7 @@ To implement this plan, use `/plan:implement`. Create an Agent Team with these s
 | `code-simplifier:code-simplifier` | Code simplification — Task 19 |
 | `learner` | Learning collection — Task 23 |
 
-The **team lead** handles: Task 1 (branch/PR), Task 9 (build/dry-run), Task 13 (Qualis verify), Task 18 (review implementation), Task 24 (archive), and all git operations (commits, pushes).
+The **team lead** handles: Task 1 (branch/PR), Task 9 (build/dry-run), Task 13 (AcmeOrgC verify), Task 18 (review implementation), Task 24 (archive), and all git operations (commits, pushes).
 
 ## Verification
 
@@ -990,17 +990,17 @@ bun run test
 # 4. Lisa builds successfully
 bun run build
 
-# 5. Dry-run against Qualis shows Rails detected
-bun run dev -- ~/workspace/qualis/app --dry-run 2>&1 | grep -i "rails"
+# 5. Dry-run against AcmeOrgC shows Rails detected
+bun run dev -- ~/workspace/acmeorgc/app --dry-run 2>&1 | grep -i "rails"
 
-# 6. Qualis RuboCop runs after apply
-cd ~/workspace/qualis/app && bundle exec rubocop
+# 6. AcmeOrgC RuboCop runs after apply
+cd ~/workspace/acmeorgc/app && bundle exec rubocop
 
-# 7. Qualis Brakeman runs
-cd ~/workspace/qualis/app && bundle exec brakeman --no-pager
+# 7. AcmeOrgC Brakeman runs
+cd ~/workspace/acmeorgc/app && bundle exec brakeman --no-pager
 
-# 8. Qualis Lefthook hooks installed
-cd ~/workspace/qualis/app && bundle exec lefthook run pre-commit
+# 8. AcmeOrgC Lefthook hooks installed
+cd ~/workspace/acmeorgc/app && bundle exec lefthook run pre-commit
 ```
 
 ## Sessions

--- a/plans/completed/delightful-napping-lemon/tasks/10.json
+++ b/plans/completed/delightful-napping-lemon/tasks/10.json
@@ -1,8 +1,8 @@
 {
   "id": "10",
-  "subject": "Qualis downstream — migrate Overcommit to Lefthook",
-  "description": "**Type:** Task\\n\\n**Description:** In `~/workspace/qualis/app`:\\n1. Uninstall overcommit: `cd ~/workspace/qualis/app && overcommit --uninstall` (if overcommit binary available, otherwise manually remove `.git/hooks/overcommit-hook`)\\n2. Install lefthook: `cd ~/workspace/qualis/app && bundle exec lefthook install`\\n3. Verify pre-commit hooks work: `cd ~/workspace/qualis/app && bundle exec lefthook run pre-commit`\\n\\nNote: `.overcommit.yml` should already be deleted by Lisa's `deletions.json`. Verify it's gone.\\n\\n**Acceptance Criteria:**\\n- [ ] Overcommit hooks uninstalled\\n- [ ] Lefthook hooks installed\\n- [ ] `.overcommit.yml` does not exist\\n- [ ] `lefthook run pre-commit` executes (may have RuboCop violations — that's expected)\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"cd ~/workspace/qualis/app && ls .overcommit.yml 2>&1; bundle exec lefthook run pre-commit 2>&1 | tail -3\\\",\\\"expected\\\":\\\".overcommit.yml not found; lefthook pre-commit runs\\\"}}\\n```",
-  "activeForm": "Migrating Qualis from Overcommit to Lefthook",
+  "subject": "AcmeOrgC downstream — migrate Overcommit to Lefthook",
+  "description": "**Type:** Task\\n\\n**Description:** In `~/workspace/acmeorgc/app`:\\n1. Uninstall overcommit: `cd ~/workspace/acmeorgc/app && overcommit --uninstall` (if overcommit binary available, otherwise manually remove `.git/hooks/overcommit-hook`)\\n2. Install lefthook: `cd ~/workspace/acmeorgc/app && bundle exec lefthook install`\\n3. Verify pre-commit hooks work: `cd ~/workspace/acmeorgc/app && bundle exec lefthook run pre-commit`\\n\\nNote: `.overcommit.yml` should already be deleted by Lisa's `deletions.json`. Verify it's gone.\\n\\n**Acceptance Criteria:**\\n- [ ] Overcommit hooks uninstalled\\n- [ ] Lefthook hooks installed\\n- [ ] `.overcommit.yml` does not exist\\n- [ ] `lefthook run pre-commit` executes (may have RuboCop violations — that's expected)\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"cd ~/workspace/acmeorgc/app && ls .overcommit.yml 2>&1; bundle exec lefthook run pre-commit 2>&1 | tail -3\\\",\\\"expected\\\":\\\".overcommit.yml not found; lefthook pre-commit runs\\\"}}\\n```",
+  "activeForm": "Migrating AcmeOrgC from Overcommit to Lefthook",
   "owner": "implementer-1",
   "status": "completed",
   "blocks": [
@@ -17,12 +17,12 @@
     "skills": [],
     "verification": {
       "type": "manual-check",
-      "command": "cd ~/workspace/qualis/app && ls .overcommit.yml 2>&1; bundle exec lefthook run pre-commit 2>&1 | tail -3",
+      "command": "cd ~/workspace/acmeorgc/app && ls .overcommit.yml 2>&1; bundle exec lefthook run pre-commit 2>&1 | tail -3",
       "expected": ".overcommit.yml not found; lefthook pre-commit runs"
     },
     "owner": "implementer-1",
     "learnings": [
-      "Qualis uses Ruby 3.4.8 via rbenv but the shell defaults to rvm Ruby 3.2.2 - must set PATH to include rbenv versions for bundle exec commands",
+      "AcmeOrgC uses Ruby 3.4.8 via rbenv but the shell defaults to rvm Ruby 3.2.2 - must set PATH to include rbenv versions for bundle exec commands",
       "Overcommit hooks are Ruby scripts installed in .git/hooks/ - safe to delete manually when overcommit binary can't run due to Ruby version mismatch"
     ]
   }

--- a/plans/completed/delightful-napping-lemon/tasks/11.json
+++ b/plans/completed/delightful-napping-lemon/tasks/11.json
@@ -1,8 +1,8 @@
 {
   "id": "11",
-  "subject": "Qualis downstream — preserve project-specific CLAUDE.md content",
-  "description": "**Type:** Task\\n\\n**Description:** In `~/workspace/qualis/app`:\\n1. Lisa has already overwritten CLAUDE.md with Rails governance version\\n2. The original CLAUDE.md content (Docker setup, architecture docs, AWS access, deployment) was committed in git before Lisa ran\\n3. Retrieve the original content: `cd ~/workspace/qualis/app && git show HEAD~1:CLAUDE.md` (or from git history)\\n4. Move relevant sections to `.claude/rules/PROJECT_RULES.md` (create-only, Lisa won't overwrite)\\n5. Organize content under clear headings: Local Development, Architecture, Deployment, Environment Variables\\n\\n**Acceptance Criteria:**\\n- [ ] CLAUDE.md contains Rails governance rules (from Lisa)\\n- [ ] `.claude/rules/PROJECT_RULES.md` contains Qualis-specific operational docs\\n- [ ] No content lost from original CLAUDE.md\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"cd ~/workspace/qualis/app && grep 'bundle exec rubocop' CLAUDE.md && grep -c 'Docker\\\\\\\\|ECS\\\\\\\\|deployment' .claude/rules/PROJECT_RULES.md\\\",\\\"expected\\\":\\\"CLAUDE.md has rubocop reference; PROJECT_RULES.md has Docker/deployment content\\\"}}\\n```",
-  "activeForm": "Preserving Qualis CLAUDE.md content",
+  "subject": "AcmeOrgC downstream — preserve project-specific CLAUDE.md content",
+  "description": "**Type:** Task\\n\\n**Description:** In `~/workspace/acmeorgc/app`:\\n1. Lisa has already overwritten CLAUDE.md with Rails governance version\\n2. The original CLAUDE.md content (Docker setup, architecture docs, AWS access, deployment) was committed in git before Lisa ran\\n3. Retrieve the original content: `cd ~/workspace/acmeorgc/app && git show HEAD~1:CLAUDE.md` (or from git history)\\n4. Move relevant sections to `.claude/rules/PROJECT_RULES.md` (create-only, Lisa won't overwrite)\\n5. Organize content under clear headings: Local Development, Architecture, Deployment, Environment Variables\\n\\n**Acceptance Criteria:**\\n- [ ] CLAUDE.md contains Rails governance rules (from Lisa)\\n- [ ] `.claude/rules/PROJECT_RULES.md` contains AcmeOrgC-specific operational docs\\n- [ ] No content lost from original CLAUDE.md\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"cd ~/workspace/acmeorgc/app && grep 'bundle exec rubocop' CLAUDE.md && grep -c 'Docker\\\\\\\\|ECS\\\\\\\\|deployment' .claude/rules/PROJECT_RULES.md\\\",\\\"expected\\\":\\\"CLAUDE.md has rubocop reference; PROJECT_RULES.md has Docker/deployment content\\\"}}\\n```",
+  "activeForm": "Preserving AcmeOrgC CLAUDE.md content",
   "owner": "implementer-1",
   "status": "completed",
   "blocks": [
@@ -17,12 +17,12 @@
     "skills": [],
     "verification": {
       "type": "manual-check",
-      "command": "cd ~/workspace/qualis/app && grep 'bundle exec rubocop' CLAUDE.md && grep -c 'Docker\\\\|ECS\\\\|deployment' .claude/rules/PROJECT_RULES.md",
+      "command": "cd ~/workspace/acmeorgc/app && grep 'bundle exec rubocop' CLAUDE.md && grep -c 'Docker\\\\|ECS\\\\|deployment' .claude/rules/PROJECT_RULES.md",
       "expected": "CLAUDE.md has rubocop reference; PROJECT_RULES.md has Docker/deployment content"
     },
     "owner": "implementer-1",
     "learnings": [
-      "PROJECT_RULES.md was already pre-populated with Qualis-specific content (likely from plan preparation), with overcommit references already updated to lefthook"
+      "PROJECT_RULES.md was already pre-populated with AcmeOrgC-specific content (likely from plan preparation), with overcommit references already updated to lefthook"
     ]
   }
 }

--- a/plans/completed/delightful-napping-lemon/tasks/12.json
+++ b/plans/completed/delightful-napping-lemon/tasks/12.json
@@ -1,8 +1,8 @@
 {
   "id": "12",
-  "subject": "Qualis downstream — verify and commit",
-  "description": "**Type:** Task\\n\\n**Description:** In `~/workspace/qualis/app`:\\n1. Run `bundle exec rubocop` — may have violations from existing code (expected, not blocking)\\n2. Run `bundle exec brakeman --no-pager` — verify it runs (may have findings)\\n3. Run `bundle exec lefthook run pre-commit` — verify hooks execute\\n4. Create a branch, commit all changes, push\\n5. Note: Qualis uses Minitest, so `bundle exec rspec` will fail (no spec/ tests yet). This is expected per design decision #5.\\n\\n**Acceptance Criteria:**\\n- [ ] RuboCop runs without errors (violations OK)\\n- [ ] Brakeman runs without errors\\n- [ ] Lefthook hooks execute\\n- [ ] Changes committed and pushed on a feature branch\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"cd ~/workspace/qualis/app && bundle exec brakeman --no-pager 2>&1 | tail -3\\\",\\\"expected\\\":\\\"Brakeman runs and produces output\\\"}}\\n```",
-  "activeForm": "Verifying and committing Qualis changes",
+  "subject": "AcmeOrgC downstream — verify and commit",
+  "description": "**Type:** Task\\n\\n**Description:** In `~/workspace/acmeorgc/app`:\\n1. Run `bundle exec rubocop` — may have violations from existing code (expected, not blocking)\\n2. Run `bundle exec brakeman --no-pager` — verify it runs (may have findings)\\n3. Run `bundle exec lefthook run pre-commit` — verify hooks execute\\n4. Create a branch, commit all changes, push\\n5. Note: AcmeOrgC uses Minitest, so `bundle exec rspec` will fail (no spec/ tests yet). This is expected per design decision #5.\\n\\n**Acceptance Criteria:**\\n- [ ] RuboCop runs without errors (violations OK)\\n- [ ] Brakeman runs without errors\\n- [ ] Lefthook hooks execute\\n- [ ] Changes committed and pushed on a feature branch\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"cd ~/workspace/acmeorgc/app && bundle exec brakeman --no-pager 2>&1 | tail -3\\\",\\\"expected\\\":\\\"Brakeman runs and produces output\\\"}}\\n```",
+  "activeForm": "Verifying and committing AcmeOrgC changes",
   "owner": "implementer-1",
   "status": "completed",
   "blocks": [
@@ -21,7 +21,7 @@
     "skills": [],
     "verification": {
       "type": "manual-check",
-      "command": "cd ~/workspace/qualis/app && bundle exec brakeman --no-pager 2>&1 | tail -3",
+      "command": "cd ~/workspace/acmeorgc/app && bundle exec brakeman --no-pager 2>&1 | tail -3",
       "expected": "Brakeman runs and produces output"
     },
     "owner": "implementer-1"

--- a/plans/completed/delightful-napping-lemon/tasks/8.json
+++ b/plans/completed/delightful-napping-lemon/tasks/8.json
@@ -1,8 +1,8 @@
 {
   "id": "8",
-  "subject": "Build and dry-run against Qualis",
-  "description": "**Type:** Task\\n\\n**Description:** Build Lisa locally and run against Qualis to verify output:\\n1. `bun run build` in Lisa repo\\n2. `bun run dev -- ~/workspace/qualis/app --dry-run` to preview changes\\n3. Verify: Rails detected, CLAUDE.md is Rails-specific, .rubocop.yml deployed, lefthook.yml deployed, Gemfile.lisa deployed, Gemfile gets eval_gemfile, .overcommit.yml marked for deletion, NO TS artifacts\\n\\n**Acceptance Criteria:**\\n- [ ] Lisa builds without errors\\n- [ ] Dry-run detects \\\"rails\\\" type for Qualis\\n- [ ] No TypeScript artifacts in dry-run output\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"bun run build && bun run dev -- ~/workspace/qualis/app --dry-run 2>&1 | grep -i 'rails'\\\",\\\"expected\\\":\\\"Build succeeds, dry-run shows Rails detected\\\"}}\\n```",
-  "activeForm": "Building Lisa and dry-running against Qualis",
+  "subject": "Build and dry-run against AcmeOrgC",
+  "description": "**Type:** Task\\n\\n**Description:** Build Lisa locally and run against AcmeOrgC to verify output:\\n1. `bun run build` in Lisa repo\\n2. `bun run dev -- ~/workspace/acmeorgc/app --dry-run` to preview changes\\n3. Verify: Rails detected, CLAUDE.md is Rails-specific, .rubocop.yml deployed, lefthook.yml deployed, Gemfile.lisa deployed, Gemfile gets eval_gemfile, .overcommit.yml marked for deletion, NO TS artifacts\\n\\n**Acceptance Criteria:**\\n- [ ] Lisa builds without errors\\n- [ ] Dry-run detects \\\"rails\\\" type for AcmeOrgC\\n- [ ] No TypeScript artifacts in dry-run output\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"bun run build && bun run dev -- ~/workspace/acmeorgc/app --dry-run 2>&1 | grep -i 'rails'\\\",\\\"expected\\\":\\\"Build succeeds, dry-run shows Rails detected\\\"}}\\n```",
+  "activeForm": "Building Lisa and dry-running against AcmeOrgC",
   "owner": "team-lead",
   "status": "completed",
   "blocks": [
@@ -17,7 +17,7 @@
     "skills": [],
     "verification": {
       "type": "manual-check",
-      "command": "bun run build && bun run dev -- ~/workspace/qualis/app --dry-run 2>&1 | grep -i 'rails'",
+      "command": "bun run build && bun run dev -- ~/workspace/acmeorgc/app --dry-run 2>&1 | grep -i 'rails'",
       "expected": "Build succeeds, dry-run shows Rails detected"
     },
     "owner": "team-lead"

--- a/plans/completed/delightful-napping-lemon/tasks/9.json
+++ b/plans/completed/delightful-napping-lemon/tasks/9.json
@@ -1,8 +1,8 @@
 {
   "id": "9",
-  "subject": "Qualis downstream — clean up Gemfile and install",
-  "description": "**Type:** Task\\n\\n**Description:** In `~/workspace/qualis/app`:\\n1. Run `bun run dev -- ~/workspace/qualis/app --yes` from Lisa repo to apply templates\\n2. Remove duplicate gems from Qualis Gemfile (brakeman, rubocop-rails, rubocop-performance already in Gemfile.lisa)\\n3. Remove `rubocop-rails-omakase` gem (replaced by Lisa's .rubocop.yml)\\n4. Remove `overcommit` gem\\n5. Run `cd ~/workspace/qualis/app && bundle install`\\n\\n**Acceptance Criteria:**\\n- [ ] Lisa templates applied to Qualis\\n- [ ] Duplicate gems removed from Gemfile\\n- [ ] overcommit gem removed\\n- [ ] `bundle install` succeeds\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"cd ~/workspace/qualis/app && bundle check\\\",\\\"expected\\\":\\\"The Gemfile's dependencies are satisfied\\\"}}\\n```",
-  "activeForm": "Cleaning up Qualis Gemfile and installing",
+  "subject": "AcmeOrgC downstream — clean up Gemfile and install",
+  "description": "**Type:** Task\\n\\n**Description:** In `~/workspace/acmeorgc/app`:\\n1. Run `bun run dev -- ~/workspace/acmeorgc/app --yes` from Lisa repo to apply templates\\n2. Remove duplicate gems from AcmeOrgC Gemfile (brakeman, rubocop-rails, rubocop-performance already in Gemfile.lisa)\\n3. Remove `rubocop-rails-omakase` gem (replaced by Lisa's .rubocop.yml)\\n4. Remove `overcommit` gem\\n5. Run `cd ~/workspace/acmeorgc/app && bundle install`\\n\\n**Acceptance Criteria:**\\n- [ ] Lisa templates applied to AcmeOrgC\\n- [ ] Duplicate gems removed from Gemfile\\n- [ ] overcommit gem removed\\n- [ ] `bundle install` succeeds\\n\\n**Verification:**\\n```json\\n{\\\"plan\\\":\\\"delightful-napping-lemon\\\",\\\"type\\\":\\\"task\\\",\\\"skills\\\":[],\\\"verification\\\":{\\\"type\\\":\\\"manual-check\\\",\\\"command\\\":\\\"cd ~/workspace/acmeorgc/app && bundle check\\\",\\\"expected\\\":\\\"The Gemfile's dependencies are satisfied\\\"}}\\n```",
+  "activeForm": "Cleaning up AcmeOrgC Gemfile and installing",
   "owner": "implementer-1",
   "status": "completed",
   "blocks": [
@@ -18,7 +18,7 @@
     "skills": [],
     "verification": {
       "type": "manual-check",
-      "command": "cd ~/workspace/qualis/app && bundle check",
+      "command": "cd ~/workspace/acmeorgc/app && bundle check",
       "expected": "The Gemfile's dependencies are satisfied"
     },
     "owner": "implementer-1",

--- a/plans/completed/dynamic-knitting-bird.md
+++ b/plans/completed/dynamic-knitting-bird.md
@@ -1,4 +1,4 @@
-# Apply Lisa to thumbwar/frontend and acmeorgb/frontend-v2
+# Apply Lisa to acmeorgd/frontend and acmeorgb/frontend-v2
 
 ## Overview
 
@@ -8,7 +8,7 @@ Both projects are on Lisa v1.12.1 (current Lisa is v1.15.0+ with the jest setupF
 
 ## Key Risks
 
-### thumbwar/frontend
+### acmeorgd/frontend
 - **On `main` branch** - must create a feature branch first
 - Has `jest.config.js` (CommonJS, multi-project config for eslint-plugins + expo tests). Lisa will create `jest.config.ts` alongside it - the .js file must be deleted or it will conflict
 - `jest.setup.pre.js` is minimal (only `__ExpoImportMetaRegistry` + `structuredClone`) - does NOT define `__DEV__`. Since the updated Lisa template has empty `setupFiles`, no jest-expo setup will run automatically. Need to either use `jest-expo` preset in local config or add `__DEV__` definition to setup.pre.js
@@ -25,17 +25,17 @@ Both projects are on Lisa v1.12.1 (current Lisa is v1.15.0+ with the jest setupF
 ## Execution Plan
 
 ### Task 1: Create feature branches (parallel)
-- `cd ~/workspace/thumbwar/frontend && git checkout -b chore/update-lisa`
+- `cd ~/workspace/acmeorgd/frontend && git checkout -b chore/update-lisa`
 - `cd ~/workspace/acmeorgb/frontend-v2 && git checkout -b chore/update-lisa`
 
 ### Task 2: Run Lisa on both (sequential, from lisa dir)
 ```bash
 cd ~/workspace/lisa
-bun run dev ~/workspace/thumbwar/frontend -y
+bun run dev ~/workspace/acmeorgd/frontend -y
 bun run dev ~/workspace/acmeorgb/frontend-v2 -y
 ```
 
-### Task 3: Fix thumbwar/frontend post-Lisa
+### Task 3: Fix acmeorgd/frontend post-Lisa
 1. **Delete old jest.config.js** - conflicts with new jest.config.ts
 2. **Create jest.config.local.ts** with:
    - Multi-project support for eslint plugin tests (node env)
@@ -73,10 +73,10 @@ bun run dev ~/workspace/acmeorgb/frontend-v2 -y
 
 | File | Project | Action |
 |------|---------|--------|
-| `jest.config.js` | thumbwar | Delete (replaced by jest.config.ts) |
-| `jest.config.local.ts` | thumbwar | Create with project-specific config |
-| `jest.setup.pre.js` | thumbwar | Update to add __DEV__ and RN globals |
-| `jest.thresholds.json` | thumbwar | Update to 98% thresholds |
+| `jest.config.js` | acmeorgd | Delete (replaced by jest.config.ts) |
+| `jest.config.local.ts` | acmeorgd | Create with project-specific config |
+| `jest.setup.pre.js` | acmeorgd | Update to add __DEV__ and RN globals |
+| `jest.thresholds.json` | acmeorgd | Update to 98% thresholds |
 | `jest.config.local.ts` | acmeorgb | Create with project-specific config |
 | Various Lisa-managed files | both | Auto-applied by Lisa |
 
@@ -87,8 +87,8 @@ bun run dev ~/workspace/acmeorgb/frontend-v2 -y
 ## Verification
 
 ```bash
-# thumbwar - verify all quality gates pass
-cd ~/workspace/thumbwar/frontend
+# acmeorgd - verify all quality gates pass
+cd ~/workspace/acmeorgd/frontend
 bun run test:cov
 bun run test:integration
 bun run lint

--- a/plans/completed/fix-cdk-build-and-extensionless-imports/fix-cdk-build-and-extensionless-imports.md
+++ b/plans/completed/fix-cdk-build-and-extensionless-imports/fix-cdk-build-and-extensionless-imports.md
@@ -169,25 +169,25 @@ Projects with non-standard directories override via `tsconfig.local.json` (creat
    bun run test -- --listTests
    ```
 
-5. **Run Lisa against Qualis infrastructure (CDK project):**
+5. **Run Lisa against AcmeOrgC infrastructure (CDK project):**
    ```bash
-   cd /Users/cody/workspace/qualis/infrastructure && npx @codyswann/lisa@local .
+   cd /Users/cody/workspace/acmeorgc/infrastructure && npx @codyswann/lisa@local .
    ```
 
-6. **Qualis build passes:**
+6. **AcmeOrgC build passes:**
    ```bash
-   cd /Users/cody/workspace/qualis/infrastructure && npm run build
+   cd /Users/cody/workspace/acmeorgc/infrastructure && npm run build
    ```
 
-7. **Qualis npm install prepare step works:**
+7. **AcmeOrgC npm install prepare step works:**
    ```bash
-   cd /Users/cody/workspace/qualis/infrastructure && npm install
+   cd /Users/cody/workspace/acmeorgc/infrastructure && npm install
    ```
    Expected: prepare runs `husky install || true`
 
-8. **Qualis ESLint works:**
+8. **AcmeOrgC ESLint works:**
    ```bash
-   cd /Users/cody/workspace/qualis/infrastructure && npm run lint
+   cd /Users/cody/workspace/acmeorgc/infrastructure && npm run lint
    ```
 
 ## Task List
@@ -215,9 +215,9 @@ Create these tasks using `TaskCreate`. Tasks 1-3 can run in parallel (independen
 **Skills:** `/coding-philosophy`
 **Verification:** `jq '.force.scripts.prepare' cdk/package-lisa/package.lisa.json` outputs `"husky install || true"` AND `jq '.include' cdk/copy-overwrite/tsconfig.cdk.json` outputs the array
 
-### Task 4: Integration test against Qualis infrastructure
+### Task 4: Integration test against AcmeOrgC infrastructure
 **Type:** Task (blocked by Tasks 1-3)
-**Description:** Run Lisa locally against `/Users/cody/workspace/qualis/infrastructure`. Verify `npm run build` passes, `npm install` prepare step runs `husky install || true`, and `npm run lint` works.
+**Description:** Run Lisa locally against `/Users/cody/workspace/acmeorgc/infrastructure`. Verify `npm run build` passes, `npm install` prepare step runs `husky install || true`, and `npm run lint` works.
 **Skills:** `/coding-philosophy`, `/lisa:integration-test`
 **Verification:** All three commands exit 0
 

--- a/plans/completed/fix-cdk-build-and-extensionless-imports/tasks/b861e8cd-8292-47b9-9efe-2878279cad75/4.json
+++ b/plans/completed/fix-cdk-build-and-extensionless-imports/tasks/b861e8cd-8292-47b9-9efe-2878279cad75/4.json
@@ -1,8 +1,8 @@
 {
   "id": "4",
-  "subject": "Integration test against Qualis infrastructure",
-  "description": "**Type:** Task\n\n**Description:** Run Lisa locally against `/Users/cody/workspace/qualis/infrastructure`. Verify `npm run build` passes, `npm install` prepare step runs `husky install || true`, and `npm run lint` works.\n\n**Skills to Invoke:** `/coding-philosophy`, `/lisa:integration-test`\n\n**Verification:**\n- type: test\n- command: Build, install, and lint Qualis infrastructure\n- expected: All three commands exit 0",
-  "activeForm": "Running integration test against Qualis",
+  "subject": "Integration test against AcmeOrgC infrastructure",
+  "description": "**Type:** Task\n\n**Description:** Run Lisa locally against `/Users/cody/workspace/acmeorgc/infrastructure`. Verify `npm run build` passes, `npm install` prepare step runs `husky install || true`, and `npm run lint` works.\n\n**Skills to Invoke:** `/coding-philosophy`, `/lisa:integration-test`\n\n**Verification:**\n- type: test\n- command: Build, install, and lint AcmeOrgC infrastructure\n- expected: All three commands exit 0",
+  "activeForm": "Running integration test against AcmeOrgC",
   "status": "completed",
   "blocks": [
     "5",
@@ -22,14 +22,14 @@
     ],
     "verification": {
       "type": "test",
-      "command": "cd /Users/cody/workspace/qualis/infrastructure && npm run build && npm install && npm run lint",
+      "command": "cd /Users/cody/workspace/acmeorgc/infrastructure && npm run build && npm install && npm run lint",
       "expected": "All commands exit 0"
     },
     "learnings": [
-      "Qualis CDK build was failing because tsc --noEmit with no include scope picks up eslint/jest config files that use ESM features incompatible with module: commonjs",
+      "AcmeOrgC CDK build was failing because tsc --noEmit with no include scope picks up eslint/jest config files that use ESM features incompatible with module: commonjs",
       "Adding include: [lib/**/*, bin/**/*, test/**/*] to tsconfig.cdk.json fixes the build by scoping tsc to app directories only",
       "tsconfig.eslint.json TS4023 errors with module: preserve are harmless — typescript-eslint parser handles them differently than direct tsc compilation",
-      "Qualis already had prepare: husky install || true from a previous manual fix"
+      "AcmeOrgC already had prepare: husky install || true from a previous manual fix"
     ]
   }
 }

--- a/plans/completed/jest-setup-inheritance/jest-setup-inheritance.md
+++ b/plans/completed/jest-setup-inheritance/jest-setup-inheritance.md
@@ -162,11 +162,11 @@ Update the JSDoc remarks to remove the note about `setupFiles` needing to define
 
 This was already done earlier in this session — verify the change is present (added `"components/ui"` to `exclude` array).
 
-### Task 9: Apply Lisa to ThumbWar and migrate project-specific mocks
+### Task 9: Apply Lisa to AcmeOrgD and migrate project-specific mocks
 
-Run `bun run dev /Users/cody/workspace/thumbwar/frontend` to apply updated templates.
+Run `bun run dev /Users/cody/workspace/acmeorgd/frontend` to apply updated templates.
 
-Then migrate ThumbWar's project-specific mocks:
+Then migrate AcmeOrgD's project-specific mocks:
 
 **`jest.setup.local.ts`** — move these mocks from the current `jest.setup.ts`:
 - `expo/src/winter` mock
@@ -182,7 +182,7 @@ Then migrate ThumbWar's project-specific mocks:
 - `afterEach` clearAllTimers
 - `afterAll` restore warn + useRealTimers
 
-**`jest.setup.pre.local.js`** — move these from `jest.setup.pre.js` (if ThumbWar has project-specific additions beyond the base):
+**`jest.setup.pre.local.js`** — move these from `jest.setup.pre.js` (if AcmeOrgD has project-specific additions beyond the base):
 - `setImmediate`/`clearImmediate` polyfill
 - `ErrorUtils` mock
 - `__ExpoImportMetaRegistry` mock
@@ -191,10 +191,10 @@ Then migrate ThumbWar's project-specific mocks:
 
 **`jest.config.local.ts`** — remove `setupFiles` and `setupFilesAfterEnv` entries (now managed by `jest.expo.ts`).
 
-### Task 10: Verify ThumbWar tests pass
+### Task 10: Verify AcmeOrgD tests pass
 
 ```bash
-cd /Users/cody/workspace/thumbwar/frontend && bun run test
+cd /Users/cody/workspace/acmeorgd/frontend && bun run test
 ```
 
 Expected: 18 suites, 232 tests passing.
@@ -203,7 +203,7 @@ Expected: 18 suites, 232 tests passing.
 
 Run `bun run dev /Users/cody/workspace/acmeorga/frontend` to apply updated templates.
 
-Same migration pattern as ThumbWar: acmeorga has `jest.setup.js` (old) + `jest.setup.ts` (Lisa create-only) + `jest.setup.pre.js`. Move project-specific mocks from `jest.setup.js`/`jest.setup.ts` into `jest.setup.local.ts`, move project-specific pre-setup from `jest.setup.pre.js` into `jest.setup.pre.local.js`, remove `setupFiles`/`setupFilesAfterEnv` from `jest.config.local.ts`, delete old `jest.setup.js`.
+Same migration pattern as AcmeOrgD: acmeorga has `jest.setup.js` (old) + `jest.setup.ts` (Lisa create-only) + `jest.setup.pre.js`. Move project-specific mocks from `jest.setup.js`/`jest.setup.ts` into `jest.setup.local.ts`, move project-specific pre-setup from `jest.setup.pre.js` into `jest.setup.pre.local.js`, remove `setupFiles`/`setupFilesAfterEnv` from `jest.config.local.ts`, delete old `jest.setup.js`.
 
 ### Task 12: Verify acmeorga/frontend tests pass
 
@@ -279,8 +279,8 @@ Re-run all verification commands from completed tasks.
 # Lisa's own tests
 bun run test
 
-# ThumbWar tests after migration
-cd /Users/cody/workspace/thumbwar/frontend && bun run test
+# AcmeOrgD tests after migration
+cd /Users/cody/workspace/acmeorgd/frontend && bun run test
 
 # acmeorga/frontend tests after migration
 cd /Users/cody/workspace/acmeorga/frontend && bun run test

--- a/plans/completed/jest-setup-inheritance/tasks/20.json
+++ b/plans/completed/jest-setup-inheritance/tasks/20.json
@@ -10,7 +10,7 @@
     "plan": "jest-setup-inheritance",
     "type": "task",
     "learnings": [
-      "All verification passed: Lisa (15 suites/218 tests), ThumbWar (18/232), acmeorga (178/2212), frontend-v2 (275/5653)"
+      "All verification passed: Lisa (15 suites/218 tests), AcmeOrgD (18/232), acmeorga (178/2212), frontend-v2 (275/5653)"
     ]
   }
 }

--- a/plans/completed/jest-setup-inheritance/tasks/9.json
+++ b/plans/completed/jest-setup-inheritance/tasks/9.json
@@ -1,8 +1,8 @@
 {
   "id": "9",
-  "subject": "Apply Lisa to ThumbWar and migrate project-specific mocks",
-  "description": "Run bun run dev on ThumbWar, then migrate project-specific mocks to jest.setup.local.ts and jest.setup.pre.local.js. Remove setupFiles from jest.config.local.ts.\n\n**Verification:** `cd /Users/cody/workspace/thumbwar/frontend && bun run test`",
-  "activeForm": "Migrating ThumbWar jest setup",
+  "subject": "Apply Lisa to AcmeOrgD and migrate project-specific mocks",
+  "description": "Run bun run dev on AcmeOrgD, then migrate project-specific mocks to jest.setup.local.ts and jest.setup.pre.local.js. Remove setupFiles from jest.config.local.ts.\n\n**Verification:** `cd /Users/cody/workspace/acmeorgd/frontend && bun run test`",
+  "activeForm": "Migrating AcmeOrgD jest setup",
   "status": "completed",
   "blocks": [],
   "blockedBy": [],
@@ -11,12 +11,12 @@
     "type": "task",
     "verification": {
       "type": "test",
-      "command": "cd /Users/cody/workspace/thumbwar/frontend && bun run test",
+      "command": "cd /Users/cody/workspace/acmeorgd/frontend && bun run test",
       "expected": "18 suites, 232 tests passing"
     },
     "learnings": [
-      "ThumbWar had pre-existing lint error (functional/immutable-data) in jest.setup.ts reanimated mock - fixed with spread pattern",
-      "ThumbWar needed components/ui added to tsconfig.expo.json exclude manually since prior Lisa run didn't include it"
+      "AcmeOrgD had pre-existing lint error (functional/immutable-data) in jest.setup.ts reanimated mock - fixed with spread pattern",
+      "AcmeOrgD needed components/ui added to tsconfig.expo.json exclude manually since prior Lisa run didn't include it"
     ]
   }
 }

--- a/plans/completed/nifty-floating-thacker/fix-cdk-tsconfig-sourcemap.md
+++ b/plans/completed/nifty-floating-thacker/fix-cdk-tsconfig-sourcemap.md
@@ -119,13 +119,13 @@ Create tasks using `TaskCreate` in the following order:
 
 ### Task 2: Run Lisa integration test against downstream CDK project
 
-- **subject:** "Run Lisa integration test against Qualis infrastructure"
-- **activeForm:** "Running Lisa integration test against Qualis infrastructure"
+- **subject:** "Run Lisa integration test against AcmeOrgC infrastructure"
+- **activeForm:** "Running Lisa integration test against AcmeOrgC infrastructure"
 - **Description:**
 
   **Type:** Task
 
-  **Description:** Apply the updated Lisa templates to `/Users/cody/workspace/qualis/infrastructure` and verify the sourceMap conflict is resolved.
+  **Description:** Apply the updated Lisa templates to `/Users/cody/workspace/acmeorgc/infrastructure` and verify the sourceMap conflict is resolved.
 
   **Acceptance Criteria:**
   - [ ] `lisa .` runs successfully against the CDK project
@@ -133,13 +133,13 @@ Create tasks using `TaskCreate` in the following order:
   - [ ] No `TS5053` error when running the build
 
   **Relevant Research:**
-  - Downstream project: `/Users/cody/workspace/qualis/infrastructure`
+  - Downstream project: `/Users/cody/workspace/acmeorgc/infrastructure`
   - Use `/lisa:integration-test` skill
 
   **Skills to Invoke:** `/coding-philosophy`, `/lisa:integration-test`
 
   **Implementation Details:**
-  - Run Lisa against `/Users/cody/workspace/qualis/infrastructure`
+  - Run Lisa against `/Users/cody/workspace/acmeorgc/infrastructure`
   - Verify `tsconfig.cdk.json` in the downstream project now includes `sourceMap: false`
   - Run the project's build script to confirm no TS5053 error
 
@@ -147,7 +147,7 @@ Create tasks using `TaskCreate` in the following order:
 
   **Verification:**
   - **Type:** `manual-check`
-  - **Command:** `cd /Users/cody/workspace/qualis/infrastructure && cat tsconfig.cdk.json | node -e "const fs=require('fs'); const d=JSON.parse(fs.readFileSync('/dev/stdin','utf8')); console.log('sourceMap:', d.compilerOptions.sourceMap, 'inlineSourceMap:', d.compilerOptions.inlineSourceMap);"`
+  - **Command:** `cd /Users/cody/workspace/acmeorgc/infrastructure && cat tsconfig.cdk.json | node -e "const fs=require('fs'); const d=JSON.parse(fs.readFileSync('/dev/stdin','utf8')); console.log('sourceMap:', d.compilerOptions.sourceMap, 'inlineSourceMap:', d.compilerOptions.inlineSourceMap);"`
   - **Expected:** `sourceMap: false inlineSourceMap: true`
 
   **Metadata:**
@@ -158,7 +158,7 @@ Create tasks using `TaskCreate` in the following order:
     "skills": ["/coding-philosophy", "/lisa:integration-test"],
     "verification": {
       "type": "manual-check",
-      "command": "cd /Users/cody/workspace/qualis/infrastructure && cat tsconfig.cdk.json | node -e \"...\"",
+      "command": "cd /Users/cody/workspace/acmeorgc/infrastructure && cat tsconfig.cdk.json | node -e \"...\"",
       "expected": "sourceMap: false inlineSourceMap: true"
     }
   }
@@ -262,7 +262,7 @@ Create tasks using `TaskCreate` in the following order:
 ## Verification
 
 1. Verify `cdk/copy-overwrite/tsconfig.cdk.json` has `sourceMap: false`
-2. Run Lisa against `/Users/cody/workspace/qualis/infrastructure` and confirm no `TS5053` error
+2. Run Lisa against `/Users/cody/workspace/acmeorgc/infrastructure` and confirm no `TS5053` error
 3. PR is open targeting `main`
 
 ## Sessions

--- a/plans/completed/nifty-floating-thacker/tasks/ed275924-2307-40ba-a237-a8fbb021090b/2.json
+++ b/plans/completed/nifty-floating-thacker/tasks/ed275924-2307-40ba-a237-a8fbb021090b/2.json
@@ -1,8 +1,8 @@
 {
   "id": "2",
-  "subject": "Run Lisa integration test against Qualis infrastructure",
-  "description": "**Type:** Task\n\n**Description:** Apply the updated Lisa templates to `/Users/cody/workspace/qualis/infrastructure` and verify the sourceMap conflict is resolved.\n\n**Acceptance Criteria:**\n- [ ] `lisa .` runs successfully against the CDK project\n- [ ] `tsconfig.cdk.json` in the downstream project has `sourceMap: false`\n- [ ] No `TS5053` error when running the build\n\n**Relevant Research:**\n- Downstream project: `/Users/cody/workspace/qualis/infrastructure`\n- Use `/lisa:integration-test` skill\n\n**Skills to Invoke:** `/coding-philosophy`, `/lisa:integration-test`\n\n**Implementation Details:**\n- Run Lisa against `/Users/cody/workspace/qualis/infrastructure`\n- Verify `tsconfig.cdk.json` in the downstream project now includes `sourceMap: false`\n- Run the project's build script to confirm no TS5053 error\n\n**Testing Requirements:** Integration test via `/lisa:integration-test`\n\n**Verification:**\n- **Type:** `manual-check`\n- **Command:** `cd /Users/cody/workspace/qualis/infrastructure && node -e \"const d=require('./tsconfig.cdk.json'); console.log('sourceMap:', d.compilerOptions.sourceMap, 'inlineSourceMap:', d.compilerOptions.inlineSourceMap);\"`\n- **Expected:** `sourceMap: false inlineSourceMap: true`",
-  "activeForm": "Running Lisa integration test against Qualis infrastructure",
+  "subject": "Run Lisa integration test against AcmeOrgC infrastructure",
+  "description": "**Type:** Task\n\n**Description:** Apply the updated Lisa templates to `/Users/cody/workspace/acmeorgc/infrastructure` and verify the sourceMap conflict is resolved.\n\n**Acceptance Criteria:**\n- [ ] `lisa .` runs successfully against the CDK project\n- [ ] `tsconfig.cdk.json` in the downstream project has `sourceMap: false`\n- [ ] No `TS5053` error when running the build\n\n**Relevant Research:**\n- Downstream project: `/Users/cody/workspace/acmeorgc/infrastructure`\n- Use `/lisa:integration-test` skill\n\n**Skills to Invoke:** `/coding-philosophy`, `/lisa:integration-test`\n\n**Implementation Details:**\n- Run Lisa against `/Users/cody/workspace/acmeorgc/infrastructure`\n- Verify `tsconfig.cdk.json` in the downstream project now includes `sourceMap: false`\n- Run the project's build script to confirm no TS5053 error\n\n**Testing Requirements:** Integration test via `/lisa:integration-test`\n\n**Verification:**\n- **Type:** `manual-check`\n- **Command:** `cd /Users/cody/workspace/acmeorgc/infrastructure && node -e \"const d=require('./tsconfig.cdk.json'); console.log('sourceMap:', d.compilerOptions.sourceMap, 'inlineSourceMap:', d.compilerOptions.inlineSourceMap);\"`\n- **Expected:** `sourceMap: false inlineSourceMap: true`",
+  "activeForm": "Running Lisa integration test against AcmeOrgC infrastructure",
   "status": "completed",
   "blocks": [
     "3"
@@ -19,7 +19,7 @@
     ],
     "verification": {
       "type": "manual-check",
-      "command": "cd /Users/cody/workspace/qualis/infrastructure && node -e \"const d=require('./tsconfig.cdk.json'); console.log('sourceMap:', d.compilerOptions.sourceMap, 'inlineSourceMap:', d.compilerOptions.inlineSourceMap);\"",
+      "command": "cd /Users/cody/workspace/acmeorgc/infrastructure && node -e \"const d=require('./tsconfig.cdk.json'); console.log('sourceMap:', d.compilerOptions.sourceMap, 'inlineSourceMap:', d.compilerOptions.inlineSourceMap);\"",
       "expected": "sourceMap: false inlineSourceMap: true"
     },
     "learnings": [

--- a/plans/completed/standardize-expo-configs/standardize-expo-configs.md
+++ b/plans/completed/standardize-expo-configs/standardize-expo-configs.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Three Expo projects (acmeorga, acmeorgb, thumbwar) share the same Lisa-managed base files but have divergent project-specific configs. Investigation revealed:
+Three Expo projects (acmeorga, acmeorgb, acmeorgd) share the same Lisa-managed base files but have divergent project-specific configs. Investigation revealed:
 
 1. **acmeorga's `tsconfig.expo.json`** predates the current Lisa template — uses explicit per-directory path aliases instead of catch-all `@/*`, missing `noEmit`/`allowImportingTsExtensions`, has unnecessary `useUnknownInCatchVariables: false`
 2. **Lisa expo templates are missing** a create-only `jest.config.local.ts` and `babel.config.js`, causing each project to independently create these files with inconsistent patterns
@@ -34,7 +34,7 @@ Content based on the common pattern across all three projects:
 - `babel-preset-expo` with `jsxImportSource: "nativewind"`
 - `nativewind/babel` preset
 
-No `module-resolver` plugin — thumbwar works fine without it (the catch-all `@/*` tsconfig path + jest `moduleNameMapper` handle resolution). Projects that need it can add it in their copy.
+No `module-resolver` plugin — acmeorgd works fine without it (the catch-all `@/*` tsconfig path + jest `moduleNameMapper` handle resolution). Projects that need it can add it in their copy.
 
 ### 3. Add `expo/create-only/jest.setup.pre.js`
 
@@ -62,7 +62,7 @@ Content: Minimal shared mocks (PlatformConstants, AppState, Appearance, DeviceIn
 
 ### 6. Update `expo/copy-overwrite/tsconfig.json` to include `nativewind-env.d.ts`
 
-The Lisa template's `tsconfig.json` doesn't include `nativewind-env.d.ts` in its `include` array, but acmeorgb and thumbwar both added it manually. Since all expo projects use NativeWind, add it to the template.
+The Lisa template's `tsconfig.json` doesn't include `nativewind-env.d.ts` in its `include` array, but acmeorgb and acmeorgd both added it manually. Since all expo projects use NativeWind, add it to the template.
 
 **File**: `expo/copy-overwrite/tsconfig.json`
 

--- a/plans/completed/sync-nestjs-backends/sync-nestjs-backends.md
+++ b/plans/completed/sync-nestjs-backends/sync-nestjs-backends.md
@@ -2,13 +2,13 @@
 
 ## Summary
 
-Run Lisa v1.15.0 against `acmeorgb/backend-v2` and `thumbwar/backend` to bring them up from v1.12.1. This mirrors the frontend sync already completed for acmeorga, acmeorgb, and thumbwar frontends.
+Run Lisa v1.15.0 against `acmeorgb/backend-v2` and `acmeorgd/backend` to bring them up from v1.12.1. This mirrors the frontend sync already completed for acmeorga, acmeorgb, and acmeorgd frontends.
 
 ## Branch Strategy
 
 - **Lisa repo**: Already on `fix/expo-knip-and-tsconfig` with open PR #137 to `main`. Any Lisa template changes push here.
 - **acmeorgb/backend-v2**: Currently on `dev` (protected). Create `chore/lisa-sync-v1.15` from `dev`. PR targets `dev`.
-- **thumbwar/backend**: Currently on `main` (protected). Create `chore/lisa-sync-v1.15` from `main`. PR targets `main`.
+- **acmeorgd/backend**: Currently on `main` (protected). Create `chore/lisa-sync-v1.15` from `main`. PR targets `main`.
 
 ## What Lisa Sync Will Do
 
@@ -49,7 +49,7 @@ The critical manual step is migrating project-specific Jest config into the new 
 
 **`jest.thresholds.json`**: Default 70/70/70/70 matches — no overrides needed (use template default).
 
-### thumbwar/backend
+### acmeorgd/backend
 
 **`jest.config.local.ts`** needs:
 - `rootDir` override: `"."` (template uses `"src"` — need to check which is correct for this project)
@@ -63,7 +63,7 @@ The critical manual step is migrating project-specific Jest config into the new 
 
 ## Post-Sync Cleanup
 
-### thumbwar/backend — Delete legacy files
+### acmeorgd/backend — Delete legacy files
 - `eslint.base.mjs` (replaced by `eslint.base.ts`)
 - `eslint.config.mjs` (replaced by `eslint.config.ts`)
 - `eslint.slow.config.mjs` (replaced by `eslint.slow.config.ts`)
@@ -87,7 +87,7 @@ bun run knip
 
 ## Execution Order
 
-Sequential: acmeorgb/backend-v2 first, then thumbwar/backend. The first sync may reveal issues that inform the second.
+Sequential: acmeorgb/backend-v2 first, then acmeorgd/backend. The first sync may reveal issues that inform the second.
 
 ## Skills Used
 
@@ -104,16 +104,16 @@ Create tasks using `TaskCreate` with the following items. Subagents should handl
 3. **Post-sync cleanup for acmeorgb/backend-v2** — Remove duplicate scripts, verify package.lisa.json, run `bun install`
 4. **Verify acmeorgb/backend-v2** — Run `bun run typecheck`, `bun run test`, `bun run lint`, `bun run format:check`, `bun run knip`. Fix any failures.
 5. **Commit and PR for acmeorgb/backend-v2** — Use `/git:commit` then `/git:submit-pr` targeting `dev`
-6. **Create branch and run Lisa sync on thumbwar/backend** — `cd /Users/cody/workspace/thumbwar/backend && git checkout -b chore/lisa-sync-v1.15 main`, then `cd /Users/cody/workspace/lisa && bun run dev /Users/cody/workspace/thumbwar/backend -y`
-7. **Migrate thumbwar jest config to modular structure** — Move project-specific settings (testRegex `.test.ts`, rootDir `.`, coverage exclusions, moduleNameMapper) into `jest.config.local.ts`, set `jest.thresholds.json` with `{ "global": { "branches": 70, "functions": 68, "lines": 77, "statements": 77 } }`
-8. **Post-sync cleanup for thumbwar/backend** — Delete 4 legacy files (`eslint.base.mjs`, `eslint.config.mjs`, `eslint.slow.config.mjs`, `eslint.thresholds.config.json`), remove duplicate scripts, run `bun install`
-9. **Verify thumbwar/backend** — Run `bun run typecheck`, `bun run test`, `bun run lint`, `bun run format:check`, `bun run knip`. Fix any failures.
-10. **Commit and PR for thumbwar/backend** — Use `/git:commit` then `/git:submit-pr` targeting `main`
+6. **Create branch and run Lisa sync on acmeorgd/backend** — `cd /Users/cody/workspace/acmeorgd/backend && git checkout -b chore/lisa-sync-v1.15 main`, then `cd /Users/cody/workspace/lisa && bun run dev /Users/cody/workspace/acmeorgd/backend -y`
+7. **Migrate acmeorgd jest config to modular structure** — Move project-specific settings (testRegex `.test.ts`, rootDir `.`, coverage exclusions, moduleNameMapper) into `jest.config.local.ts`, set `jest.thresholds.json` with `{ "global": { "branches": 70, "functions": 68, "lines": 77, "statements": 77 } }`
+8. **Post-sync cleanup for acmeorgd/backend** — Delete 4 legacy files (`eslint.base.mjs`, `eslint.config.mjs`, `eslint.slow.config.mjs`, `eslint.thresholds.config.json`), remove duplicate scripts, run `bun install`
+9. **Verify acmeorgd/backend** — Run `bun run typecheck`, `bun run test`, `bun run lint`, `bun run format:check`, `bun run knip`. Fix any failures.
+10. **Commit and PR for acmeorgd/backend** — Use `/git:commit` then `/git:submit-pr` targeting `main`
 11. **Update/add/remove tests** — Verify existing tests still pass in both repos after config migration. No new tests needed (config-only changes).
 12. **Update/add/remove documentation** — Update JSDoc preambles in any new `jest.config.local.ts` files. No markdown doc changes expected.
 13. **Archive this plan** — Create folder `sync-nestjs-backends` in `./plans/completed/`, rename this plan to `sync-nestjs-backends.md`, move it into `./plans/completed/sync-nestjs-backends/`, read session IDs from the plan file, move `~/.claude/tasks/<session-id>` directories to `./plans/completed/sync-nestjs-backends/tasks`
 
-Tasks 1-5 are sequential (acmeorgb). Tasks 6-10 are sequential (thumbwar). Tasks 11-12 can run in parallel after tasks 4 and 9 complete. Task 13 runs last after all others complete.
+Tasks 1-5 are sequential (acmeorgb). Tasks 6-10 are sequential (acmeorgd). Tasks 11-12 can run in parallel after tasks 4 and 9 complete. Task 13 runs last after all others complete.
 
 ## Critical Files
 
@@ -122,6 +122,6 @@ Tasks 1-5 are sequential (acmeorgb). Tasks 6-10 are sequential (thumbwar). Tasks
 - `typescript/copy-overwrite/jest.base.ts` — Shared jest utilities (mergeConfigs, mergeThresholds)
 - `nestjs/package-lisa/package.lisa.json` — NestJS package.json governance
 - `acmeorgb/backend-v2/jest.config.ts` — 99-line custom config to decompose
-- `thumbwar/backend/jest.config.ts` — 41-line custom config to decompose
+- `acmeorgd/backend/jest.config.ts` — 41-line custom config to decompose
 
 ## Sessions

--- a/plans/delegated-seeking-pike.md
+++ b/plans/delegated-seeking-pike.md
@@ -4,7 +4,7 @@
 
 When `@codyswann/lisa` is installed in a downstream project, bun won't run Lisa's postinstall script unless the package is already in `trustedDependencies`. But Lisa's postinstall is what applies templates that add `@codyswann/lisa` to `trustedDependencies` (via the `merge` section). This chicken-and-egg problem means new projects never get Lisa's postinstall to run, so trustedDependencies never gets populated.
 
-**Observed in:** thumbwar/frontend — has `@codyswann/lisa` as a devDependency but it's missing from `trustedDependencies`.
+**Observed in:** acmeorgd/frontend — has `@codyswann/lisa` as a devDependency but it's missing from `trustedDependencies`.
 
 ## Solution
 
@@ -62,4 +62,4 @@ Add test cases:
 1. Run `bun run test:unit` — all existing + new tests pass
 2. Run `bun run lint` — no new violations
 3. Run `bun run typecheck` — no type errors
-4. Integration test: Apply Lisa to thumbwar/frontend and verify `trustedDependencies` includes `@codyswann/lisa`
+4. Integration test: Apply Lisa to acmeorgd/frontend and verify `trustedDependencies` includes `@codyswann/lisa`

--- a/plans/joyful-sleeping-pelican.md
+++ b/plans/joyful-sleeping-pelican.md
@@ -6,7 +6,7 @@ The Jest→Vitest infrastructure migration (Phases 0-7) is complete for Lisa, Ty
 
 1. **CDK/infrastructure projects** — were initially excluded but should migrate to Vitest (CDK tests use Template assertions, not jest.fn/mock, so migration is clean)
 2. **acme-product-b** — merged with Jest preserved, needs test file transformation (48 files, 5 with `jest.isolateModules`)
-3. **NestJS backends** (acmeorga/backend, acmeorgb/backend-v2, thumbwar/backend) — PRs open with vitest config but test files still use Jest APIs via compat shim
+3. **NestJS backends** (acmeorga/backend, acmeorgb/backend-v2, acmeorgd/backend) — PRs open with vitest config but test files still use Jest APIs via compat shim
 
 **Goal:** After this work, only Expo projects should have Jest. All TypeScript, NestJS, CDK, and npm-package projects use Vitest.
 
@@ -79,7 +79,7 @@ Transform test files in downstream projects from Jest APIs to Vitest APIs.
 
 ### B1. Mechanical transformations (all projects)
 
-Applied to: acme-product-b, acmeorga/backend, acmeorgb/backend-v2, thumbwar/backend
+Applied to: acme-product-b, acmeorga/backend, acmeorgb/backend-v2, acmeorgd/backend
 
 For every `.test.ts` and `.spec.ts` file:
 - `jest.fn()` → `vi.fn()`
@@ -146,8 +146,8 @@ NestJS projects had test execution commented out in `.husky/pre-push`. Re-enable
 After Lisa publishes CDK vitest support:
 - acmeorga/infrastructure → main (new PR, previous one already merged with Jest)
 - acmeorgb/infrastructure-v2 → main (new PR)
-- qualis/infrastructure → main (new PR)
-- thumbwar/infrastructure → main (update existing PR #75 or new PR)
+- acmeorgc/infrastructure → main (new PR)
+- acmeorgd/infrastructure → main (update existing PR #75 or new PR)
 
 CDK tests don't use jest.fn(), so no codemod needed — just config swap.
 
@@ -156,7 +156,7 @@ CDK tests don't use jest.fn(), so no codemod needed — just config swap.
 - acmeorgb/acme-product-b → dev (update existing merged code, new PR)
 - acmeorga/backend → staging (update existing open PR #571)
 - acmeorgb/backend-v2 → dev (update existing open PR #612)
-- thumbwar/backend → main (update existing open PR #113)
+- acmeorgd/backend → main (update existing open PR #113)
 
 ---
 
@@ -176,7 +176,7 @@ After each phase:
 - `bun run build && bun run test && bun run typecheck && bun run lint`
 - For downstream: `bun test` locally before pushing
 - Watch CI checks pass before merging
-- Verify deploys succeed (except thumbwar — expected to fail)
+- Verify deploys succeed (except acmeorgd — expected to fail)
 
 ## Sessions
 

--- a/src/core/downstream-names.ts
+++ b/src/core/downstream-names.ts
@@ -1,0 +1,338 @@
+/**
+ * The fixed list of host-project names the shape guard cannot see, stored so
+ * the list itself is never published.
+ *
+ * `downstream-references.ts` detects a *shape* — `github.com/owner/repo` and
+ * workflow `uses:` — and deliberately refuses to match bare `a/b` in prose,
+ * because that shape collides with file paths, date fractions and option
+ * syntax, and a guard with false positives gets disabled. That reasoning is
+ * sound and is left intact. It is also, measured on this repository, blind to
+ * every occurrence that actually happens: a host name in running prose, in a
+ * code comment, or inside a local absolute path, with no `github.com` in front
+ * of it and frequently no slash anywhere in it.
+ *
+ * A known list has no false-positive problem at all, which is the entire
+ * objection to widening the regex — a token either is one of a handful of known
+ * names or it is not, and `2026/08/20`, `src/core/index.ts` and `--flag=a/b`
+ * are none of them. The recorded objection to a list was different: a plaintext
+ * denylist in a public repository publishes the very names it exists to
+ * protect.
+ *
+ * **So the names are stored as truncated salted digests.** Be precise about
+ * what that buys, because overclaiming here would be worse than not doing it:
+ *
+ * - It prevents *enumeration*. Nobody can read this file, grep it, or receive
+ *   it in an npm tarball and come away with a list of names.
+ * - It does **not** prevent *confirmation*. Anyone holding a specific guess can
+ *   hash it and check. That is unavoidable for any in-tree denylist — the guard
+ *   must be able to answer "is this token a host name?", and so must anyone
+ *   holding the data that lets it. Truncation to 40 bits blunts even that:
+ *   a brute force over plausible slugs returns thousands of preimages per
+ *   digest, so a recovered candidate is not a recovered name.
+ *
+ * A name too sensitive to appear even as a digest belongs in
+ * `LISA_DOWNSTREAM_NAMES` instead — an out-of-tree, environment-supplied
+ * extension. The cost of that choice is stated plainly: an environment
+ * variable absent from required CI means the guard bites locally and not in
+ * CI, so it is the weaker of the two placements, not the stronger.
+ * @module core/downstream-names
+ */
+import { createHash } from "node:crypto";
+
+/**
+ * Domain separator mixed into every digest.
+ *
+ * Not a secret — it ships in this file and must, because required CI has to
+ * reproduce the digests. Its job is to make these values specific to this
+ * guard, so a digest here cannot be matched against a digest computed anywhere
+ * else for any other purpose.
+ */
+const DIGEST_SALT = "lisa/downstream-name/v1";
+
+/**
+ * Hex characters kept from each SHA-256 digest — 40 bits.
+ *
+ * Chosen against two opposing errors. Too wide and each digest has a single
+ * preimage, which turns "you can test a guess" into "you can recover the
+ * name". Too narrow and unrelated text collides: the tracked tree yields on the
+ * order of 10^7 candidate spellings per scan, so at 32 bits a handful of
+ * entries would be expected to produce a spurious hit roughly once every few
+ * dozen runs — a flaky guard, which is a disabled guard.
+ */
+const DIGEST_HEX_LENGTH = 10;
+
+/**
+ * Most words one name may span.
+ *
+ * Covers a company name written out in full (`Some Host Systems`) without
+ * paying for windows nobody uses.
+ */
+const MAX_NAME_WORDS = 3;
+
+/**
+ * The single characters allowed to sit between two words of one name.
+ *
+ * A name may be written spaced, hyphenated, underscored, dotted or slashed, and
+ * all of those must reach the same entry. A sentence boundary must not: `". "`
+ * is two characters, so `…the api. Creator of…` cannot join into `apicreator`.
+ */
+const NAME_SEPARATORS = new Set([" ", "-", "_", ".", "/", "\\"]);
+
+/**
+ * Shortest name that may be added at runtime.
+ *
+ * A three-character entry matches an initialism somewhere in almost any
+ * repository. Refusing it is the difference between a list with no
+ * false-positive problem and a list that reintroduces the one the shape guard
+ * was written to avoid.
+ */
+export const MIN_NAME_LENGTH = 5;
+
+/**
+ * Strip a name to the form the digests are taken over.
+ *
+ * Case and separators are spelling, not identity: `Some-Host`, `some host` and
+ * `SomeHost` are one name.
+ * @param raw - A name or a candidate span of source text.
+ * @returns Lowercased, alphanumerics only.
+ */
+export function normalizeName(raw: string): string {
+  return raw.toLowerCase().replaceAll(/[^a-z0-9]+/gu, "");
+}
+
+/**
+ * The stored form of one name: its normalized length, then its digest.
+ *
+ * The length is carried in the clear on purpose. It is what lets a scan reject
+ * the overwhelming majority of candidate spellings with an integer comparison
+ * instead of a hash, and knowing that some name is eight characters long
+ * identifies nobody.
+ * @param raw - The name to encode.
+ * @returns `"<length>:<digest>"`.
+ */
+export function nameEntry(raw: string): string {
+  const normalized = normalizeName(raw);
+  const digest = createHash("sha256")
+    .update(DIGEST_SALT)
+    .update(normalized)
+    .digest("hex")
+    .slice(0, DIGEST_HEX_LENGTH);
+  return `${normalized.length}:${digest}`;
+}
+
+/**
+ * Host org and company names, as entries.
+ *
+ * Org and company slugs only. The two other identity shapes this repository
+ * carries — host repository names and a host tracker's project-key prefix — are
+ * deliberately absent; arming them is a several-hundred-file rewrite and an
+ * owner decision, not a cleanup. See
+ * `.agents/rules/never-name-downstream-projects.md` for how to add one.
+ *
+ * Sorted, so the order of this array says nothing about the order the names
+ * were added or how they relate to each other.
+ */
+export const HOST_NAME_ENTRIES: readonly string[] = [
+  "10:53a6dbd968",
+  "12:b6c1d2ff60",
+  "14:503e0725ea",
+  "6:cd2afeda7f",
+  "7:bf13141dea",
+  "8:3ad5ab7f19",
+  "8:c712a72605",
+];
+
+/** Environment variable carrying extra names, comma-separated, in plaintext. */
+export const NAME_ENV_VAR = "LISA_DOWNSTREAM_NAMES";
+
+/**
+ * Everything a scan needs to test a candidate span, prepared once.
+ *
+ * `lengths` is not a convenience: deriving it per line would cost more than the
+ * matching does, and it is the filter that lets almost every candidate be
+ * rejected on an integer comparison instead of a hash.
+ */
+export interface NameMatcher {
+  /** `"<length>:<digest>"` for every known name. */
+  readonly entries: ReadonlySet<string>;
+  /** Every normalized length present in {@link entries}. */
+  readonly lengths: ReadonlySet<number>;
+  /** The longest normalized length present, used to stop widening a window. */
+  readonly maxLength: number;
+}
+
+/**
+ * Read the process environment through one narrow, reviewable exception.
+ *
+ * The ban exists so application code reaches configuration through a config
+ * service. This is a repository scanner with no project config to reach, and
+ * the variable it reads is the escape hatch for a name too sensitive to commit
+ * even as a digest.
+ * @returns The current process environment.
+ */
+function readProcessEnv(): NodeJS.ProcessEnv {
+  // eslint-disable-next-line no-restricted-syntax -- a repository scanner has no config service to read
+  return process.env;
+}
+
+/**
+ * Matchers already built, keyed by the environment value they were built from.
+ *
+ * Returning the same object for the same environment is what makes the
+ * per-matcher answer cache reachable across files; rebuilding per file would
+ * leave every scan hashing from cold. In practice this holds one entry.
+ */
+const built = new Map<string, NameMatcher>();
+
+/**
+ * Assemble a matcher from the committed entries plus a raw environment value.
+ * @param raw - Comma-separated extra names, possibly empty.
+ * @returns A prepared matcher.
+ */
+function buildMatcher(raw: string): NameMatcher {
+  const extra = raw
+    .split(",")
+    .map(part => normalizeName(part))
+    .filter(name => name.length >= MIN_NAME_LENGTH)
+    .map(name => nameEntry(name));
+  const entries = new Set([...HOST_NAME_ENTRIES, ...extra]);
+  const lengths = [...entries].map(entry =>
+    Number(entry.slice(0, entry.indexOf(":")))
+  );
+  return {
+    entries,
+    lengths: new Set(lengths),
+    maxLength: Math.max(0, ...lengths),
+  };
+}
+
+/**
+ * The matcher a scan should use: the committed entries plus any supplied by
+ * the environment.
+ *
+ * Environment names shorter than {@link MIN_NAME_LENGTH} are dropped rather
+ * than rejected loudly — a scan is not the place to fail a run over a malformed
+ * environment variable, and a silently-ignored short name is visible the moment
+ * anyone checks whether the guard bites.
+ * @param env - Environment to read; defaults to the process environment.
+ * @returns A prepared matcher.
+ */
+export function hostNameEntries(
+  env: NodeJS.ProcessEnv = readProcessEnv()
+): NameMatcher {
+  const raw = env[NAME_ENV_VAR] ?? "";
+  const existing = built.get(raw);
+  if (existing !== undefined) return existing;
+  const matcher = buildMatcher(raw);
+  // eslint-disable-next-line functional/immutable-data -- a pure memo of a pure function; it changes how long an answer takes, never the answer
+  built.set(raw, matcher);
+  return matcher;
+}
+
+/** Maximal runs of alphanumerics — the only thing a name can be made of. */
+const WORD = /[A-Za-z0-9]+/gu;
+
+/**
+ * Per-matcher memo of which candidate spellings are names.
+ *
+ * A repository scan asks about the same handful of words several million times,
+ * and a digest costs three orders of magnitude more than a map lookup. Keyed by
+ * matcher rather than globally, because the answer depends on which entries are
+ * loaded — one shared cache would let a matcher answer another matcher's
+ * question, which is how a guard starts reporting a stale verdict.
+ */
+const answered = new WeakMap<NameMatcher, Map<string, boolean>>();
+
+/**
+ * Whether a candidate spelling is one of the known names.
+ * @param candidate - Alphanumerics only, in whatever case the source used.
+ * @param matcher - Prepared matcher.
+ * @returns True when the candidate hashes to a known entry.
+ */
+function isKnownName(candidate: string, matcher: NameMatcher): boolean {
+  const cache = answered.get(matcher) ?? new Map<string, boolean>();
+  if (!answered.has(matcher)) answered.set(matcher, cache);
+  const remembered = cache.get(candidate);
+  if (remembered !== undefined) return remembered;
+  const known = matcher.entries.has(nameEntry(candidate));
+  // eslint-disable-next-line functional/immutable-data -- same memo, same guarantee
+  cache.set(candidate, known);
+  return known;
+}
+
+/**
+ * Whether `next` continues the name that `previous` started.
+ *
+ * Exactly one separator may sit between them. A sentence boundary is two
+ * characters, so `the api. Creator of` cannot join into `apicreator`.
+ * @param text - The line both words came from.
+ * @param previous - The earlier word match.
+ * @param next - The later word match.
+ * @returns True when the two words belong to one name.
+ */
+function continues(
+  text: string,
+  previous: RegExpExecArray,
+  next: RegExpExecArray
+): boolean {
+  const gap = previous.index + previous[0].length;
+  return next.index - gap === 1 && NAME_SEPARATORS.has(text[gap] ?? "");
+}
+
+/* eslint-disable functional/no-let, functional/immutable-data -- a scan this size cannot afford an allocation per word, and neither accumulator escapes the call */
+/**
+ * Every span starting at one word that spells a known host name.
+ *
+ * The window stops widening as soon as it is longer than the longest known
+ * name, because adding a word can only make it longer still.
+ * @param text - The line being scanned.
+ * @param words - Every word on the line.
+ * @param first - Index of the word the window starts at.
+ * @param matcher - Prepared matcher.
+ * @returns The matched source spans.
+ */
+function namesStartingAt(
+  text: string,
+  words: readonly RegExpExecArray[],
+  first: number,
+  matcher: NameMatcher
+): readonly string[] {
+  const start = words[first]?.index ?? 0;
+  const found: string[] = [];
+  let candidate = "";
+  let previous: RegExpExecArray | undefined;
+  for (const word of words.slice(first, first + MAX_NAME_WORDS)) {
+    if (previous !== undefined && !continues(text, previous, word)) break;
+    previous = word;
+    candidate += word[0];
+    if (candidate.length > matcher.maxLength) break;
+    if (
+      matcher.lengths.has(candidate.length) &&
+      isKnownName(candidate, matcher)
+    ) {
+      found.push(text.slice(start, word.index + word[0].length));
+    }
+  }
+  return found;
+}
+/* eslint-enable functional/no-let, functional/immutable-data -- back to repository defaults */
+
+/**
+ * Every span of one line that spells a known host name.
+ *
+ * Matching is anchored to word boundaries at both ends, which is what keeps a
+ * name from firing inside a longer word: an entry for `somehost` does not match
+ * `somehosting`.
+ * @param text - The line to scan.
+ * @param matcher - Prepared matcher from {@link hostNameEntries}.
+ * @returns The matched source spans, in order.
+ */
+export function findHostNames(
+  text: string,
+  matcher: NameMatcher
+): readonly string[] {
+  const words = [...text.matchAll(WORD)];
+  return words.flatMap((_word, first) =>
+    namesStartingAt(text, words, first, matcher)
+  );
+}

--- a/src/core/downstream-references.ts
+++ b/src/core/downstream-references.ts
@@ -5,13 +5,27 @@
  * public and `dist/` is in the npm `files` allowlist, so a comment in `src/` is
  * published twice — on github.com and to every consumer that installs.
  *
- * **Shape detection, not a name list.** A guard that enumerated the client
- * names would publish the very list it exists to protect, in the same public
- * repository. So this allowlists the orgs that are legitimately public and
- * flags everything else, which also means a NEW downstream project is caught
- * without anyone remembering to add it.
+ * **Two detectors, because one shape was never the whole problem.**
+ *
+ * The first is shape detection: allowlist the orgs that are legitimately
+ * public, flag every other `github.com/owner/repo` or workflow `uses:`, and a
+ * newly onboarded downstream project is caught without anyone remembering to
+ * add it. That reach is real and it is kept.
+ *
+ * The second is a known-name check, added because the first measured zero
+ * violations on a tree that had them. Every occurrence that actually happens is
+ * a bare name in prose, in a code comment, or inside a local absolute path —
+ * no `github.com` in front of it, and frequently no slash in it at all. Shape
+ * detection cannot reach that without matching bare `a/b` everywhere, which
+ * collides with file paths, date fractions and option syntax; a guard with
+ * false positives gets disabled, which is worse than a known blind spot. A
+ * fixed list has no false-positive problem to trade against, and the objection
+ * to a list — that it publishes the names — is answered by storing digests
+ * rather than names. See `./downstream-names.js`.
  * @module core/downstream-references
  */
+import type { NameMatcher } from "./downstream-names.js";
+import { findHostNames, hostNameEntries } from "./downstream-names.js";
 
 /**
  * GitHub orgs this repository may legitimately name.
@@ -181,7 +195,6 @@ const OWNER_REPO =
 
 /**
  * Whether a captured owner is something other than a real account name.
- *
  * @param owner - The lowercased first path segment.
  * @returns True when it must not be treated as an org.
  */
@@ -239,17 +252,41 @@ function accountViolations(
 }
 
 /**
+ * Known host names spelled out on one line.
+ * @param text - The line's text.
+ * @param line - 1-indexed line number.
+ * @param matcher - Prepared name matcher.
+ * @returns Violations on this line.
+ */
+function nameViolations(
+  text: string,
+  line: number,
+  matcher: NameMatcher
+): readonly DownstreamReference[] {
+  return findHostNames(text, matcher).map(match => ({
+    line,
+    match,
+    reason:
+      "names a downstream host project — write the evidence, not the identity",
+  }));
+}
+
+/**
  * Find downstream-project references in one file's contents.
  * @param contents - The file's text.
+ * @param matcher - Name matcher to use; defaults to the committed list plus
+ *   anything the environment adds.
  * @returns Every violation found, in line order.
  */
 export function findDownstreamReferences(
-  contents: string
+  contents: string,
+  matcher: NameMatcher = hostNameEntries()
 ): readonly DownstreamReference[] {
   return contents
     .split("\n")
     .flatMap((text, index) => [
       ...ownerViolations(text, index + 1),
       ...accountViolations(text, index + 1),
+      ...nameViolations(text, index + 1, matcher),
     ]);
 }

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8464,6 +8464,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "src/core/apply-receipt.ts": true,
     "src/core/bootstrap-environment.ts": true,
     "src/core/config.ts": true,
+    "src/core/downstream-names.ts": true,
     "src/core/downstream-references.ts": true,
     "src/core/git-service.ts": true,
     "src/core/guard-capabilities.ts": true,

--- a/src/migrations/ensure-tsconfig-local-includes.ts
+++ b/src/migrations/ensure-tsconfig-local-includes.ts
@@ -95,7 +95,7 @@ async function loadTemplateDefaults(
  *
  * Additionally, this migration preserves a project's narrower include/exclude from
  * the pre-strategy tsconfig.json when the stack template's include/exclude would
- * widen tsc scope. Evidence: thumbwar-backend's tsconfig.json pinned `include: ["src/**\/*"]`
+ * widen tsc scope. Evidence: acmeorgd-backend's tsconfig.json pinned `include: ["src/**\/*"]`
  * but after Lisa overwrote tsconfig.json the stack template's include was used,
  * pulling `vitest.*.ts` into typecheck scope.
  */

--- a/tests/integration/nightly-e2e-report-workflow.test.ts
+++ b/tests/integration/nightly-e2e-report-workflow.test.ts
@@ -350,7 +350,7 @@ describe("the blocking claim is wired end to end (§10.7)", () => {
     // read a `not_required` issue concludes the reporter is broken and
     // hardcodes the sentence back.
     expect(doc).toContain("measurably false");
-    expect(doc).toContain("TunnlAI/frontend");
+    expect(doc).toContain("AcmeOrgB/frontend");
   });
 
   it("the guard reads the EFFECTIVE rules endpoint, never one ruleset by id", () => {

--- a/tests/unit/config/eslint-ignore-wiki.test.ts
+++ b/tests/unit/config/eslint-ignore-wiki.test.ts
@@ -10,8 +10,8 @@
  * because the template is copy-overwrite, every Lisa update clobbered any
  * project's hand-added `wiki/**` entry. `eslint .` then linted
  * `wiki/lisa-wiki.config.json` and failed `sonarjs/no-duplicate-string` on the
- * schema-required enum literals — hitting thumbwar-infrastructure, api-creator,
- * qualis-infrastructure, and thumbwar-frontend.
+ * schema-required enum literals — hitting acmeorgd-infrastructure, api-creator,
+ * acmeorgc-infrastructure, and acmeorgd-frontend.
  *
  * These tests keep the template and the compiled default in lock-step so the
  * regression cannot return silently.

--- a/tests/unit/core/no-downstream-project-names.test.ts
+++ b/tests/unit/core/no-downstream-project-names.test.ts
@@ -20,6 +20,14 @@ import path from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import type { NameMatcher } from "../../../src/core/downstream-names.js";
+import {
+  HOST_NAME_ENTRIES,
+  hostNameEntries,
+  MIN_NAME_LENGTH,
+  NAME_ENV_VAR,
+  nameEntry,
+} from "../../../src/core/downstream-names.js";
 import {
   findDownstreamReferences,
   PLACEHOLDER_ACCOUNTS,
@@ -135,5 +143,142 @@ describe("Lisa never names a downstream project", () => {
     for (const org of PUBLIC_ORGS) {
       expect(org).toBe(org.toLowerCase());
     }
+  });
+});
+
+/**
+ * A matcher built from names that belong to nobody.
+ *
+ * Every example below is invented. The committed list is proved separately, by
+ * its shape and by the scan above — a test that spelled a real name out to
+ * prove the guard catches real names would be the leak the guard exists to
+ * prevent.
+ * @returns A matcher over the synthetic names.
+ */
+const syntheticMatcher = (): NameMatcher =>
+  hostNameEntries({ [NAME_ENV_VAR]: "somehost, Widget Foundry" });
+
+describe("the known-name check reaches the shape the regex cannot", () => {
+  it("flags a bare host name in running prose", () => {
+    // The measurement that made this necessary: the shape guard reported zero
+    // violations on a tree that had 189, and every one of them looked like
+    // this — a name in a sentence, with no `github.com` in front of it.
+    const found = findDownstreamReferences(
+      "Measured against somehost last week.",
+      syntheticMatcher()
+    );
+    expect(found).toHaveLength(1);
+    expect(found[0]?.match).toBe("somehost");
+  });
+
+  it("flags a bare host name in a code comment and in a local path", () => {
+    expect(
+      findDownstreamReferences(
+        "// Evidence: somehost-backend pinned its tsconfig include.",
+        syntheticMatcher()
+      )
+    ).toHaveLength(1);
+    expect(
+      findDownstreamReferences(
+        "/Users/someone/workspace/somehost/infrastructure",
+        syntheticMatcher()
+      )
+    ).toHaveLength(1);
+  });
+
+  it("flags a host name spelled with a separator or a different case", () => {
+    for (const spelling of [
+      "SomeHost",
+      "SOMEHOST",
+      "Widget Foundry",
+      "widget-foundry",
+      "widget_foundry",
+      "WidgetFoundry",
+    ]) {
+      expect(
+        findDownstreamReferences(
+          `see ${spelling} for context`,
+          syntheticMatcher()
+        )
+      ).toHaveLength(1);
+    }
+  });
+
+  it("does NOT fire on file paths, date fractions or option syntax", () => {
+    // This control is the whole reason the shape guard refused to match bare
+    // `a/b` in prose, and it is the property a known list buys outright: none
+    // of these tokens is a name, so none of them can hash to one. A guard that
+    // fired here would be switched off within a day, and a switched-off guard
+    // catches nothing at all.
+    for (const line of [
+      "import { x } from '../../src/core/index.js';",
+      "see src/core/downstream-references.ts:42 for the reason",
+      "Measured 2026/08/20, and again on 08/20/2026",
+      "roughly 3/4 of the tracked files",
+      "run with --exclude=a/b and -o n/a",
+      "docs/decisions/2026-08-19-guard-mutation-gate.md",
+      "uses: actions/checkout@v6",
+      "https://github.com/CodySwannGT/lisa/issues/1",
+    ]) {
+      expect(findDownstreamReferences(line, syntheticMatcher())).toEqual([]);
+    }
+  });
+
+  it("does NOT fire on a longer word that merely starts with a name", () => {
+    // Boundary anchoring at both ends. Without the trailing boundary, an entry
+    // would fire inside every word it happens to prefix, which is the
+    // false-positive class that gets a guard disabled.
+    for (const line of [
+      "somehosting is a different word",
+      "the somehostile takeover",
+      "presomehost and somehostx",
+    ]) {
+      expect(findDownstreamReferences(line, syntheticMatcher())).toEqual([]);
+    }
+  });
+
+  it("does NOT join two words across a sentence boundary", () => {
+    // `". "` is two characters, so it cannot glue `widget` to `Foundry`. One
+    // separator may; a sentence may not.
+    expect(
+      findDownstreamReferences(
+        "shipped the widget. Foundry work lands next.",
+        syntheticMatcher()
+      )
+    ).toEqual([]);
+    expect(
+      findDownstreamReferences(
+        "the widget, foundry, and mill teams",
+        syntheticMatcher()
+      )
+    ).toEqual([]);
+  });
+
+  it("refuses an environment name too short to be safe", () => {
+    // A three-character entry matches an initialism in almost any repository.
+    // Accepting one would hand back the false-positive problem a known list
+    // exists to avoid.
+    const short = hostNameEntries({ [NAME_ENV_VAR]: "abc" });
+    expect(short.entries.size).toBe(HOST_NAME_ENTRIES.length);
+    expect(MIN_NAME_LENGTH).toBeGreaterThan(3);
+  });
+
+  it("keeps the committed list armed and stored as digests, not names", () => {
+    // Two claims, both load-bearing. Armed: an empty list is a guard that
+    // reports a clean tree for the same reason a broken one does. Digests: a
+    // plaintext list in a public repository publishes what it protects.
+    expect(HOST_NAME_ENTRIES.length).toBeGreaterThan(0);
+    for (const entry of HOST_NAME_ENTRIES) {
+      expect(entry).toMatch(/^\d+:[0-9a-f]{10}$/u);
+      expect(Number(entry.split(":")[0])).toBeGreaterThanOrEqual(
+        MIN_NAME_LENGTH
+      );
+    }
+  });
+
+  it("treats case and separators as spelling rather than identity", () => {
+    expect(nameEntry("Some-Host")).toBe(nameEntry("some host"));
+    expect(nameEntry("SomeHost")).toBe(nameEntry("somehost"));
+    expect(nameEntry("somehost")).not.toBe(nameEntry("somehosts"));
   });
 });

--- a/tests/unit/strategies/package-lisa.test.ts
+++ b/tests/unit/strategies/package-lisa.test.ts
@@ -725,7 +725,7 @@ describe("PackageLisaStrategy", () => {
   // `$name` self-reference must be accompanied by the backing direct dependency,
   // otherwise the postinstall (skip-git-check) apply writes a dangling `$esbuild`
   // that passes local checks but fails `npm ci` in CI only. See the fleet ledger:
-  // qualis-infra #177, gemini infra-v2 #335, cdkstarter #13.
+  // acmeorgc-infra #177, gemini infra-v2 #335, cdkstarter #13.
   describe("$name self-reference backing dependency", () => {
     it("materializes the forced devDependency backing a $ref under skip-git-check", async () => {
       await createPackageLisaTemplate("cdk", {
@@ -2022,7 +2022,7 @@ describe("PackageLisaStrategy", () => {
     // jest-expo, the react-native-* runtime libs, @sentry/react-native, etc.)
     // in `force`. Because force REPLACES project values, updating Lisa on an
     // Expo SDK 54 app force-bundled a full SDK 54->56 + RN 0.81->0.85 major
-    // upgrade (blocked acmeorga/frontend, thumbwar/frontend, expostarter).
+    // upgrade (blocked acmeorga/frontend, acmeorgd/frontend, expostarter).
     // The fix moves the SDK-version-coupled packages to `defaults` (project
     // value wins; Lisa is only a fallback for fresh projects), while pure
     // tooling stays in `force`. These tests load the REAL template
@@ -2206,7 +2206,7 @@ describe("PackageLisaStrategy", () => {
       //     calls `Sentry.configureScope`, which Sentry v8 REMOVED — so 3.3.0
       //     throws `(0, t.configureScope) is not a function` on EVERY GraphQL
       //     request at runtime (broke acmeorgb/frontend-v2 in dev and the
-      //     prod path of expostarter/thumbwar where the Sentry DSN is set).
+      //     prod path of expostarter/acmeorgd where the Sentry DSN is set).
       // 4.4.0 (Apollo v3 peer + Sentry v8 API) is the only compatible version,
       // so it is pinned exactly — a range re-opens one failure mode or the other.
       expect(template.force.dependencies["@apollo/client"]).toMatch(/^\^?3\./);
@@ -2419,7 +2419,7 @@ describe("PackageLisaStrategy", () => {
 
   describe("CDK real template: aws-cdk-lib stays in defaults", () => {
     // Regression: aws-cdk-lib was force-pinned EXACTLY (2.246.0), so a
-    // project that had moved ahead (qualis/infrastructure on 2.259.0) got a
+    // project that had moved ahead (acmeorgc/infrastructure on 2.259.0) got a
     // 13-minor downgrade on the next apply — which can break synth for
     // stacks using newer constructs. Projects own their aws-cdk-lib pace;
     // CVE-driven bumps go through per-repo security gates instead. The

--- a/tests/unit/utils/postinstall-trampoline.test.ts
+++ b/tests/unit/utils/postinstall-trampoline.test.ts
@@ -610,7 +610,7 @@ describe("postinstall-trampoline", () => {
       // no lifecycle env var is set so the trampoline never schedules. Without
       // an in-process regen, package-lock.json drifts from package.json and
       // `npm ci` fails. This is the exact failure mode that hit
-      // acmeorgb/infrastructure-v2 and thumbwar/infrastructure during the
+      // acmeorgb/infrastructure-v2 and acmeorgd/infrastructure during the
       // 2.8.0 batch upgrade.
       const { spawnSpy, dir } = await runRegen([NPM_LOCK]);
       try {

--- a/wiki/documentation/claude/review.md
+++ b/wiki/documentation/claude/review.md
@@ -6,4 +6,4 @@ No high-confidence issues found above the 80-point threshold. Checked for bugs, 
 
 Minor notes (below threshold, informational):
 - `src/detection/detectors/rails.ts` — missing `@module` JSDoc tag (CLAUDE.md: "Always create clear documentation preambles with JSDoc for new code")
-- `rails/copy-overwrite/.rubocop.yml` — `TargetRubyVersion: 3.4` may need adjustment for projects on older Ruby versions (e.g., Qualis uses 3.2.2). This is a design decision documented in the plan, not a bug.
+- `rails/copy-overwrite/.rubocop.yml` — `TargetRubyVersion: 3.4` may need adjustment for projects on older Ruby versions (e.g., AcmeOrgC uses 3.2.2). This is a design decision documented in the plan, not a bug.

--- a/wiki/sources/github/2026-05-14-git-and-pr-history.md
+++ b/wiki/sources/github/2026-05-14-git-and-pr-history.md
@@ -954,7 +954,7 @@
 | 4a7284a56ae7588fa5fcce0962b21d52b794a255 | 2026-02-13T06:08:25-05:00 | Cody Swann |  | Merge branch 'main' into chore/agent-delegation-rule |
 | 488d2e2c63d02aba7997cd6b94c0a218ce779704 | 2026-02-13T06:08:15-05:00 | Cody Swann |  | Merge pull request #179 from CodySwannGT/feat/rails-versioning |
 | 1b03add6aa347e146c33966ee6bb9ffc84454caa | 2026-02-13T06:08:08-05:00 | Cody Swann |  | Merge branch 'main' into feat/rails-versioning |
-| 74fe66f23e8637cb9441571c62384de705a5ddc1 | 2026-02-12T19:56:10-05:00 | Cody Swann |  | chore: add qualis staging version display screenshot |
+| 74fe66f23e8637cb9441571c62384de705a5ddc1 | 2026-02-12T19:56:10-05:00 | Cody Swann |  | chore: add acmeorgc staging version display screenshot |
 | 2f49ad260f957d5694e9b3408fb2642358b7ce0c | 2026-02-12T19:56:04-05:00 | Cody Swann |  | docs: add agent team delegation rule to CLAUDE.md templates |
 | 7e12af1050476677a7da387a19925c5650019b72 | 2026-02-12T19:51:49-05:00 | Cody Swann |  | Merge branch 'main' of https://github.com/CodySwannGT/lisa |
 | 847d052971c6d1baef022f10318b27186b09b60a | 2026-02-12T18:26:44-05:00 | Cody Swann |  | feat(rails): add action-controller and action-view best practices skills |

--- a/wiki/sources/memory/2026-05-27-memory.md
+++ b/wiki/sources/memory/2026-05-27-memory.md
@@ -215,7 +215,7 @@ metadata:
 
 The `/lisa-update-projects` skill doc says it reads the project list from `.lisa.config.local.json`, but the actual file in the Lisa monorepo root is **`.lisa.workspaces.json`** (gitignored, local-only). Format is a flat map of `"~/workspace/<path>": "<target-branch>"`.
 
-As of 2026-05-21 it lists projects under acmeorga, acmeorgb/projects, thumbwar, qualis, plus railsstarter and api-creator. The acmeorga repos live at `~/workspace/acmeorga/projects/{backend,frontend,infrastructure}` (separate `acmeorga/*` repos), NOT `~/workspace/acmeorga/{...}` — an older config pointed at the wrong (now-wiki) path; I corrected it.
+As of 2026-05-21 it lists projects under acmeorga, acmeorgb/projects, acmeorgd, acmeorgc, plus railsstarter and api-creator. The acmeorga repos live at `~/workspace/acmeorga/projects/{backend,frontend,infrastructure}` (separate `acmeorga/*` repos), NOT `~/workspace/acmeorga/{...}` — an older config pointed at the wrong (now-wiki) path; I corrected it.
 
 **How to apply:** When running the update batch, read `.lisa.workspaces.json` for the project→branch map. Expand `~` to `/Users/cody`. Determine each project's package manager from `package.json` `engines` (bun=`please-use-npm` ⇒ use npm). Several AcmeOrgA/gemini repos disable repo-level auto-merge — those PRs need manual merge and that's not a failure.
 

--- a/wiki/sources/memory/2026-05-28-memory.md
+++ b/wiki/sources/memory/2026-05-28-memory.md
@@ -215,7 +215,7 @@ metadata:
 
 The `/lisa-update-projects` skill doc says it reads the project list from `.lisa.config.local.json`, but the actual file in the Lisa monorepo root is **`.lisa.workspaces.json`** (gitignored, local-only). Format is a flat map of `"~/workspace/<path>": "<target-branch>"`.
 
-As of 2026-05-21 it lists projects under acmeorga, acmeorgb/projects, thumbwar, qualis, plus railsstarter and api-creator. The acmeorga repos live at `~/workspace/acmeorga/projects/{backend,frontend,infrastructure}` (separate `acmeorga/*` repos), NOT `~/workspace/acmeorga/{...}` — an older config pointed at the wrong (now-wiki) path; I corrected it.
+As of 2026-05-21 it lists projects under acmeorga, acmeorgb/projects, acmeorgd, acmeorgc, plus railsstarter and api-creator. The acmeorga repos live at `~/workspace/acmeorga/projects/{backend,frontend,infrastructure}` (separate `acmeorga/*` repos), NOT `~/workspace/acmeorga/{...}` — an older config pointed at the wrong (now-wiki) path; I corrected it.
 
 **How to apply:** When running the update batch, read `.lisa.workspaces.json` for the project→branch map. Expand `~` to `/Users/cody`. Determine each project's package manager from `package.json` `engines` (bun=`please-use-npm` ⇒ use npm). Several AcmeOrgA/gemini repos disable repo-level auto-merge — those PRs need manual merge and that's not a failure.
 


### PR DESCRIPTION
## What

The downstream-name guard matched only `github.com/owner/repo` and workflow `uses: owner/repo`. On the tracked tree it reported **0 violations while 189 existed across 28 files** — one of them in `src/`, and therefore in every published tarball, because `dist/` is in the npm `files` allowlist. The blind spot was not a rounding error; it was the whole live surface.

## The obvious widening is the wrong fix, and the fence stays where it is

`downstream-references.ts` documents its own gap and the reasoning is sound: bare `a/b` collides with file paths, date fractions and option syntax, and a guard with false positives gets switched off — worse than a known gap. **That comment is kept and the shape detector is unchanged.** Chesterton holds: the fence was drawn in the right place for the right reason. This adds a second fence rather than moving the first.

It is also measurably the wrong fix. Re-measured 2026-08-20 on the tracked tree, excluding `CHANGELOG.md`:

| shape | occurrences | files | old guard saw |
|---|---|---|---|
| org / company slugs | **189** | 28 | 0 |
| host repository names, org stripped | ~490 | ~110 | 0 |
| host tracker project-key prefix | 110 | 52 | 0 |

**A narrowed bare `A/b` prose match reaches neither large shape, because neither contains a slash.** Only a name-list approach reaches them.

## The mechanism: a hashed in-tree denylist

A fixed known list has **no false-positive problem at all** — which is the entire objection to widening the regex. A token either is a known name or it is not, and `2026/08/20`, `src/core/index.ts` and `--flag=a/b` are none of them.

The recorded objection to a list was different: a plaintext denylist in a public repository publishes the very names it protects. Answered by storing **SHA-256 digests truncated to 40 bits, salted with an in-tree domain separator**, and bounded honestly in the module docstring rather than overclaimed:

- It prevents **enumeration** — nobody reads the list out of the repo or the tarball.
- It does **not** prevent **confirmation** — anyone with a specific guess can hash it and check. That is inherent to any in-tree denylist: the guard must be able to answer "is this token a host name?", and so must anyone holding the data that lets it. Truncation blunts it — a brute force returns thousands of preimages per digest, so a recovered candidate is not a recovered name.

A name too sensitive to appear even as a digest goes in `LISA_DOWNSTREAM_NAMES`, with its cost stated: an env var absent from required CI bites locally and not in CI, so it is the weaker placement, not the stronger.

Matching is anchored to word boundaries at both ends and joins words across **at most one** separator, so a name cannot fire inside a longer word and a sentence boundary cannot glue two words into one.

## Measured catch rate

Reproduced independently against the pre-fix tree by running the new detector over all 7,611 tracked files:

```
files with at least one known-name hit: 28
total occurrences caught:              189
```

**189/189 of the seeded shape — 100%, against a guard that saw 0.** Two further shapes stay out and stay owner calls, costed in `.agents/rules/never-name-downstream-projects.md` so nobody has to re-derive them:

- **Host repository names (~490 occurrences, ~110 files).** One line each to add. The cost is a 110-file rewrite in the same commit, because the guard goes red the moment a digest lands — plus real false-positive risk, since these are generic English compounds a repository could legitimately name a directory.
- **Tracker project-key prefix (110 occurrences, 52 files).** Three characters, below the five-character minimum the list enforces for good reason: a three-character entry matches an initialism in almost any repository. It is also load-bearing test data inside BDD grammar fixtures, where it reads as an anonymous placeholder. An example key in a fixture is genuinely not the same object as a live identifier.

All 189 occurrences are scrubbed in this PR, so the tree is green.

## Bite tests and mutation evidence

Every example in the tests is synthetic.

**Positive, with the detector unwired (`findHostNames` returning `[]`):**

```
× flags a bare host name in running prose
× flags a bare host name in a code comment and in a local path
× flags a host name spelled with a separator or a different case
     Tests  3 failed | 10 passed (13)
```

**The false-positive controls are the point, not decoration** — they are the entire reason the fence was drawn where it was. The guard is proved *not* to fire on file paths, `2026/08/20`, `3/4`, `--flag=a/b`, `n/a`, a longer word that merely starts with a name, or two words joined across a sentence boundary.

Mutants, each killed by a control:

| mutant | dies on |
|---|---|
| widen the separator gap (`=== 1` → `<= 2`) | `does NOT join two words across a sentence boundary` |
| make word runs non-maximal | `does NOT fire on a longer word…` **and** the repository scan |
| empty the committed list | `keeps the committed list armed and stored as digests, not names` |
| drop case normalization | two tests |

One mutant survives deliberately: removing the window-length short-circuit is a pure performance change that provably cannot alter a verdict, and pinning it would pin an implementation detail.

## Also

This issue's body was a verbatim copy of #2772's (the nightly-e2e self-bypass decision) — nothing was lost, #2772 still holds that text — and has been rewritten to describe its actual subject.

Work-Item: CodySwannGT/lisa#2783
