### PR TITLE
fix(maestro): retry the failed flows, not the whole suite

### DIFF
--- a/.github/workflows/maestro-native-e2e.yml
+++ b/.github/workflows/maestro-native-e2e.yml
@@ -444,7 +444,17 @@ on:
         default: ''
         type: string
       flow_runner:
-        description: 'Optional shell script path that runs Maestro flows and writes the supplied JUnit report/debug outputs'
+        description: >-
+          Optional shell script path that runs Maestro flows and writes the
+          supplied JUnit report/debug outputs.
+
+          It is invoked as `<runner> <report-path> <debug-dir> <maestro args…>
+          <target>`. The TARGET is the flows directory for a suite run and a
+          single flow FILE when the iOS arm re-runs one failed flow in
+          isolation, so a runner must pass the target through to Maestro rather
+          than assuming it is a directory. The REPORT PATH likewise varies —
+          an isolated re-run is written to its own report so the suite's
+          original one stays intact as the record of what happened first.
         required: false
         default: ''
         type: string
@@ -505,6 +515,61 @@ on:
         description: 'MAESTRO_DRIVER_STARTUP_TIMEOUT for the iOS XCUITest driver, in milliseconds. Bounds how long Maestro waits for the driver to bind its port before abandoning the whole suite.'
         required: false
         default: 240000
+        type: number
+      ios_flow_retry_tag:
+        description: >-
+          Maestro tag that marks a flow as SAFE TO RE-RUN ON ITS OWN, enabling
+          per-flow retry on the iOS arm. Empty (the default) disables the
+          feature entirely and preserves today's behaviour exactly.
+
+          Retry is opt-in per flow because nothing can derive isolation
+          safety. Flows inherit session state and some mutate shared data, and
+          a flow that reads a record an earlier flow created is
+          indistinguishable, from its source, from one that creates its own.
+          Re-running a dependent flow alone manufactures a FALSE failure, which
+          is worse than the flake it was meant to absorb — so a flow is retried
+          only where the project has asserted it stands alone.
+
+          Set this to the tag your project uses (e.g. `retryable`) and add that
+          tag to the flows that carry their own sign-in preamble and own their
+          own fixtures. Leave it empty and no flow is ever re-run.
+        required: false
+        default: ''
+        type: string
+      ios_flow_retry_attempts:
+        description: >-
+          Extra attempts granted to a single retry-eligible flow that failed,
+          on top of its first run. Default 1.
+
+          1 is not timidity, it is what the evidence supports: the faults this
+          exists for are single-shot host and simulator transients — a
+          CoreSimulator placeholder that never got promoted, a touch-up event
+          the starved host never delivered — and a fault that survives a fresh
+          isolated re-run is not one of them. Raising this buys green for a
+          flow that is genuinely sick, which is the failure mode of retry.
+        required: false
+        default: 1
+        type: number
+      ios_flow_retry_rate_percent:
+        description: >-
+          Ceiling on the share of executed flows allowed to fail their first
+          attempt before the run is failed OUTRIGHT and nothing is retried.
+          Default 10.
+
+          This is the honest cost of retry made visible. Retry hides
+          flakiness — that is what it is for — so it needs a rate above which
+          it refuses to help. 10% is set from measurement: the environmental
+          losses this feature absorbs ran at 1 flow in 41 (2.4%), so 10 leaves
+          four times that headroom while a suite losing 5 of 41 still reds. It
+          is checked BEFORE any retry runs, so a breach costs no extra minutes.
+
+          The rate bounds one run. The cross-run signal — a flow that keeps
+          needing a retry — comes from the ledger, which every run publishes as
+          `maestro-ios-retries-<count>`: the count is in the artifact NAME, so
+          a reader compares nights from the artifacts list without opening
+          anything.
+        required: false
+        default: 10
         type: number
       concurrency_group:
         description: >-
@@ -1771,6 +1836,27 @@ jobs:
           echo "MAESTRO_E2E_ARGS=$ARGS" >> "$GITHUB_ENV"
 
       - name: 📱 Run Maestro flows on emulator
+        # THIS ARM IS SINGLE-ATTEMPT BY DECISION, NOT BY OMISSION. The iOS arm
+        # carries both a driver-startup retry and a per-flow retry; this one
+        # carries neither, and a reader comparing the two is owed the reason.
+        #
+        # `android-emulator-runner` executes each LINE of `script:` as its own
+        # `sh -c`, which is why the Maestro invocation below is one very long
+        # line. A retry needs shell state that survives across commands — a
+        # function to call twice, a failed-flow list, a loop counter — and none
+        # of that survives a per-line `sh -c`. Nor can the retry move to a step
+        # AFTER this one: the emulator exists only for the duration of this
+        # action, so by the time a later step could read the JUnit report there
+        # is no device left to re-run anything on. The remaining option is a
+        # SECOND invocation of the action, which boots and provisions a fresh
+        # AVD — minutes of setup to re-run one flow, on a fresh device whose
+        # state is not the state the flow failed in.
+        #
+        # So parity here is not a matter of copying the iOS block across. It
+        # needs the suite invocation extracted behind the `flow_runner` seam
+        # (a caller-supplied script CAN hold multi-line shell), and that is a
+        # larger change than this one. Until then: Android reds on the first
+        # flow failure, exactly as it always has.
         uses: reactivecircus/android-emulator-runner@v2
         env:
           FLOW_RUNNER: ${{ inputs.flow_runner }}
@@ -2286,6 +2372,14 @@ jobs:
           # buys a slow one more room. The retry below is what covers a driver
           # that fails to come up at all.
           MAESTRO_DRIVER_STARTUP_TIMEOUT: ${{ inputs.ios_driver_startup_timeout_ms }}
+          # Per-flow retry policy. Passed through `env` for the same reason
+          # FLOWS_DIR is: a `${{ }}` expansion is substituted into the script
+          # TEXT before bash parses it, so a caller wiring a reusable input to
+          # event-controlled data could inject shell commands. As env vars
+          # these values are only ever data.
+          FLOW_RETRY_TAG: ${{ inputs.ios_flow_retry_tag }}
+          FLOW_RETRY_ATTEMPTS: ${{ inputs.ios_flow_retry_attempts }}
+          FLOW_RETRY_RATE_PERCENT: ${{ inputs.ios_flow_retry_rate_percent }}
         # EXPLICIT `shell: bash` is load-bearing, not style. The default `run`
         # shell is `bash -e {0}` WITHOUT pipefail, and every suite invocation
         # below is piped into `tee` — so without this the exit status read
@@ -2294,49 +2388,370 @@ jobs:
         run: |
           # MAESTRO_E2E_ARGS is a flag list that needs word splitting.
           # shellcheck disable=SC2086
