### PR TITLE
fix(gates): declare the two contexts GitHub already requires

### DIFF
--- a/.lisa.config.json
+++ b/.lisa.config.json
@@ -92,7 +92,7 @@
     },
     "code-style-slow": {
       "push": "required",
-      "pull-request": "optional"
+      "pull-request": "required"
     },
     "format-conformance": {
       "pull-request": "required"
@@ -135,7 +135,7 @@
     "dead-code": {
       "run": "knip:check",
       "push": "required",
-      "pull-request": "optional"
+      "pull-request": "required"
     },
     "artifact-freshness": {
       "commit": "required"

--- a/tests/unit/scripts/lisa-gates-self-config.test.ts
+++ b/tests/unit/scripts/lisa-gates-self-config.test.ts
@@ -79,14 +79,25 @@ const BOTH_RAN = [MANIFEST, LEDGER];
 const PULL_REQUEST = "pull-request";
 
 /**
- * Contexts the `required` pull-request gates imply — verified 2026-08-15 as a
- * strict subset of the live `quality checks` ruleset.
+ * Contexts the `required` pull-request gates imply.
+ *
+ * Seven were verified 2026-08-15 as a strict subset of the live `quality
+ * checks` ruleset. `🐢 Slow Lint Rules` and `🗑️ Dead Code Detection` joined on
+ * #2861: #2862 added them to the ruleset TEMPLATE, and they are declared here
+ * so `contextsFor` derives them too. Until the next
+ * `scripts/lisa-github-rulesets.sh` run provisions the template, those two are
+ * declared-but-not-yet-live — which `lisa-reconcile-policy` reports as MISSING
+ * and `on_drift: repair` converges by ADDING them. That is the safe direction;
+ * the state this replaced had them live-but-not-declared, where `repair
+ * --prune` would have deleted them.
  */
 const REQUIRED_PR_CONTEXTS = [
   "🔍 Quality Checks / 🏗️ Build",
+  "🔍 Quality Checks / 🐢 Slow Lint Rules",
   "🔍 Quality Checks / 📐 Check Formatting",
   "🔍 Quality Checks / 🔍 Type Check",
   "🔍 Quality Checks / 🔗 Work-Item Traceability",
+  "🔍 Quality Checks / 🗑️ Dead Code Detection",
   "🔍 Quality Checks / 🧪 Run Integration Tests",
   "🔍 Quality Checks / 🧪 Run Unit Tests",
   "🔍 Quality Checks / 🧹 Lint",
@@ -275,7 +286,7 @@ describe("Lisa's own gates and policy blocks", () => {
 });
 
 describe("gates backing a required branch-protection context", () => {
-  it("derives exactly the contexts the live ruleset requires", () => {
+  it("derives exactly the contexts the ruleset template requires", () => {
     expect(contextsFor(parsedConfig().gates) as string[]).toEqual(
       REQUIRED_PR_CONTEXTS
     );

--- a/tests/unit/scripts/slow-lint-dead-code-enforcement.test.ts
+++ b/tests/unit/scripts/slow-lint-dead-code-enforcement.test.ts
@@ -15,12 +15,22 @@
  * caller workflow, or teaching a template caller to skip one of these jobs
  * fails by name rather than silently un-gating the merge.
  *
+ * The promotion has two halves and #2862 shipped only the first. The ruleset
+ * template is what PROVISIONS a required context; the gates block is what
+ * `contextsFor` DERIVES the declared set from, and `lisa-reconcile-policy`
+ * compares that derived set against live. With the template promoted and the
+ * gates block untouched, both contexts classified as EXTRA — live but not
+ * declared — and `repair --prune` deletes an EXTRA. So the ruling survived only
+ * until somebody ran a prune. The second half declares them, which is what the
+ * `pull-request` assertions below pin.
+ *
  * @module tests/unit/scripts/slow-lint-dead-code-enforcement
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { contextsFor } from "../../../all/copy-overwrite/scripts/lisa-gates.mjs";
 import { readWorkflow } from "../../../scripts/check-required-check-promotions.mjs";
 
 const REPO_ROOT = path.resolve(
@@ -31,6 +41,7 @@ const REPO_ROOT = path.resolve(
 );
 
 const TYPESCRIPT_RULESET = "typescript/github-rulesets/quality-checks.json";
+const LISA_CONFIG = ".lisa.config.json";
 const LEDGER = ".github/required-check-promotions.json";
 const QUALITY_WORKFLOW = ".github/workflows/quality.yml";
 const CI_WORKFLOW = ".github/workflows/ci.yml";
@@ -167,11 +178,61 @@ describe("slow lint and dead code gate the merge, not only the push", () => {
     }
   );
 
+  it.each(PROMOTED)(
+    "declares $context at pull-request so contextsFor derives it",
+    ({ context }) => {
+      // #2862 promoted these two in the ruleset template but deliberately left
+      // the gates block alone, which made them live-but-not-declared. That is
+      // the dangerous half of the split: `contextsFor` is what
+      // `lisa-reconcile-policy` derives the DECLARED set from, so a context
+      // missing here classifies as EXTRA — and `repair --prune` deletes an
+      // EXTRA. The declaration is what turns a silent deletion into a
+      // convergeable MISSING.
+      const config = readJson(LISA_CONFIG) as {
+        gates: Record<string, { "pull-request"?: string }>;
+      };
+      const id = context.endsWith("🐢 Slow Lint Rules")
+        ? "code-style-slow"
+        : "dead-code";
+      expect(config.gates[id]?.["pull-request"]).toBe("required");
+      expect(contextsFor(config.gates) as string[]).toContain(context);
+    }
+  );
+
+  it("derives each promoted context byte-for-byte as the template spells it", () => {
+    // Two surfaces decide required contexts — the ruleset template that
+    // PROVISIONS, and `contextsFor` that DERIVES what reconcile compares
+    // against. A one-character difference between them (an emoji variation
+    // selector, a spacing change) leaves the declaration failing to match the
+    // live context it was written to cover, which reads as MISSING and EXTRA
+    // simultaneously and is worse than never declaring it at all.
+    const config = readJson(LISA_CONFIG) as { gates: object };
+    const derived = new Set(contextsFor(config.gates) as string[]);
+    const template = new Set(
+      requiredChecks(TYPESCRIPT_RULESET).map(check => check.context)
+    );
+    for (const { context } of PROMOTED) {
+      expect(derived).toContain(context);
+      expect(template).toContain(context);
+    }
+  });
+
+  it("keeps dead-code pointed at the knip task the promotion was sized on", () => {
+    // The headroom ledger sized this gate's budget by running `knip:check`. A
+    // declaration edit that dropped the `run` override would silently retarget
+    // the gate at the registry default, and the proven budget would then
+    // describe a command the gate no longer runs.
+    const config = readJson(LISA_CONFIG) as {
+      gates: Record<string, { run?: string }>;
+    };
+    expect(config.gates["dead-code"]?.run).toBe("knip:check");
+  });
+
   it("leaves the push moment for both gates exactly as it was", () => {
     // The owner's ruling was to PROMOTE, explicitly not to make either gate
     // cheaper at push. If a later change flips these to make pushes faster, it
     // is reversing a decision rather than tuning a number.
-    const config = readJson(".lisa.config.json") as {
+    const config = readJson(LISA_CONFIG) as {
       gates: Record<string, { push?: string }>;
     };
     expect(config.gates["code-style-slow"]?.push).toBe("required");


### PR DESCRIPTION
## What

Flips the `pull-request` level from `optional` to `required` on exactly two gate entries in
`.lisa.config.json` — `code-style-slow` and `dead-code`. `git diff --numstat` on the config is
`2 2`.

## Why

#2862 promoted `🐢 Slow Lint Rules` and `🗑️ Dead Code Detection` to required branch-protection
contexts, per the owner's ruling on #2861. It changed the ruleset template and the promotion ledger,
and deliberately left the gates block alone — #2861's own acceptance criteria required that block to
be byte-identical.

That split the promotion across two surfaces that then disagreed:

- `typescript/github-rulesets/quality-checks.json` **provisions** the live ruleset. It names both.
- `contextsFor(gates, {moment: "pull-request"})` **derives** the declared set, and emits a context
  only for a gate whose level is `required` at that moment. Both read `optional`, so it emitted
  neither.

`lisa-reconcile-policy.mjs` compares the derived set against live, so both contexts classified as
**EXTRA — live but not declared**. EXTRA is not an error and nothing was broken. But `repair --prune`
deletes an EXTRA, and the deletion reads in the audit log as a routine reconciliation. The ruling
survived only until somebody pruned.

Declaring them converts the failure mode from a silent deletion into a **MISSING**, which
`on_drift: repair` converges by ADDING.

## Before / after — measured, not assumed

The live ruleset has **not** been re-provisioned from #2862's template yet, so a run of
`lisa-reconcile-policy.mjs` against live does not mention these two contexts at all today. Reporting
them as EXTRA-against-live would be fabricating. Instead the comparison below feeds the script's own
`reconcileContexts({declared, live})` with the **ruleset template** as `live` — which is exactly
what live becomes on the next `scripts/lisa-github-rulesets.sh` run, and is the state the `--prune`
hazard applies to.

**Before** (`origin/main` @ `41fde8200`):

```
declared contexts (contextsFor, moment=pull-request):
  🔍 Quality Checks / 🏗️ Build
  🔍 Quality Checks / 📐 Check Formatting
  🔍 Quality Checks / 🔍 Type Check
  🔍 Quality Checks / 🔗 Work-Item Traceability
  🔍 Quality Checks / 🧪 Run Integration Tests
  🔍 Quality Checks / 🧪 Run Unit Tests
  🔍 Quality Checks / 🧹 Lint

🔍 Quality Checks / 🐢 Slow Lint Rules
  EXTRA=true  MATCHED=false  declared=false
🔍 Quality Checks / 🗑️ Dead Code Detection
  EXTRA=true  MATCHED=false  declared=false
```

**After** (this branch):

```
declared contexts (contextsFor, moment=pull-request):
  🔍 Quality Checks / 🏗️ Build
  🔍 Quality Checks / 🐢 Slow Lint Rules
  🔍 Quality Checks / 📐 Check Formatting
  🔍 Quality Checks / 🔍 Type Check
  🔍 Quality Checks / 🔗 Work-Item Traceability
  🔍 Quality Checks / 🗑️ Dead Code Detection
  🔍 Quality Checks / 🧪 Run Integration Tests
  🔍 Quality Checks / 🧪 Run Unit Tests
  🔍 Quality Checks / 🧹 Lint

🔍 Quality Checks / 🐢 Slow Lint Rules
  EXTRA=false  MATCHED=true  declared=true
🔍 Quality Checks / 🗑️ Dead Code Detection
  EXTRA=false  MATCHED=true  declared=true
```

Run against the **live** ruleset, the same script now reports the two as `MISSING (declared, not
required on GitHub)` rather than not at all — the expected consequence of the template not yet being
provisioned, and the safe direction: `repair` adds a MISSING. Lisa's `policy.on_drift` is `repair`,
and no CI workflow invokes this script (only the `lisa-doctor` skill and the unit suites), so nothing
reddens on this PR because of it.

## String equality, checked character for character

The two derived strings are byte-identical to what #2862 put in the template:

```
🔍 Quality Checks / 🐢 Slow Lint Rules
🔍 Quality Checks / 🗑️ Dead Code Detection
```

A near-miss here — an emoji variation selector, a spacing change — would read as MISSING and EXTRA
simultaneously, which is worse than the gap being closed. `derives each promoted context
byte-for-byte as the template spells it` pins the equality in both directions so it cannot drift.

## Preserved fields

Read back with `jq` after the edit:

```json
{
  "code-style-slow": { "push": "required", "pull-request": "required" },
  "dead-code": { "run": "knip:check", "push": "required", "pull-request": "required" }
}
```

`"push": "required"` survives on both — **nothing here makes any gate cheaper at push** — and
`dead-code` keeps `"run": "knip:check"`, which is the command its proven headroom in
`.github/required-check-promotions.json` was sized on.

## Regression tests, mutation-checked

Added to `tests/unit/scripts/slow-lint-dead-code-enforcement.test.ts` (#2862's suite):

- `declares $context at pull-request so contextsFor derives it`
- `derives each promoted context byte-for-byte as the template spells it`
- `keeps dead-code pointed at the knip task the promotion was sized on`

Each mutation was run and the failures confirmed **by name**:

| Mutation | Tests that died |
|---|---|
| `code-style-slow` → `optional` | `declares '🔍 Quality Checks / 🐢 Slow Lint Rules' at pull-request so contextsFor derives it`; `derives each promoted context byte-for-byte as the template spells it`; `derives exactly the contexts the ruleset template requires` |
| `dead-code` → `optional` | `declares '🔍 Quality Checks / 🗑️ Dead Code Detection' at pull-request so contextsFor derives it`; `derives each promoted context byte-for-byte as the template spells it`; `derives exactly the contexts the ruleset template requires` |
| delete `dead-code.run` | `keeps dead-code pointed at the knip task the promotion was sized on` |

## One pre-existing test updated

`tests/unit/scripts/lisa-gates-self-config.test.ts` asserted the derived set with `toEqual` against a
hardcoded seven-context list, so it necessarily fails once two more are derived. Its list gains the
two contexts in `localeCompare` order, and its comment — which claimed the whole list was "verified
2026-08-15 as a strict subset of the live `quality checks` ruleset" — is corrected, because that is
no longer true of the two new entries until the ruleset is provisioned. Its title changes from
"derives exactly the contexts the **live ruleset** requires" to "...the **ruleset template**
requires" for the same reason. That test is a third mutation detector and is listed above.

## Verification

- `bun run test tests/unit/scripts/ tests/integration/quality-gate-facade.test.ts` — **120 files,
  2233 tests, all passing**.
- `bun run check:required-check-promotions` — `20 recorded, 0 violation(s)`, `No unproven promotion.`
  (17 pre-existing grandfathered debt lines, unchanged by this PR.)
- Pre-commit and pre-push gates ran clean; no `--no-verify`.

## Scope

Touches no other gate entry. The other four items of #2829 remain **unruled** and untouched — in
particular nothing here switches a check off at push to make pushes faster. No change to the ruleset
templates or `.github/required-check-promotions.json` (#2862 owns those, and it merged). No live
branch protection was edited by hand.

Work-Item: CodySwannGT/lisa#2865

## No CI behaviour changes — the edit is purely declarative

Worth stating because "flip two gates to required" sounds like it could newly redden pull requests.
It cannot. The gate resolver embedded in `quality.yml` (the `node "$RESOLVER" list --moment=… --json
--include-off` step) branches on exactly one level:

```js
if (hit && hit.level === "off") return process.stdout.write("configured=off\n");
```

`required` and `optional` are indistinguishable to it — both resolve `configured=true`, both run the
task, and both already fail the job on a non-zero exit. So `🐢 Slow Lint Rules` and `🗑️ Dead Code
Detection` ran and bit on every pull request before this change and behave identically after it.

The level is read by two other surfaces, and neither is touched here: `contextsFor`, which is the
point of this PR, and the pre-push hook, where `required` blocks and `optional` warns — and the
`push` level is unchanged on both gates.