-          run_suite() {
+          run_target() {
             if [ -n "$FLOW_RUNNER" ]; then
-              bash "$FLOW_RUNNER" maestro-ios-report.xml maestro-debug $MAESTRO_E2E_ARGS "$FLOWS_DIR"
+              bash "$FLOW_RUNNER" "$1" maestro-debug $MAESTRO_E2E_ARGS "$2"
             else
-              maestro test "$FLOWS_DIR" \
+              maestro test "$2" \
                 $MAESTRO_E2E_ARGS \
                 --format junit \
-                --output maestro-ios-report.xml \
+                --output "$1" \
                 --debug-output maestro-debug
             fi
           }
 
-          # Retry ONLY on driver startup, never on flow failures. A blanket
-          # retry would double a four-hour suite every time one assertion
-          # reds, and would also paper over the real regressions this suite
-          # exists to find. The signature below is the exception Maestro
-          # throws when the XCUITest runner never binds its port — the whole
-          # suite is lost before flow 1, so re-running it costs nothing that
-          # was not already lost.
+          run_suite() {
+            run_target maestro-ios-report.xml "$FLOWS_DIR"
+          }
+
+          # ------------------------------------------------------------------
+          # Per-flow retry — state, helpers, and the policy that uses them.
+          #
+          # WHAT IS BROKEN TODAY, stated plainly so the next reader does not
+          # have to rediscover it: the driver-startup retry below is the ONLY
+          # retry this workflow has, it fires on one regex, and it re-runs the
+          # WHOLE suite. Every flake that is not a driver-startup timeout —
+          # every per-flow environmental fault — therefore reds the run with no
+          # retry at all. Two measured examples, from nights where one arm was
+          # fully green and the other lost exactly one flow of forty-one:
+          #
+          #   * `launchApp: clearState` failed having executed ZERO steps. On
+          #     iOS `clearState` is uninstall+reinstall; the reinstall
+          #     succeeded (`Success (End) : Install (New)`) but SpringBoard
+          #     never promoted the placeholder, so the launch retried for 10s
+          #     against `LaunchServicesDataMismatch` and then failed with
+          #     `NotFound ("Application ... is unknown to FrontBoard")`.
+          #   * An `assertNotVisible` failed because the touch-UP event was
+          #     never delivered. The driver tapped the correct pixel; the
+          #     simulator log shows `down` with no matching `up` and no
+          #     touch-move evaluations, while the identical tap on the
+          #     identical component 13s earlier received both. The host was
+          #     starved: the pre-tap screenshot took 3,257ms against 132ms
+          #     earlier, and simulator log volume had tripled to ~12,000
+          #     lines/sec.
+          #
+          # Neither has a code fix. Neither matches DRIVER_FAILURE. Both cost a
+          # whole suite re-run to clear by hand.
+          #
+          # DO NOT gate this retry on the failure TEXT. The first example's
+          # JUnit `<failure>` element read, in its entirety, `Unknown error` —
+          # the cause was only in `maestro-debug/.maestro/tests/<ts>/<flow>/`.
+          # A retry keyed on an error string would be the same too-narrow regex
+          # this exists to replace. The report is read for WHICH flows failed,
+          # never for why.
+          # ------------------------------------------------------------------
+          LEDGER="maestro-ios-retries.txt"
+          ROWS="maestro-ios-retry-rows.txt"
+          : > "$ROWS"
+          RETRY_ENABLED=false
+          if [ -n "$FLOW_RETRY_TAG" ]; then
+            RETRY_ENABLED=true
+          fi
+          EXECUTED=0
+          FAILED_COUNT=0
+          SKIPPED_COUNT=0
+          RETRIED=0
+          RECOVERED=0
+          UNRECOVERED=0
+          BREACH=false
+
+          # Count the `<testcase` elements a report actually contains. Same
+          # reading as the flow-count step: the elements are what happened, the
+          # `tests="N"` attribute is what the writer claimed.
+          count_testcases() {
+            { grep -o '<testcase' "$1" || true; } | wc -l | tr -d ' '
+          }
+
+          # The flow FILES that failed, one per line, deduped and sorted.
+          #
+          # Sorted on purpose, not as a tidiness habit: the ledger this feeds
+          # is compared across nights and across arms, and Maestro's execution
+          # order is not a stable key. A set that reorders itself must not read
+          # as a different set.
+          #
+          # The split at EVERY `<testcase` is also load-bearing. A greedy match
+          # over `<testcase .../>` swallows the self-closing slash and then
+          # hunts for the next `</testcase>`, which merges a PASSING case into
+          # the following failing one and reports the passing flow's name
+          # against the failing flow's message. Splitting first means a record
+          # can hold at most one case's body. `${record%%>*}` then trims the
+          # record to its open tag before `file=` is read, so failure TEXT that
+          # happens to contain `file="` cannot be mistaken for the attribute.
+          failed_flow_files() {
+            tr '\n' ' ' < "$1" \
+              | awk '{ gsub(/<testcase/, "\n<testcase"); print }' \
+              | while IFS= read -r record; do
+                  case "$record" in
+                    "<testcase"*) ;;
+                    *) continue ;;
+                  esac
+                  case "$record" in
+                    *"<failure"* | *"<error"*) ;;
+                    *) continue ;;
+                  esac
+                  printf '%s\n' "${record%%>*}" \
+                    | sed -n 's/.*file="\([^"]*\)".*/\1/p'
+                done \
+              | sed '/^$/d' \
+              | LC_ALL=C sort -u
+          }
+
+          # Resolve a report's `file` attribute to a path on disk. The reported
+          # path is repo-relative and exact in every report this workflow
+          # produces; the flows-dir fallback keeps reports from older runners
+          # readable. Mirrors the classifier's `resolveFlowPath`.
+          resolve_flow_path() {
+            if [ -f "$1" ]; then
+              printf '%s\n' "$1"
+              return 0
+            fi
+            if [ -n "$FLOWS_DIR" ] && [ -f "$FLOWS_DIR/$(basename "$1")" ]; then
+              printf '%s\n' "$FLOWS_DIR/$(basename "$1")"
+              return 0
+            fi
+            return 1
+          }
+
+          # Is this flow SAFE to re-run on its own?
+          #
+          # Nothing can derive that. A flow that reads a record an earlier flow
+          # created looks exactly like one that creates its own, so no
+          # inspection of the file can prove independence — and a wrong guess
+          # here manufactures a false failure, which is worse than the flake it
+          # was meant to absorb. So eligibility is DECLARED, per flow, by a
+          # Maestro tag the project names in `ios_flow_retry_tag`. Untagged is
+          # never re-run. A project that configures no tag retries nothing and
+          # behaves exactly as it does today. Silence produces the safe answer,
+          # never the flattering one — the same asymmetry the flake classifier
+          # is built on.
+          #
+          # Both `tags: [a, b]` and the block form are accepted, and only the
+          # flow's Maestro header — everything before the first `---` — is read.
+          flow_is_retryable() {
+            if [ ! -f "$1" ]; then
+              return 1
+            fi
+            awk -v want="$FLOW_RETRY_TAG" '
+              /^---[[:space:]]*$/ { exit }
+              /^tags:/ {
+                intags = 1
+                rest = $0
+                sub(/^tags:[[:space:]]*/, "", rest)
+                if (rest ~ /^\[/) {
+                  gsub(/[][,]/, " ", rest)
+                  n = split(rest, parts, /[[:space:]]+/)
+                  for (i = 1; i <= n; i++) {
+                    gsub(/["]/, "", parts[i])
+                    if (parts[i] == want) { found = 1 }
+                  }
+                  intags = 0
+                }
+                next
+              }
+              intags == 1 && /^[[:space:]]*-[[:space:]]/ {
+                v = $0
+                sub(/^[[:space:]]*-[[:space:]]*/, "", v)
+                gsub(/[[:space:]"]/, "", v)
+                if (v == want) { found = 1 }
+                next
+              }
+              intags == 1 && /^[^[:space:]#]/ { intags = 0 }
+              END { exit(found ? 0 : 1) }
+            ' "$1"
+          }
+
+          # The ledger is the point of this feature, not a by-product of it.
+          # A retry that leaves no trace turns a flow failing 40% of the time
+          # into a permanently green flow nobody ever looks at, and real
+          # defects get found precisely because flakes fail loudly. EVERY run
+          # writes this file — including a clean one, so "0 retries" is a
+          # recorded reading rather than an absence.
+          write_ledger() {
+            RATE=0
+            if [ "$EXECUTED" -gt 0 ]; then
+              RATE=$(( FAILED_COUNT * 100 / EXECUTED ))
+            fi
+            {
+              echo "platform=ios"
+              echo "retry_enabled=$RETRY_ENABLED"
+              echo "retry_tag=$FLOW_RETRY_TAG"
+              echo "retry_attempts_allowed=$FLOW_RETRY_ATTEMPTS"
+              echo "retry_rate_threshold_percent=$FLOW_RETRY_RATE_PERCENT"
+              echo "executed=$EXECUTED"
+              echo "failed_first_attempt=$FAILED_COUNT"
+              echo "retried=$RETRIED"
+              echo "recovered=$RECOVERED"
+              echo "unrecovered=$UNRECOVERED"
+              echo "not_eligible=$SKIPPED_COUNT"
+              echo "retry_rate_percent=$RATE"
+              echo "rate_breach=$BREACH"
+              LC_ALL=C sort "$ROWS"
+            } > "$LEDGER"
+            cat "$LEDGER"
+          }
+
+          record_row() {
+            printf 'flow|%s|%s|%s\n' "$1" "$2" "$3" >> "$ROWS"
+          }
+
+          count_report_flows() {
+            if [ -f maestro-ios-report.xml ]; then
+              count_testcases maestro-ios-report.xml
+            else
+              echo 0
+            fi
+          }
+
+          retry_failed_flows() {
+            if [ -f maestro-ios-report.xml ]; then
+              EXECUTED=$(count_testcases maestro-ios-report.xml)
+              FAILED_LIST=$(failed_flow_files maestro-ios-report.xml)
+            else
+              FAILED_LIST=""
+            fi
+            if [ -n "$FAILED_LIST" ]; then
+              FAILED_COUNT=$(printf '%s\n' "$FAILED_LIST" | wc -l | tr -d ' ')
+            fi
+
+            if [ "$RETRY_ENABLED" != "true" ]; then
+              SKIPPED_COUNT=$FAILED_COUNT
+              echo "::notice::Per-flow retry is off (ios_flow_retry_tag is empty) — $FAILED_COUNT failed flow(s) stand."
+              write_ledger
+              return 1
+            fi
+
+            if [ "$FAILED_COUNT" -eq 0 ]; then
+              echo "::notice::The suite failed but its report names no failed flow — there is nothing to re-run."
+              write_ledger
+              return 1
+            fi
+
+            # The rate budget is checked BEFORE anything is re-run, and a
+            # breach means nothing is re-run at all. Above the budget the arm
+            # is degraded or the failures are real; either way, spending the
+            # job's remaining minutes on retries buys a green that hides which
+            # of the two it was.
+            if [ "$EXECUTED" -gt 0 ] && [ "$(( FAILED_COUNT * 100 ))" -gt "$(( FLOW_RETRY_RATE_PERCENT * EXECUTED ))" ]; then
+              BREACH=true
+              SKIPPED_COUNT=$FAILED_COUNT
+              while IFS= read -r reported; do
+                if [ -n "$reported" ]; then
+                  record_row "$reported" 1 over-budget
+                fi
+              done <<< "$FAILED_LIST"
+              echo "::error title=Maestro retry budget exceeded (ios)::$FAILED_COUNT of $EXECUTED flow(s) failed on the first attempt, above the ${FLOW_RETRY_RATE_PERCENT}% budget. NOTHING was retried. A rate this high is a degraded arm or a real regression, and retrying would spend the job's budget hiding which."
+              write_ledger
+              return 1
+            fi
+
+            ELIGIBLE_LIST=""
+            SKIPPED_LIST=""
+            while IFS= read -r reported; do
+              if [ -z "$reported" ]; then
+                continue
+              fi
+              resolved=$(resolve_flow_path "$reported" || true)
+              if [ -n "$resolved" ] && flow_is_retryable "$resolved"; then
+                ELIGIBLE_LIST=$(printf '%s\n%s' "$ELIGIBLE_LIST" "$resolved")
+              else
+                SKIPPED_LIST=$(printf '%s\n%s' "$SKIPPED_LIST" "$reported")
+              fi
+            done <<< "$FAILED_LIST"
+            ELIGIBLE_LIST=$(printf '%s\n' "$ELIGIBLE_LIST" | sed '/^$/d' | LC_ALL=C sort -u)
+            SKIPPED_LIST=$(printf '%s\n' "$SKIPPED_LIST" | sed '/^$/d' | LC_ALL=C sort -u)
+
+            while IFS= read -r skipped; do
+              if [ -n "$skipped" ]; then
+                SKIPPED_COUNT=$(( SKIPPED_COUNT + 1 ))
+                record_row "$skipped" 1 not-eligible
+                echo "::notice::$skipped failed and carries no '$FLOW_RETRY_TAG' tag — not re-run. Tag it only if it is genuinely safe to run on its own."
+              fi
+            done <<< "$SKIPPED_LIST"
+
+            while IFS= read -r flow; do
+              if [ -z "$flow" ]; then
+                continue
+              fi
+              attempt=0
+              outcome=unrecovered
+              while [ "$attempt" -lt "$FLOW_RETRY_ATTEMPTS" ]; do
+                attempt=$(( attempt + 1 ))
+                slug=$(printf '%s' "$flow" | tr -c 'A-Za-z0-9._-' '-')
+                retry_report="maestro-ios-retry-${slug}-${attempt}.xml"
+                echo "::warning title=Maestro flow retried (ios)::$flow failed and is being re-run on its own (attempt $(( attempt + 1 ))). A retry is a SYMPTOM. Read the maestro-ios-retries artifact before treating this run as a clean green."
+                if run_target "$retry_report" "$flow" 2>&1 | tee "maestro-ios-retry-${slug}-${attempt}.log"; then
+                  ran=0
+                  if [ -f "$retry_report" ]; then
+                    ran=$(count_testcases "$retry_report")
+                  fi
+                  if [ "$ran" -eq 0 ]; then
+                    # A re-run that executed nothing exits 0. Trusting that
+                    # status would turn every tag-filtered flow into a
+                    # permanent false green — the same fail-open shape as a
+                    # suite reporting success having tested nothing.
+                    echo "::error title=Retry executed nothing (ios)::The isolated re-run of $flow succeeded having executed 0 flows, so this run's tag filters exclude it. Counting it as NOT recovered: a zero-flow re-run proves nothing."
+                    outcome=vacuous
+                    break
+                  fi
+                  outcome=recovered
+                  break
+                fi
+              done
+              RETRIED=$(( RETRIED + 1 ))
+              record_row "$flow" "$(( attempt + 1 ))" "$outcome"
+              if [ "$outcome" = "recovered" ]; then
+                RECOVERED=$(( RECOVERED + 1 ))
+              else
+                UNRECOVERED=$(( UNRECOVERED + 1 ))
+              fi
+            done <<< "$ELIGIBLE_LIST"
+
+            write_ledger
+
+            if [ "$FAILED_COUNT" -gt 0 ] && [ "$RECOVERED" -eq "$FAILED_COUNT" ]; then
+              echo "::notice title=iOS suite green only after per-flow retry::$RECOVERED of $EXECUTED flow(s) needed an isolated re-run. This is NOT the same result as a first-time green; a flow that keeps appearing here is a defect, not luck."
+              return 0
+            fi
+            return 1
+          }
+
+          # Retry the WHOLE SUITE only on driver startup. A blanket suite retry
+          # would double a four-hour run every time one assertion reds. The
+          # signature below is the exception Maestro throws when the XCUITest
+          # runner never binds its port — the whole suite is lost before flow 1,
+          # so re-running it costs nothing that was not already lost.
           DRIVER_FAILURE='IOSDriverTimeoutException|iOS driver not ready in time'
 
           if run_suite 2>&1 | tee maestro-ios-run-1.log; then
+            EXECUTED=$(count_report_flows)
+            write_ledger
             exit 0
           fi
 
-          if ! grep -Eq "$DRIVER_FAILURE" maestro-ios-run-1.log; then
-            echo "::notice::Suite failed on flow results, not on driver startup — not retrying."
+          if grep -Eq "$DRIVER_FAILURE" maestro-ios-run-1.log; then
+            echo "::warning title=iOS driver failed to start::The XCUITest driver did not bind its port within ${MAESTRO_DRIVER_STARTUP_TIMEOUT}ms and NO flow executed. Recycling the simulator and retrying once."
+            xcrun simctl shutdown "$IOS_SIM_UDID" || true
+            xcrun simctl erase "$IOS_SIM_UDID" || true
+            xcrun simctl boot "$IOS_SIM_UDID"
+            xcrun simctl bootstatus "$IOS_SIM_UDID"
+            xcrun simctl install "$IOS_SIM_UDID" "$IOS_APP_PATH"
+
+            if run_suite 2>&1 | tee maestro-ios-run-2.log; then
+              echo "::notice title=iOS driver recovered on retry::The first attempt lost the driver; the retry ran the suite. Treat repeated warnings of this kind as a real defect, not as noise — see the flow-count artifact for what each attempt actually ran."
+              EXECUTED=$(count_report_flows)
+              write_ledger
+              exit 0
+            fi
             exit 1
           fi
 
-          echo "::warning title=iOS driver failed to start::The XCUITest driver did not bind its port within ${MAESTRO_DRIVER_STARTUP_TIMEOUT}ms and NO flow executed. Recycling the simulator and retrying once."
-          xcrun simctl shutdown "$IOS_SIM_UDID" || true
-          xcrun simctl erase "$IOS_SIM_UDID" || true
-          xcrun simctl boot "$IOS_SIM_UDID"
-          xcrun simctl bootstatus "$IOS_SIM_UDID"
-          xcrun simctl install "$IOS_SIM_UDID" "$IOS_APP_PATH"
-
-          if run_suite 2>&1 | tee maestro-ios-run-2.log; then
-            echo "::notice title=iOS driver recovered on retry::The first attempt lost the driver; the retry ran the suite. Treat repeated warnings of this kind as a real defect, not as noise — see the flow-count artifact for what each attempt actually ran."
+          # Not a driver-startup loss, so the suite ran and individual flows
+          # reported. Do not re-run the suite; re-run the failed flows.
+          echo "::notice::Suite failed on flow results, not on driver startup — not retrying the whole suite."
+          if retry_failed_flows; then
             exit 0
           fi
           exit 1
-
       - name: 🔢 Count executed flows
         # Byte-identical to the android job's copy with the platform swapped —
         # see the comment there for why the duplication is deliberate and why
@@ -2474,6 +2889,97 @@ jobs:
           fi
           echo "✅ iOS executed $EXECUTED flow(s)."
 
+      - name: 🚦 Enforce the per-flow retry budget
+        # The loud half of per-flow retry, and the reason the feature is
+        # allowed to exist at all.
+        #
+        # A retry that is invisible is a lie told once per night: a flow
+        # failing 40% of the time goes green forever and nobody looks at it
+        # again. Real defects get found because flakes fail LOUDLY, so every
+        # retry this workflow performs is published three ways — an annotation
+        # on the run, a table in the job summary, and an artifact whose NAME
+        # carries the retry count so nights are comparable from the artifacts
+        # list without opening anything.
+        #
+        # It is also an independent gate. The run step already exits non-zero
+        # for the same conditions; this step re-derives the verdict from the
+        # ledger on disk so neither one alone can turn a red arm green. That is
+        # the same pairing the zero-flow detector uses — a counting step and a
+        # separate assertion that shouts.
+        id: retry_budget
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          LEDGER: maestro-ios-retries.txt
+        run: |
+          if [[ ! -f "$LEDGER" ]]; then
+            # The suite step writes the ledger on every path it can reach. No
+            # ledger means it never ran (a cancelled or crashed job), and there
+            # is no reading to enforce — the zero-flow assertion above owns
+            # that case.
+            echo "retried=0" >> "${GITHUB_OUTPUT:-/dev/null}"
+            echo "No $LEDGER — the suite step never reached a verdict; nothing to enforce."
+            exit 0
+          fi
+          key() { { grep "^$1=" "$LEDGER" || true; } | tail -1 | cut -d= -f2-; }
+          ENABLED=$(key retry_enabled)
+          EXECUTED=$(key executed)
+          FAILED=$(key failed_first_attempt)
+          RETRIED=$(key retried)
+          RECOVERED=$(key recovered)
+          UNRECOVERED=$(key unrecovered)
+          NOT_ELIGIBLE=$(key not_eligible)
+          RATE=$(key retry_rate_percent)
+          THRESHOLD=$(key retry_rate_threshold_percent)
+          BREACH=$(key rate_breach)
+          echo "retried=${RETRIED:-0}" >> "${GITHUB_OUTPUT:-/dev/null}"
+          {
+            echo "### 🍎 iOS per-flow retry ledger"
+            echo ""
+            echo "| flow | attempts | outcome |"
+            echo "| --- | --- | --- |"
+            # Rows are written sorted by flow path, so this table is
+            # byte-comparable between two runs that executed the same flows in
+            # a different order.
+            { grep '^flow|' "$LEDGER" || true; } \
+              | awk -F'|' '{ printf "| `%s` | %s | %s |\n", $2, $3, $4 }'
+            echo ""
+            echo "Executed **$EXECUTED**; failed first attempt **$FAILED**; retried **$RETRIED**; recovered **$RECOVERED**."
+            echo ""
+            echo "First-attempt failure rate **${RATE}%**, budget **${THRESHOLD}%**. Per-flow retry enabled: \`$ENABLED\`."
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          if [[ "${RETRIED:-0}" -gt 0 ]]; then
+            echo "::warning title=iOS flows needed a retry::$RETRIED flow(s) of $EXECUTED did not pass on their first attempt this run. Green after a retry is NOT green first time. A flow that appears in this ledger on consecutive nights is a defect — open maestro-ios-retries-$RETRIED and compare."
+          fi
+          if [[ "$BREACH" == "true" ]]; then
+            echo "::error title=iOS retry budget exceeded::$FAILED of $EXECUTED flow(s) failed their first attempt (${RATE}%), above the ${THRESHOLD}% budget. Nothing was retried and this arm is FAILED. Retry is not the lever here — find out why the arm is losing flows."
+            exit 1
+          fi
+          if [[ "${UNRECOVERED:-0}" -gt 0 ]]; then
+            echo "::error title=iOS flows failed after retry::${UNRECOVERED} flow(s) failed again when re-run on their own. An isolated re-run removes ordering and host contention as explanations, so this is the arm's most credible real-failure signal."
+            exit 1
+          fi
+          if [[ "${NOT_ELIGIBLE:-0}" -gt 0 ]]; then
+            echo "::error title=iOS flows failed and were not retried::${NOT_ELIGIBLE} failed flow(s) are not marked safe to run in isolation, so they were not re-run. Their failures stand."
+            exit 1
+          fi
+          echo "✅ iOS retry budget respected (retried ${RETRIED:-0}, rate ${RATE}% of ${THRESHOLD}%)."
+
+      - name: 📤 Publish the per-flow retry ledger
+        # The RETRY COUNT IS THE ARTIFACT NAME, for the reason the flow-count
+        # artifact gives: a reader — or a nightly health gate — reads the
+        # number off the artifacts LIST, without downloading anything, and can
+        # therefore compare tonight's retries against last night's. `ignore`
+        # rather than `error` because a project that has not enabled the
+        # feature legitimately produces no ledger on a cancelled job.
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: maestro-ios-retries-${{ steps.retry_budget.outputs.retried }}
+          path: maestro-ios-retries.txt
+          if-no-files-found: ignore
+          retention-days: 30
+
       - name: 🔍 Classify Maestro failures (diagnostic, never gating)
         # Byte-identical to the android job's copy with the platform swapped,
         # for the reason the flow-count step gives: a reader compares the two
@@ -2508,6 +3014,9 @@ jobs:
             maestro-ios-report.xml
             maestro-ios-run-1.log
             maestro-ios-run-2.log
+            maestro-ios-retries.txt
+            maestro-ios-retry-*.xml
+            maestro-ios-retry-*.log
             maestro-debug
           # See the Android upload above: `maestro-debug/.maestro/` is hidden,
           # and without this the artifact is the junit XML and nothing else.

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -8773,6 +8773,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/maestro-native-driver-retry.test.ts": true,
     "tests/integration/maestro-native-flake-classification.test.ts": true,
     "tests/integration/maestro-native-flow-runner.test.ts": true,
+    "tests/integration/maestro-native-per-flow-retry.test.ts": true,
     "tests/integration/maestro-native-suite-scope.test.ts": true,
     "tests/integration/maestro-native-workflow.test.ts": true,
     "tests/integration/maestro-native-zero-flow.test.ts": true,

--- a/tests/integration/maestro-native-flow-runner.test.ts
+++ b/tests/integration/maestro-native-flow-runner.test.ts
@@ -103,15 +103,26 @@ describe("maestro-native flow_runner seam", () => {
     // script text.
     expect(iosRun?.env?.FLOWS_DIR).toBe(FLOWS_DIR_EXPANSION);
     expect(iosRun?.run).not.toContain(FLOWS_DIR_EXPANSION);
+    // The invocation is now parameterised by REPORT PATH and TARGET, because
+    // per-flow retry re-runs one flow file through the same seam and writes it
+    // to its own report. The caller's runner therefore still receives the
+    // report path first, the debug dir second, the assembled args, and the
+    // thing to run last — the contract is unchanged, only the two variable
+    // positions are.
     expect(iosRun?.run).toContain(
-      'bash "$FLOW_RUNNER" maestro-ios-report.xml maestro-debug $MAESTRO_E2E_ARGS "$FLOWS_DIR"'
+      'bash "$FLOW_RUNNER" "$1" maestro-debug $MAESTRO_E2E_ARGS "$2"'
     );
-    // Indentation-agnostic on purpose: the invocation now lives inside a
-    // `run_suite()` function so the driver-startup retry can call it twice,
-    // which shifts it two columns. What matters is that the flows dir and the
+    // …and the suite call still supplies exactly the pair the assertion above
+    // used to spell out inline.
+    expect(iosRun?.run).toContain(
+      'run_target maestro-ios-report.xml "$FLOWS_DIR"'
+    );
+    // Indentation-agnostic on purpose: the invocation lives inside functions
+    // so the driver-startup retry and the per-flow retry can both call it,
+    // which shifts it two columns. What matters is that the target and the
     // assembled args still reach the same command, not how deep it sits.
     expect(iosRun?.run.replace(/\n\s+/g, " ")).toContain(
-      'maestro test "$FLOWS_DIR" \\ $MAESTRO_E2E_ARGS'
+      'maestro test "$2" \\ $MAESTRO_E2E_ARGS'
     );
   });
 });

--- a/tests/integration/maestro-native-per-flow-retry.test.ts
+++ b/tests/integration/maestro-native-per-flow-retry.test.ts
@@ -1,0 +1,717 @@
+/* eslint-disable max-lines -- one feature, and each guard is only proved by pairing a positive case with the negative case that dies when the guard is removed; splitting the pairs apart is what makes such a suite unreadable */
+/**
+ * Behavioral tests for per-flow retry, EXECUTED rather than asserted: both the
+ * iOS suite step and the retry-budget gate are pulled verbatim out of the YAML
+ * and run, with the suite stubbed through the workflow's own `flow_runner`
+ * seam.
+ *
+ * ## What is broken today, which is what these tests pin
+ *
+ * The only retry this workflow has fires on the regex
+ * `IOSDriverTimeoutException|iOS driver not ready in time` and re-runs the
+ * WHOLE suite. Every per-flow environmental fault therefore reds a run with no
+ * retry at all — measured twice on nights where one arm was fully green and the
+ * other lost exactly one flow of forty-one, once to a CoreSimulator placeholder
+ * the reinstall never promoted (`LaunchServicesDataMismatch`, then `NotFound
+ * ("Application ... is unknown to FrontBoard")`) and once to a touch-UP event a
+ * starved host never delivered. Neither has a code fix; neither matches that
+ * regex.
+ *
+ * ## The bite controls
+ *
+ * Every guard here is proved in BOTH directions, because a test that cannot
+ * fail is as broken as one that cannot pass:
+ *
+ *  - retry fires for a tagged flow AND does not fire for an untagged one;
+ *  - the rate budget stands down at 9% AND fails the arm at 12%;
+ *  - a re-run that passed is accepted AND a re-run that passed having executed
+ *    ZERO flows is refused;
+ *  - the gate passes a within-budget ledger AND fails a breached one.
+ *
+ * Delete the eligibility check and the untagged case starts retrying. Delete
+ * the budget arithmetic and the 12% case goes green. Delete the zero-flow guard
+ * on a re-run and a tag-filtered flow becomes a permanent false green.
+ *
+ * Sibling of maestro-native-driver-retry.test.ts, which pins the suite-level
+ * retry this one deliberately leaves alone.
+ */
+import * as fs from "fs-extra";
+import yaml from "js-yaml";
+import { execFileSync } from "node:child_process";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..");
+const REUSABLE_YML = path.join(
+  REPO_ROOT,
+  ".github",
+  "workflows",
+  "maestro-native-e2e.yml"
+);
+
+/** `bash` by absolute path — never resolved through a writeable $PATH. */
+const BASH = "/bin/bash";
+
+/** The per-flow retry ledger the suite step writes and the gate reads. */
+const LEDGER_FILE = "maestro-ios-retries.txt";
+
+/**
+ * Byte order, matching the `LC_ALL=C sort` the workflow uses.
+ *
+ * Deliberately NOT `localeCompare`: the ledger is sorted by a C-locale sort
+ * on the runner, and a comparator that disagreed with it would make this
+ * suite assert an order the artifact does not have.
+ * @param left - First row
+ * @param right - Second row
+ * @returns Negative, zero, or positive per the usual sort contract
+ */
+const byCodePoint = (left: string, right: string): number => {
+  if (left < right) return -1;
+  return left > right ? 1 : 0;
+};
+
+/** How many flows the fixture suite executes, matching the measured arm. */
+const SUITE_SIZE = 41;
+
+/** Shape of a single step inside a workflow job's `steps:` list. */
+interface WorkflowStep {
+  id?: string;
+  name?: string;
+  run?: string;
+  env?: Record<string, unknown>;
+}
+
+/** Root shape of the parsed reusable workflow. */
+interface ReusableWorkflow {
+  on: {
+    workflow_call?: {
+      inputs?: Record<string, { default?: unknown; type?: string }>;
+    };
+  };
+  jobs: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+/** Outcome of executing a workflow step against a fixture. */
+interface StepResult {
+  status: number;
+  attempts: number;
+  output: string;
+  ledger: string | null;
+}
+
+/** How the stubbed runner behaves once the suite has failed. */
+type RetryMode = "retry-passes" | "retry-fails" | "retry-executes-nothing";
+
+/** Knobs for one suite-step execution. */
+interface RunOptions {
+  mode?: RetryMode;
+  /** Flow basenames the fixture report marks as failed. */
+  failing?: readonly string[];
+  /** Flow basenames whose file carries the retry tag. */
+  tagged?: readonly string[];
+  /** Value of the `ios_flow_retry_tag` input. */
+  tag?: string;
+  attempts?: string;
+  ratePercent?: string;
+  /** Emit the failing test cases last rather than first. */
+  reverseOrder?: boolean;
+  /** Emit every failing test case twice. */
+  repeatFailing?: boolean;
+  /** Make the first suite attempt succeed. */
+  suitePasses?: boolean;
+}
+
+/** Flow basenames the fixture project contains. */
+const FLOW_NAMES = Array.from(
+  { length: SUITE_SIZE },
+  (_unused, index) => `flow-${String(index).padStart(2, "0")}`
+);
+
+/**
+ * A JUnit report in Maestro's shape.
+ *
+ * The passing cases are SELF-CLOSING and the failing ones are not, which is the
+ * exact pairing that defeats a greedy `<testcase[^>]*>` match: it swallows the
+ * self-closing slash and reports the passing flow's name against the next
+ * failing flow's message.
+ * @param failing - Basenames of the flows that failed
+ * @param reverseOrder - Emit failing cases last rather than first
+ * @param repeatFailing - Emit each failing case twice, as two suites can
+ * @returns JUnit XML
+ */
+const buildReport = (
+  failing: readonly string[],
+  reverseOrder = false,
+  repeatFailing = false
+): string => {
+  const ordered = reverseOrder ? [...FLOW_NAMES].reverse() : FLOW_NAMES;
+  const rows = ordered.flatMap(name => {
+    if (!failing.includes(name)) {
+      return [
+        `    <testcase name="${name}" file=".maestro/flows/${name}.yaml" status="SUCCESS" time="10"/>`,
+      ];
+    }
+    // The failure BODY carries a decoy `file="…"` and is otherwise the exact
+    // text one of the measured faults produced: `Unknown error`, with the real
+    // cause only in the debug bundle. Both halves are deliberate. The decoy
+    // proves the flow path is read from the open TAG rather than from anywhere
+    // in the record; `Unknown error` is why this retry may never be gated on
+    // matching an error string.
+    const failed =
+      `    <testcase name="${name}" file=".maestro/flows/${name}.yaml" status="ERROR" time="20">\n` +
+      `      <failure>Unknown error (see file="debug/decoy.yaml")</failure>\n    </testcase>`;
+    return repeatFailing ? [failed, failed] : [failed];
+  });
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    "<testsuites>",
+    `  <testsuite name="suite" tests="${SUITE_SIZE}" failures="${failing.length}">`,
+    ...rows,
+    "  </testsuite>",
+    "</testsuites>",
+    "",
+  ].join("\n");
+};
+
+/** A flow file carrying the retry tag in block form. */
+const TAGGED_FLOW =
+  "appId: ${MAESTRO_APP_ID}\ntags:\n  - retryable\n---\n- launchApp\n";
+
+/** The ledger row a flow-07 first-attempt loss produces once it recovers. */
+const FLOW_07_RECOVERED = "flow|.maestro/flows/flow-07.yaml|2|recovered";
+
+/** The same, for flow-01. */
+const FLOW_01_RECOVERED = "flow|.maestro/flows/flow-01.yaml|2|recovered";
+
+/** A flow file carrying no tags at all. */
+const PLAIN_FLOW = "appId: ${MAESTRO_APP_ID}\n---\n- launchApp\n";
+
+describe("maestro-native-e2e per-flow retry (executed)", () => {
+  let workflow: ReusableWorkflow;
+
+  beforeAll(async () => {
+    workflow = yaml.load(
+      await fs.readFile(REUSABLE_YML, "utf-8")
+    ) as ReusableWorkflow;
+  });
+
+  /**
+   * The verbatim `run:` text of a named iOS step — never a copy of it.
+   * @param namePart - Substring of the step's `name:`
+   * @returns The step's shell script exactly as CI will run it
+   */
+  const iosStep = (namePart: string): string => {
+    const step = (workflow.jobs.ios.steps ?? []).find(candidate =>
+      candidate.name?.includes(namePart)
+    );
+    if (!step?.run) throw new Error(`no iOS step matching "${namePart}"`);
+    // No `${{ }}` may survive into the script: an expansion is substituted into
+    // the script TEXT before bash parses it, and executing the step verbatim is
+    // only meaningful if nothing had to be rewritten to make it runnable.
+    expect(step.run).not.toContain("${{");
+    return step.run;
+  };
+
+  /**
+   * Runs the real suite step against a fixture project.
+   * @param options - Fixture and policy knobs
+   * @returns Exit status, stub invocation count, output, and the ledger
+   */
+  const runSuiteStep = async (
+    options: RunOptions = {}
+  ): Promise<StepResult> => {
+    const {
+      mode = "retry-passes",
+      failing = ["flow-07"],
+      tagged = failing,
+      tag = "retryable",
+      attempts = "1",
+      ratePercent = "10",
+      reverseOrder = false,
+      repeatFailing = false,
+      suitePasses = false,
+    } = options;
+
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "maestro-perflow-"));
+    try {
+      const flows = path.join(dir, ".maestro", "flows");
+      await fs.ensureDir(flows);
+      await Promise.all(
+        FLOW_NAMES.map(name =>
+          fs.writeFile(
+            path.join(flows, `${name}.yaml`),
+            tagged.includes(name) ? TAGGED_FLOW : PLAIN_FLOW
+          )
+        )
+      );
+
+      const bin = path.join(dir, "bin");
+      await fs.ensureDir(bin);
+      await fs.writeFile(
+        path.join(bin, "xcrun"),
+        "#!/usr/bin/env bash\nexit 0\n",
+        {
+          mode: 0o755,
+        }
+      );
+
+      const counter = path.join(dir, "attempts");
+      await fs.writeFile(counter, "0");
+      const seedReport = path.join(dir, "seed-report.xml");
+      await fs.writeFile(
+        seedReport,
+        buildReport(failing, reverseOrder, repeatFailing)
+      );
+
+      const stub = path.join(dir, "flow-runner.sh");
+      await fs.writeFile(
+        stub,
+        [
+          "#!/usr/bin/env bash",
+          'n=$(( $(cat "$STUB_ATTEMPTS") + 1 ))',
+          'echo "$n" > "$STUB_ATTEMPTS"',
+          'out="$1"; shift 2',
+          'target="${@: -1}"',
+          'if [ "$n" -eq 1 ]; then',
+          '  cp "$STUB_SEED" "$out"',
+          '  if [ "$STUB_SUITE_PASSES" = "true" ]; then exit 0; fi',
+          '  echo "[FAILED] a flow reported a failure"',
+          "  exit 1",
+          "fi",
+          'if [ "$STUB_MODE" = "retry-fails" ]; then',
+          '  printf \'<testsuites><testsuite tests="1" failures="1"><testcase name="x" file="%s" status="ERROR"><failure>Unknown error</failure></testcase></testsuite></testsuites>\' "$target" > "$out"',
+          "  exit 1",
+          "fi",
+          'if [ "$STUB_MODE" = "retry-executes-nothing" ]; then',
+          '  printf \'<testsuites><testsuite tests="0" failures="0"></testsuite></testsuites>\' > "$out"',
+          "  exit 0",
+          "fi",
+          'printf \'<testsuites><testsuite tests="1" failures="0"><testcase name="x" file="%s" status="SUCCESS"/></testsuite></testsuites>\' "$target" > "$out"',
+          "exit 0",
+        ].join("\n"),
+        { mode: 0o755 }
+      );
+
+      const env = {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        FLOW_RUNNER: stub,
+        FLOWS_DIR: ".maestro/flows",
+        MAESTRO_E2E_ARGS: "",
+        MAESTRO_DRIVER_STARTUP_TIMEOUT: "240000",
+        IOS_SIM_UDID: "STUB-UDID",
+        IOS_APP_PATH: dir,
+        STUB_ATTEMPTS: counter,
+        STUB_SEED: seedReport,
+        STUB_MODE: mode,
+        STUB_SUITE_PASSES: String(suitePasses),
+        FLOW_RETRY_TAG: tag,
+        FLOW_RETRY_ATTEMPTS: attempts,
+        FLOW_RETRY_RATE_PERCENT: ratePercent,
+      };
+
+      let status = 0;
+      let output = "";
+      try {
+        output = execFileSync(
+          BASH,
+          ["-eo", "pipefail", "-c", iosStep("Run Maestro flows on simulator")],
+          { cwd: dir, env, encoding: "utf-8" }
+        );
+      } catch (error) {
+        const failure = error as { status?: number; stdout?: string };
+        status = failure.status ?? -1;
+        output = failure.stdout ?? "";
+      }
+      const ledgerPath = path.join(dir, LEDGER_FILE);
+      return {
+        status,
+        attempts: Number((await fs.readFile(counter, "utf-8")).trim()),
+        output,
+        ledger: (await fs.pathExists(ledgerPath))
+          ? await fs.readFile(ledgerPath, "utf-8")
+          : null,
+      };
+    } finally {
+      await fs.remove(dir);
+    }
+  };
+
+  /**
+   * Reads one `key=value` reading out of a ledger.
+   * @param ledger - Ledger contents
+   * @param key - Reading to fetch
+   * @returns The value, or undefined when the key is absent
+   */
+  const reading = (ledger: string | null, key: string): string | undefined =>
+    (ledger ?? "")
+      .split("\n")
+      .find(line => line.startsWith(`${key}=`))
+      ?.slice(key.length + 1);
+
+  /**
+   * The ledger's per-flow rows as an ORDER-INSENSITIVE set.
+   *
+   * Compared as a set on purpose. Maestro's execution order is not a stable
+   * key, and a caller that reorders its own list must not flip an assertion —
+   * the failure mode a previous review caught in exactly this shape.
+   * @param ledger - Ledger contents
+   * @returns Sorted `flow|attempts|outcome` rows
+   */
+  const rows = (ledger: string | null): string[] =>
+    (ledger ?? "")
+      .split("\n")
+      .filter(line => line.startsWith("flow|"))
+      .sort(byCodePoint);
+
+  /**
+   * The ledger's per-flow rows IN FILE ORDER.
+   *
+   * The set comparison above is the right default, but the ledger also has to
+   * be written in a canonical order — otherwise two runs that saw the same
+   * flows produce different bytes and the night-to-night diff is noise. Only
+   * this accessor can see that property, so only it may be used to assert it.
+   * @param ledger - Ledger contents
+   * @returns `flow|attempts|outcome` rows as written
+   */
+  const rowsInFileOrder = (ledger: string | null): string[] =>
+    (ledger ?? "").split("\n").filter(line => line.startsWith("flow|"));
+
+  describe("the eligibility guard (both directions)", () => {
+    it("re-runs a TAGGED failed flow on its own and recovers the arm", async () => {
+      const result = await runSuiteStep({ failing: ["flow-07"] });
+      expect(result.attempts).toBe(2);
+      expect(result.status).toBe(0);
+      expect(rows(result.ledger)).toEqual([FLOW_07_RECOVERED]);
+      expect(reading(result.ledger, "retried")).toBe("1");
+      expect(reading(result.ledger, "recovered")).toBe("1");
+      expect(result.output).toContain("Maestro flow retried (ios)");
+      expect(result.output).toContain("green only after per-flow retry");
+    });
+
+    it("does NOT re-run an UNTAGGED failed flow", async () => {
+      // The negative half. Delete the eligibility check in the workflow and
+      // this starts failing with attempts === 2 — which is the only thing that
+      // proves the guard is load-bearing rather than decorative. It also pins
+      // the isolation contract: a flow that inherits session state or reads
+      // another flow's fixtures would be re-run alone and fail falsely.
+      const result = await runSuiteStep({ failing: ["flow-07"], tagged: [] });
+      expect(result.attempts).toBe(1);
+      expect(result.status).toBe(1);
+      expect(rows(result.ledger)).toEqual([
+        "flow|.maestro/flows/flow-07.yaml|1|not-eligible",
+      ]);
+      expect(result.output).toContain("not re-run");
+    });
+
+    it("re-runs nothing at all when no retry tag is configured", async () => {
+      const result = await runSuiteStep({ failing: ["flow-07"], tag: "" });
+      expect(result.attempts).toBe(1);
+      expect(result.status).toBe(1);
+      expect(reading(result.ledger, "retry_enabled")).toBe("false");
+      expect(reading(result.ledger, "not_eligible")).toBe("1");
+    });
+  });
+
+  describe("the rate budget (both directions)", () => {
+    it("stands down and retries when the failure rate is inside the budget", async () => {
+      // 4 of 41 == 9%, under the 10% default.
+      const failing = ["flow-01", "flow-02", "flow-03", "flow-04"];
+      const result = await runSuiteStep({ failing });
+      expect(result.status).toBe(0);
+      expect(result.attempts).toBe(1 + failing.length);
+      expect(reading(result.ledger, "rate_breach")).toBe("false");
+      expect(reading(result.ledger, "retry_rate_percent")).toBe("9");
+      expect(rows(result.ledger)).toEqual(
+        failing
+          .map(name => `flow|.maestro/flows/${name}.yaml|2|recovered`)
+          .sort(byCodePoint)
+      );
+    });
+
+    it("fails the arm and retries NOTHING when the rate is over the budget", async () => {
+      // 5 of 41 == 12%, over the 10% default. Nothing is re-run: above the
+      // budget the arm is degraded or the failures are real, and retrying
+      // would spend the job's minutes hiding which.
+      const failing = ["flow-01", "flow-02", "flow-03", "flow-04", "flow-05"];
+      const result = await runSuiteStep({ failing });
+      expect(result.status).toBe(1);
+      expect(result.attempts).toBe(1);
+      expect(reading(result.ledger, "rate_breach")).toBe("true");
+      expect(reading(result.ledger, "retried")).toBe("0");
+      expect(result.output).toContain("retry budget exceeded");
+      expect(rows(result.ledger)).toEqual(
+        failing
+          .map(name => `flow|.maestro/flows/${name}.yaml|1|over-budget`)
+          .sort(byCodePoint)
+      );
+    });
+  });
+
+  describe("what a retry is allowed to prove", () => {
+    it("keeps the arm red when the isolated re-run fails again", async () => {
+      const result = await runSuiteStep({ mode: "retry-fails" });
+      expect(result.attempts).toBe(2);
+      expect(result.status).toBe(1);
+      expect(rows(result.ledger)).toEqual([
+        "flow|.maestro/flows/flow-07.yaml|2|unrecovered",
+      ]);
+    });
+
+    it("refuses a re-run that PASSED having executed zero flows", async () => {
+      // A tag-filtered re-run exits 0 having run nothing. Trusting that status
+      // would turn the flow into a permanent false green — the same fail-open
+      // shape as a suite reporting success having tested nothing.
+      const result = await runSuiteStep({ mode: "retry-executes-nothing" });
+      expect(result.status).toBe(1);
+      expect(rows(result.ledger)).toEqual([
+        "flow|.maestro/flows/flow-07.yaml|2|vacuous",
+      ]);
+      expect(result.output).toContain("Retry executed nothing");
+    });
+
+    it("grants exactly the configured number of extra attempts", async () => {
+      const result = await runSuiteStep({ mode: "retry-fails", attempts: "2" });
+      expect(result.attempts).toBe(3);
+      expect(rows(result.ledger)).toEqual([
+        "flow|.maestro/flows/flow-07.yaml|3|unrecovered",
+      ]);
+    });
+  });
+
+  describe("visibility", () => {
+    it("writes a ledger even for a suite that was green first time", async () => {
+      // "0 retries" has to be a RECORDED READING, not an absence — otherwise
+      // green-after-retry and green-first-time are indistinguishable from the
+      // outside, which is the whole objection to retry.
+      const result = await runSuiteStep({ suitePasses: true, failing: [] });
+      expect(result.status).toBe(0);
+      expect(result.attempts).toBe(1);
+      expect(reading(result.ledger, "retried")).toBe("0");
+      expect(reading(result.ledger, "executed")).toBe(String(SUITE_SIZE));
+      expect(rows(result.ledger)).toEqual([]);
+    });
+
+    it("produces a ledger that does not depend on the report's flow ORDER", async () => {
+      const failing = ["flow-01", "flow-30"];
+      const forward = await runSuiteStep({ failing });
+      const reversed = await runSuiteStep({ failing, reverseOrder: true });
+      // Byte-identical, not merely set-equal: the ledger is diffed between
+      // nights, and a diff that lights up because Maestro reordered itself is
+      // a diff nobody reads twice.
+      expect(reversed.ledger).toBe(forward.ledger);
+      expect(rows(forward.ledger)).toEqual([
+        FLOW_01_RECOVERED,
+        "flow|.maestro/flows/flow-30.yaml|2|recovered",
+      ]);
+    });
+
+    it("writes rows ordered by FLOW, not by which loop produced them", async () => {
+      // Ineligible flows are recorded by one loop and retried flows by
+      // another, so the rows arrive grouped by KIND. Left that way, two nights
+      // that saw the same flows in different roles produce different bytes.
+      // flow-30 is written first and must appear second.
+      const result = await runSuiteStep({
+        failing: ["flow-01", "flow-30"],
+        tagged: ["flow-01"],
+      });
+      expect(result.status).toBe(1);
+      expect(rowsInFileOrder(result.ledger)).toEqual([
+        FLOW_01_RECOVERED,
+        "flow|.maestro/flows/flow-30.yaml|1|not-eligible",
+      ]);
+    });
+
+    it("counts a flow the report names twice as ONE failed flow", async () => {
+      // A flow can appear in more than one `<testsuite>`. Counted twice it
+      // inflates the failure rate — the input that decides whether the arm is
+      // failed outright — and it would be re-run twice for no reason.
+      const result = await runSuiteStep({
+        failing: ["flow-07"],
+        repeatFailing: true,
+      });
+      expect(result.status).toBe(0);
+      expect(reading(result.ledger, "failed_first_attempt")).toBe("1");
+      expect(result.attempts).toBe(2);
+      expect(rows(result.ledger)).toEqual([FLOW_07_RECOVERED]);
+    });
+  });
+
+  describe("the retry-budget gate (both directions)", () => {
+    /**
+     * Executes the gate step against a hand-written ledger.
+     * @param ledger - Ledger contents, or null to omit the file
+     * @returns Exit status, step output, summary text, and step outputs
+     */
+    const gate = async (
+      ledger: string | null
+    ): Promise<{
+      status: number;
+      output: string;
+      summary: string;
+      outputs: string;
+    }> => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "maestro-gate-"));
+      try {
+        if (ledger !== null) {
+          await fs.writeFile(path.join(dir, LEDGER_FILE), ledger);
+        }
+        const outputs = path.join(dir, "outputs");
+        const summary = path.join(dir, "summary");
+        await fs.writeFile(outputs, "");
+        await fs.writeFile(summary, "");
+        let status = 0;
+        let output = "";
+        try {
+          output = execFileSync(
+            BASH,
+            [
+              "-eo",
+              "pipefail",
+              "-c",
+              iosStep("Enforce the per-flow retry budget"),
+            ],
+            {
+              cwd: dir,
+              env: {
+                ...process.env,
+                LEDGER: LEDGER_FILE,
+                GITHUB_OUTPUT: outputs,
+                GITHUB_STEP_SUMMARY: summary,
+              },
+              encoding: "utf-8",
+            }
+          );
+        } catch (error) {
+          const failure = error as { status?: number; stdout?: string };
+          status = failure.status ?? -1;
+          output = failure.stdout ?? "";
+        }
+        return {
+          status,
+          output,
+          summary: await fs.readFile(summary, "utf-8"),
+          outputs: await fs.readFile(outputs, "utf-8"),
+        };
+      } finally {
+        await fs.remove(dir);
+      }
+    };
+
+    /**
+     * A ledger with the given readings over a healthy default.
+     * @param overrides - Readings to replace
+     * @param flowRows - Per-flow rows to append
+     * @returns Ledger contents
+     */
+    const ledgerOf = (
+      overrides: Record<string, string> = {},
+      flowRows: readonly string[] = []
+    ): string => {
+      const base: Record<string, string> = {
+        platform: "ios",
+        retry_enabled: "true",
+        retry_tag: "retryable",
+        retry_attempts_allowed: "1",
+        retry_rate_threshold_percent: "10",
+        executed: String(SUITE_SIZE),
+        failed_first_attempt: "1",
+        retried: "1",
+        recovered: "1",
+        unrecovered: "0",
+        not_eligible: "0",
+        retry_rate_percent: "2",
+        rate_breach: "false",
+        ...overrides,
+      };
+      return [
+        ...Object.entries(base).map(([key, value]) => `${key}=${value}`),
+        ...flowRows,
+      ].join("\n");
+    };
+
+    it("passes a within-budget ledger, loudly", async () => {
+      const result = await gate(ledgerOf({}, [FLOW_07_RECOVERED]));
+      expect(result.status).toBe(0);
+      expect(result.outputs).toContain("retried=1");
+      expect(result.output).toContain("iOS flows needed a retry");
+      expect(result.summary).toContain("per-flow retry ledger");
+      expect(result.summary).toContain("flow-07.yaml");
+      expect(result.summary).toContain("recovered");
+    });
+
+    it("fails a breached ledger", async () => {
+      const result = await gate(
+        ledgerOf({
+          failed_first_attempt: "5",
+          retried: "0",
+          recovered: "0",
+          retry_rate_percent: "12",
+          rate_breach: "true",
+          not_eligible: "5",
+        })
+      );
+      expect(result.status).toBe(1);
+      expect(result.output).toContain("retry budget exceeded");
+    });
+
+    it("fails when a flow failed again after its isolated re-run", async () => {
+      const result = await gate(ledgerOf({ recovered: "0", unrecovered: "1" }));
+      expect(result.status).toBe(1);
+      expect(result.output).toContain("failed after retry");
+    });
+
+    it("fails when a failed flow was never eligible to be re-run", async () => {
+      const result = await gate(
+        ledgerOf({ retried: "0", recovered: "0", not_eligible: "1" })
+      );
+      expect(result.status).toBe(1);
+      expect(result.output).toContain("were not retried");
+    });
+
+    it("stands down, reporting zero, when there is no ledger at all", async () => {
+      const result = await gate(null);
+      expect(result.status).toBe(0);
+      expect(result.outputs).toContain("retried=0");
+    });
+
+    it("renders the same table whatever ORDER the rows arrive in", async () => {
+      const flowRows = [
+        FLOW_01_RECOVERED,
+        "flow|.maestro/flows/flow-30.yaml|2|recovered",
+      ];
+      const forward = await gate(ledgerOf({ retried: "2" }, flowRows));
+      const reversed = await gate(
+        ledgerOf({ retried: "2" }, [...flowRows].reverse())
+      );
+      /**
+       * The table's data rows as a set.
+       * @param summary - Job-summary text
+       * @returns Sorted rows naming a flow
+       */
+      const tableRows = (summary: string): string[] =>
+        summary
+          .split("\n")
+          .filter(line => line.includes(".yaml"))
+          .sort(byCodePoint);
+      expect(tableRows(reversed.summary)).toEqual(tableRows(forward.summary));
+    });
+  });
+
+  describe("the policy inputs", () => {
+    it("ships inert, with conservative defaults", () => {
+      const inputs = workflow.on.workflow_call?.inputs ?? {};
+      // Empty tag = the feature is OFF. A reusable workflow is called by repos
+      // that never asked for this, and no repo's behaviour may change until it
+      // opts in — the same "default preserves prior behavior" rule the app-id
+      // lint and the prerequisites guard follow.
+      expect(inputs.ios_flow_retry_tag?.default).toBe("");
+      expect(inputs.ios_flow_retry_attempts?.default).toBe(1);
+      expect(inputs.ios_flow_retry_rate_percent?.default).toBe(10);
+    });
+  });
+});
+/* eslint-enable max-lines -- end of the paired-case suite */


### PR DESCRIPTION
## What is broken today

`maestro-native-e2e.yml` has one retry. It lives on the iOS arm, it is gated on
`DRIVER_FAILURE='IOSDriverTimeoutException|iOS driver not ready in time'`, and when it fires it
re-runs **the entire flows directory**.

That gate does not match the faults that actually red these runs. Two were reported from a
consumer's nightly runs on consecutive nights, both on an arm scoring 40/41 while the other arm was
fully green, each a different environmental fault with **no code fix available**:

1. An app-launch-with-clear-state step failed having executed **zero** steps. On iOS clear-state is
   uninstall plus reinstall; the reinstall **succeeded** (`Success (End) : Install (New)`) but the
   home screen never promoted the placeholder, so the launch retried for 10s against
   `LaunchServicesDataMismatch` and then failed `NotFound ("Application ... is unknown to
   FrontBoard")`.
2. A visibility assertion failed because the touch-**up** event was never delivered. The driver
   tapped the correct pixel; the simulator log shows a `down` with no matching `up` and no
   touch-move evaluations, while the identical tap on the identical component 13s earlier received
   both. The host was starved at that instant: the pre-tap screenshot took **3,257ms** against
   **132ms** earlier in the same run, and simulator log volume tripled to roughly **12,000 lines
   per second**.

Neither signature matches the regex, so both nights took the `exit 1` branch. Roughly 50 minutes of
suite time thrown away for a fault in one flow out of 41 — twice.

So the unit the workflow reasons about (the suite) is not the unit that failed (one flow), and the
only granularities on offer were "re-prove 40 green flows at full price" or "retry nothing".

## What this does

Parse the JUnit report the run already writes for the failed `<testcase>` entries, resolve each back
to its flow file, and re-run **only those flow files**.

**The report is read for WHICH flows failed, never for WHY.** The first fault's `<failure>` element
said, in its entirety, `Unknown error` — the real cause was only in
`maestro-debug/.maestro/tests/<ts>/<flow>/`. A retry keyed on an error string would rebuild the
exact too-narrow-regex defect this fixes, one regex further along. There is no error-text matching
anywhere in the new path.

**The driver-startup branch is unchanged and stays whole-suite.** When the driver never binds, zero
flows executed, there is no failed-flow list to derive, and re-running everything is correct. The
two conditions are disjoint and their costs differ by two orders of magnitude, which is why this is
a second path alongside the existing one rather than a widened regex.

## Retries must be visible, not free

Per-flow retry hides flakiness — that is what it is for — and a flow failing 40% of the time would
otherwise go green forever with nobody looking at it again. The same consumer found four genuine
product defects in a single night precisely *because* flakes fail loudly. So the accounting is not
follow-up polish; it is the reason this is safe to do at all.

**Eligibility is declared, never derived.** A flow that reads a record an earlier flow created is
indistinguishable, from its source, from one that creates its own. No inspection of a flow file can
prove it stands alone, and a wrong guess re-runs a dependent flow in isolation and manufactures a
**false failure** — worse than the flake it was meant to absorb. So a flow is retried only when the
project has tagged it with the tag named in `ios_flow_retry_tag`. Untagged flows are never re-run
and their failures stand.

**The feature ships inert.** `ios_flow_retry_tag` defaults to empty, so no repo calling this
reusable workflow changes behaviour until it opts in — the same rule `lint_flow_app_id` and
`require_prerequisites` follow. Adoption is then per flow, deliberately.

**Every run writes a ledger**, including a clean one, so "0 retries" is a recorded reading rather
than an absence. It carries `executed`, `failed_first_attempt`, `retried`, `recovered`,
`unrecovered`, `not_eligible`, `retry_rate_percent`, `rate_breach`, and one
`flow|path|attempts|outcome` row per flow. Published three ways:

- a `::warning::` annotation naming each retried flow, on the run page even when the run is green;
- a table in the job summary;
- an artifact named **`maestro-ios-retries-<count>`** — the count is in the artifact NAME, following
  this file's existing flow-count idiom, so a reader compares nights straight from the artifacts
  list without downloading anything.

## Thresholds and why these defaults

| Input | Default | Why |
| --- | --- | --- |
| `ios_flow_retry_tag` | `''` | Off. Nothing is retried until a project opts in per flow. |
| `ios_flow_retry_attempts` | `1` | The faults this absorbs are single-shot host/simulator transients. A fault that survives a fresh isolated re-run is not one of them, and more attempts buy green for a flow that is genuinely sick. |
| `ios_flow_retry_rate_percent` | `10` | The reported losses ran at 1 flow in 41 (2.4%). 10 leaves four times that headroom while a suite losing 5 of 41 still reds. |

The rate is checked **before anything is re-run**, so a breach costs no extra minutes: above the
budget the arm is degraded or the failures are real, and retrying would spend the job's remaining
time hiding which. Both the rate and the threshold it crossed are named in the failure message.

One deliberate deviation from the issue's wording: the AC says "maximum share of flows permitted to
**pass only on retry**", and this measures **first-attempt failures** instead. That is a superset
(it counts flows that failed first and then recovered *and* flows that failed first and stayed
failed), so it is strictly stricter, and it is the only form that can be evaluated before spending
the retry minutes. Flagging it rather than quietly reinterpreting the AC.

A fail-open hole found while building this and closed: a re-run filtered out by
`--include-tags`/`--exclude-tags` exits **0 having executed nothing**. Trusting that status would
turn any tag-filtered flow into a permanent false green. Such a re-run is recorded as `vacuous` and
counted as not recovered.

## Android is out of scope, and the file now says why

Previously the asymmetry was undocumented, so a reader could not tell whether it was a decision or
an omission. There is now a comment on the Android run step: `android-emulator-runner` executes each
`script:` line as its own `sh -c`, so the shell state a retry needs (a function to call twice, a
failed-flow list, a loop counter) cannot survive there. Nor can the retry move to a later step — the
emulator exists only for the duration of that action, so by the time a later step could read the
report there is no device to re-run on. The remaining option is a second invocation of the action,
which boots and provisions a fresh AVD: minutes of setup to re-run one flow, on a device whose state
is not the state the flow failed in. Real parity needs the suite invocation extracted behind the
`flow_runner` seam, which is a larger change than this one.

## Order-insensitive comparisons

Applied to the product, not only to the tests, since this was the finding on the last PR here:

- the failed-flow set is `LC_ALL=C sort -u`'d, so a report that reorders itself is the same set and
  a flow named twice is one flow;
- ledger rows are C-sorted before writing, so two nights that saw the same flows produce
  byte-identical rows regardless of execution order and regardless of which internal loop wrote each
  row;
- the test comparator is an explicit code-point function, deliberately **not** `localeCompare`, with
  a comment saying why — it has to agree with the `LC_ALL=C sort` the runner performs, or the suite
  would assert an order the artifact does not have.

## Bite test, and the mutation results in full

`tests/integration/maestro-native-per-flow-retry.test.ts` — 17 tests that **execute** the workflow's
own shell pulled verbatim out of the YAML (asserting no `${{ }}` survived, so nothing had to be
rewritten to make it runnable), with the suite stubbed through the workflow's own `flow_runner` seam
and a 41-flow fixture. Both the suite step and the gate step are executed. Every guard is paired
with the negative case that dies when the guard is removed: retry fires for a tagged flow **and**
does not fire for an untagged one; the budget stands down at 9% **and** fails the arm at 12%; a
passing re-run is accepted **and** a re-run that passed having executed zero flows is refused; the
gate passes a within-budget ledger **and** fails a breached one.

Then mutated, one mutation at a time, restoring between each. Baseline green before, green after.

| # | Mutation | Result | Test that died |
| --- | --- | --- | --- |
| M1 | eligibility check removed | KILLED | does NOT re-run an UNTAGGED failed flow |
| M2 | rate budget never breaches | KILLED | fails the arm … over the budget |
| M3 | retry loop never re-runs anything | KILLED | 8 tests |
| M4 | ledger rows left in arrival order | KILLED | writes rows ordered by FLOW … |
| M5 | a zero-flow re-run is trusted | KILLED | refuses a re-run that PASSED having executed zero flows |
| M6 | gate stops failing on a breached ledger | KILLED | fails a breached ledger |
| M7 | failed-flow set no longer deduped/sorted | KILLED | counts a flow the report names twice as ONE failed flow |
| M8 | flow path read from the whole record, not the open tag | KILLED | 10 tests |
| M9 | report split on the END tag | KILLED | 11 tests |

**M4 and M7 SURVIVED the first pass.** Reporting that because it is the substantive finding, and
because a clean sweep would have said less. There were three redundant sorts in the pipeline, so
deleting any one of them changed nothing observable — the normalisation was defended in depth and
therefore not provable anywhere. Two tests were added to make each load-bearing:

- a mixed eligible/ineligible failure set whose sorted order interleaves what the two internal loops
  write, which is the only shape where the ledger's own sort is the thing doing the work;
- a report naming the same failed flow twice, which without dedupe inflates
  `failed_first_attempt` — the input that decides whether the arm is failed outright — and re-runs
  the flow twice for nothing.

M8 and M9 were added for the same reason after the parse was written: the fixture pairs
self-closing passing cases with paired failing ones (the shape that lets a greedy
`<testcase[^>]*>` swallow the self-closing slash and report a passing flow's name against the next
failing flow's message), and the failure body carries a decoy `file="…"` so reading the attribute
from anywhere but the open tag is caught.

## Gates run

`prettier --check .` clean · `oxlint` 0/1588 · `eslint . --quiet` 0 · `tsc --noEmit` 0 ·
`vitest run tests/integration` on the `test:integration:push` profile 58 files / 1049 tests passed ·
manifest regenerated in the required order (`git add` → regenerate → `git add`; the stale-manifest
failure was reproduced first to confirm the trap) and `--check` passes.

Rebased onto current `main` before pushing, because `main` had itself modified
`src/core/upstream-evidence-manifest.ts` after this work started. The manifest is regenerated on the
new base and its diff here is **+1/-0**, so nothing of that change is reverted.

Two pre-existing failures established as **not from this change** by stashing and re-running on
pristine `main` in the same environment: `mutation-gate-bite` / `mutation-gate-diff-bite` (excluded
by `test:integration:push`; they need Stryker and a built `dist/`) and
`eslint-shipped-config-templates` + `check-learnings-budget` in the unit suite (same missing
`dist/`).

## What I could not prove

Stated flatly, because each one is a real gap:

1. **No real CI execution.** Everything here is proven by executing the workflow's own shell with
   the suite stubbed. This has not run against a real simulator, and no workflow was dispatched.
2. **Android is deliberately unfixed**, for the `android-emulator-runner` reason above. This breaks
   the file's arm-symmetry convention, which the file elsewhere treats as load-bearing.
3. **The 10% default is calibrated on n=2 nights.** It is the honest reading available and it is an
   input a consumer can tighten, but it is not a distribution.
4. **The rate threshold does not catch the sick-flow-across-runs case.** One flow failing 40% of the
   time is 2.4% of 41 every night, under budget every single time. That is exactly why the retry
   count is in the artifact name — but nothing here *automatically* reads that history. Wiring it
   into a nightly health gate is a separate and larger change and was not attempted.
5. **The `flow_runner` contract changed** — the target may now be a single flow file rather than the
   flows directory, and the report path varies. The input description is updated to say so, but this
   has not been tested against a real consumer-supplied runner script.

Work-Item: CodySwannGT/lisa#2849
