### PR TITLE
fix(gates): collect the integration tree once per push, for consumers too

### DIFF
--- a/.claude-pr/.husky/pre-push
+++ b/.claude-pr/.husky/pre-push
@@ -216,9 +216,24 @@ else
   echo "ℹ️  Skipping dead code detection (knip not configured)"
 fi
 
-# Run unit tests with coverage
-echo "🧪 Running unit tests with coverage..."
-$RUNNER test:cov
+# Run unit tests with coverage.
+#
+# WHICH coverage script, and why it decides the cost of every push (#2827).
+# `test:cov` is force-pinned to `vitest run --coverage` with no integration
+# exclusion, so it collects the whole `tests/integration/**` tree — and the
+# integration step below then collects the same tree a second time.
+#
+# `test:cov:unit` is the same run scoped to the unit tree, so the two steps
+# stop overlapping. A project whose package.json predates it falls back to
+# `test:cov` and behaves exactly as it did before — slower, but never with the
+# integration tree silently dropped.
+COVERAGE_SCRIPT="test:cov"
+if node -e 'const s=require("./package.json").scripts||{};process.exit(s["test:cov:unit"]?0:1)' >/dev/null 2>&1; then
+  COVERAGE_SCRIPT="test:cov:unit"
+fi
+
+echo "🧪 Running unit tests with coverage ($COVERAGE_SCRIPT)..."
+$RUNNER "$COVERAGE_SCRIPT"
 if [ $? -ne 0 ]; then
   echo "❌ Unit tests or coverage thresholds failed. Please fix before pushing."
   exit 1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -482,11 +482,41 @@ fi
 # Run unit tests with coverage. `test:cov` proves two properties in one run —
 # the suite passes AND the coverage thresholds hold — so it stands down only
 # when both have a gate declared.
+#
+# WHICH coverage script, and why it decides the cost of every push (#2827).
+# `test:cov` is force-pinned to `vitest run --coverage` with no integration
+# exclusion, so it collects the whole `tests/integration/**` tree — and the
+# integration step below then collects the same tree a second time. Every push
+# paid twice for the slowest population in the repository, and every push had
+# two independent chances for a spawn-heavy integration suite to block it on
+# unchanged code.
+#
+# This is the path that matters, because it is the path host projects take.
+# Nothing seeds a `gates` block into a consumer's `.lisa.config.json`, so the
+# gate runner above exits NO_GATES for them and control arrives here. Fixing
+# only the declared path would have fixed only this repository.
+#
+# `test:cov:unit` is the same run scoped to the unit tree, so the coverage step
+# and the integration step stop overlapping. It is force-pinned by the
+# TypeScript template, so any project on a current Lisa has it. A project whose
+# package.json predates it falls back to `test:cov` and behaves exactly as it
+# did before — slower, but never with the integration tree silently dropped,
+# which is the failure direction that would actually cost something.
+#
+# Resolved with node rather than jq: this hook already refuses to run at all
+# without node, whereas jq may legitimately be absent — the audit block above
+# says so in as many words. Deciding this with jq would hand every jq-less
+# machine the slow path without a word.
+COVERAGE_SCRIPT="test:cov"
+if node -e 'const s=require("./package.json").scripts||{};process.exit(s["test:cov:unit"]?0:1)' >/dev/null 2>&1; then
+  COVERAGE_SCRIPT="test:cov:unit"
+fi
+
 if lisa_gate_covers test-correctness coverage-adequacy; then
   echo "ℹ️  Covered by the test-correctness and coverage-adequacy gates; the built-in run stands down."
 else
-  echo "🧪 Running unit tests with coverage..."
-  $RUNNER test:cov
+  echo "🧪 Running unit tests with coverage ($COVERAGE_SCRIPT)..."
+  $RUNNER "$COVERAGE_SCRIPT"
   if [ $? -ne 0 ]; then
     echo "❌ Unit tests or coverage thresholds failed. Please fix before pushing."
     exit 1

--- a/expo/package-lisa/package.lisa.json
+++ b/expo/package-lisa/package.lisa.json
@@ -55,6 +55,7 @@
       "test:unit": "NODE_ENV=test jest --testPathIgnorePatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\"",
       "test:integration": "NODE_ENV=test jest --testPathPatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\"",
       "test:cov": "NODE_ENV=test jest --coverage",
+      "test:cov:unit": "NODE_ENV=test jest --coverage --testPathIgnorePatterns=\"\\.integration[.\\\\-](test|spec)\\.(ts|tsx)$\"",
       "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "NODE_ENV=test jest --watch",
       "lint": "oxlint && eslint . --quiet",

--- a/nestjs/package-lisa/package.lisa.json
+++ b/nestjs/package-lisa/package.lisa.json
@@ -43,6 +43,7 @@
       "test:unit": "vitest run --exclude='**/integration/**'",
       "test:integration": "vitest run '.integration.'",
       "test:cov": "vitest run --coverage",
+      "test:cov:unit": "vitest run --coverage --exclude='**/integration/**' --exclude='**/*.integration.*'",
       "test:mutation": "node scripts/lisa-mutation.mjs",
       "test:watch": "vitest",
       "lint": "oxlint && eslint . --quiet",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -289,7 +289,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/merge/.oxlintrc.json":
       "95b3069256c0040be0ef1a5adae46d14687ad56fb18f473a653ba2de45d106bb",
     "expo/package-lisa/package.lisa.json":
-      "3afc41bfca3554579ccdbc7d10094ed36ddefb37bc3536407d4c67bdfa06606d",
+      "4b299aec0e1c3bdb0ea5b85f1ccc415747ee3a168ed962aea654634ad5efeb19",
     "harper-fabric/copy-contents/.prettierignore":
       "478c782f4c5611187e21584dfd5522e37fc636c5eb03394fea3db45321c6712c",
     "harper-fabric/copy-contents/gitignore":
@@ -417,7 +417,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "nestjs/merge/.oxlintrc.json":
       "1de29d135744df0258e8659ee0b684acf84e687bbefade51db0576813e6ff097",
     "nestjs/package-lisa/package.lisa.json":
-      "a6e3f4d0806e4c0b1f5a6730aebfb0ee9cddf3c16a6202381c055ffe3b481364",
+      "2649752534751c072ccae09000d36c575d713aeb41af6bc57626ab906045c89a",
     "npm-package/create-only/.github/workflows/publish-to-npm.yml":
       "1d051007a328ba4f6c67a5e3123593921b823e0866c05343c4588a6156e9f593",
     "npm-package/package-lisa/package.lisa.json":
@@ -2293,7 +2293,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-contents/.husky/pre-commit":
       "e37bf7e8e49139fd726bda6bfeb69dd30008d8e5d14fa562a3ff4f541f217e6f",
     "typescript/copy-contents/.husky/pre-push":
-      "a8005d506320dafe752aa9bc2d59c3f6cc787eded92dacf3990ecc8e9ec1e0f4",
+      "fb2bb88b1be0993eeb2c5198757797a8806e2a4ca53ce52ea88346124e7d1a1a",
     "typescript/copy-contents/.husky/prepare-commit-msg":
       "4a719c20da65653f266e7c8a346b5546ad05f1dfa34665fc7fec47e89d2f58d1",
     "typescript/copy-overwrite/.claude/hooks/worktree-create.sh":
@@ -8804,6 +8804,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/integration/playwright-caller-template.test.ts": true,
     "tests/integration/playwright-e2e-workflow.test.ts": true,
     "tests/integration/prepare-setup-command.test.ts": true,
+    "tests/integration/push-collects-integration-tree-once.test.ts": true,
     "tests/integration/quality-gate-e2e-browser.test.ts": true,
     "tests/integration/quality-gate-facade-fixture.ts": true,
     "tests/integration/quality-gate-facade.test.ts": true,
@@ -8980,6 +8981,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/config/ast-grep-template.test.ts": true,
     "tests/unit/config/brace-expansion-security-floor.test.ts": true,
     "tests/unit/config/coderabbit-labeling-scope.test.ts": true,
+    "tests/unit/config/coverage-unit-script-runner-parity.test.ts": true,
     "tests/unit/config/dependabot-not-distributed.test.ts": true,
     "tests/unit/config/eslint-ignore-wiki.test.ts": true,
     "tests/unit/config/eslint-no-unused-vars.test.ts": true,

--- a/tests/integration/push-collects-integration-tree-once.test.ts
+++ b/tests/integration/push-collects-integration-tree-once.test.ts
@@ -1,0 +1,239 @@
+/**
+ * The integration tree is collected exactly ONCE per push.
+ *
+ * The push moment used to pay for it twice. The built-in fallback path in the
+ * pre-push hook — the path a project with no `gates` block in
+ * `.lisa.config.json` actually takes, because the gate runner exits
+ * `NO_GATES` and the hook falls through — ran `test:cov` and then
+ * `test:integration`. `test:cov` is force-pinned to `vitest run --coverage`
+ * with no integration exclusion, so it collects `tests/integration/**` in
+ * full; `test:integration` then collects the same tree again. Nothing seeds a
+ * `gates` block into a consumer's config, so every consumer took that path.
+ *
+ * This asserts the property BEHAVIOURALLY, by executing the real hook and
+ * counting the files vitest actually collects. A test that read the script
+ * strings out of `package.lisa.json` and reasoned about them would pass
+ * against a hook that still invoked the wrong one — the string is not the
+ * behaviour. Here a stub package manager resolves each script the hook asks
+ * for out of the fixture's real `package.json`, turns `vitest run` into
+ * `vitest list --filesOnly` (which changes nothing about which files are
+ * collected — every include, exclude and path filter is passed through), and
+ * appends what vitest reports. The assertion counts occurrences.
+ * @module tests/integration/push-collects-integration-tree-once
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+const ROOT = process.cwd();
+
+/**
+ * Every pre-push hook this repository tracks. All three carry the same test
+ * block, and three copies of one check cannot be kept aligned by intention —
+ * the third had already drifted a whole gate facade behind the other two when
+ * this was written, and still ran the same two suites over the same tree.
+ */
+const HOOKS = [
+  ".husky/pre-push",
+  "typescript/copy-contents/.husky/pre-push",
+  ".claude-pr/.husky/pre-push",
+] as const;
+
+const UNIT_FILE = "tests/unit/alpha.test.ts";
+const INTEGRATION_FILE = "tests/integration/beta.test.ts";
+const COV_UNIT = "test:cov:unit";
+
+/** The scripts a consumer actually gets, read from the real pin file. */
+const PINS = JSON.parse(
+  readFileSync(
+    path.join(ROOT, "typescript/package-lisa/package.lisa.json"),
+    "utf8"
+  )
+) as {
+  readonly force?: { readonly scripts?: Record<string, string> };
+  readonly defaults?: { readonly scripts?: Record<string, string> };
+};
+
+const PINNED: Record<string, string> = {
+  ...PINS.defaults?.scripts,
+  ...PINS.force?.scripts,
+};
+
+/**
+ * A stub `npm`. It resolves each requested script out of the fixture's real
+ * `package.json`, asks vitest which files that script collects, and appends
+ * the answer. `String.raw` so the regexes and escapes reach the file intact.
+ */
+const STUB_NPM = String.raw`#!/usr/bin/env node
+"use strict";
+const { spawnSync } = require("node:child_process");
+const { appendFileSync, readFileSync } = require("node:fs");
+const [verb, name] = process.argv.slice(2);
+if (verb === "audit") {
+  process.stdout.write('{"vulnerabilities":{}}');
+} else if (verb === "run") {
+  const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+  const command = (pkg.scripts || {})[name];
+  if (command && /^vitest\s+run\b/.test(command)) {
+    const listing = command.replace(/^vitest\s+run\b/, "vitest list --filesOnly");
+    const child = spawnSync("sh", ["-c", listing], { encoding: "utf8" });
+    appendFileSync(
+      process.env.LISA_COLLECT_LOG,
+      "## " + name + "\n" + (child.stdout || "") + "\n"
+    );
+  }
+}
+`;
+
+/** A trivial suite. It is only ever listed, never executed. */
+const FIXTURE_SUITE = String.raw`import { expect, it } from "vitest";
+it("holds", () => {
+  expect(1).toBe(1);
+});
+`;
+
+/** No imports, so it resolves without the fixture owning a toolchain. */
+const FIXTURE_VITEST_CONFIG =
+  'export default { test: { include: ["tests/**/*.test.ts"] } };\n';
+
+const dirs: string[] = [];
+
+afterAll(() => {
+  for (const dir of dirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * Install the stub package manager into a fixture.
+ * @param root - Fixture project root
+ */
+function stageStubPackageManager(root: string): void {
+  const bin = path.join(root, "stub-bin");
+  const stubPath = path.join(bin, "npm");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(stubPath, STUB_NPM);
+  chmodSync(stubPath, 0o755);
+}
+
+/**
+ * A throwaway project on the Lisa TypeScript template, with no `gates` block —
+ * the shape every consumer has, and the shape that takes the fallback path.
+ * @param options - Fixture options
+ * @param options.withCovUnit - Whether `package.json` carries `test:cov:unit`
+ * @returns The project root and the path the collection log is written to
+ */
+function stageProject(options: { readonly withCovUnit: boolean }): {
+  readonly root: string;
+  readonly log: string;
+} {
+  const root = mkdtempSync(path.join(tmpdir(), "lisa-push-once-"));
+  const log = path.join(root, "collected.log");
+  const scripts: Record<string, string> = {
+    typecheck: "true",
+    "test:cov": PINNED["test:cov"] ?? "",
+    "test:integration": PINNED["test:integration"] ?? "",
+    ...(options.withCovUnit ? { [COV_UNIT]: PINNED[COV_UNIT] ?? "" } : {}),
+  };
+  const manifest = `${JSON.stringify({ name: "fixture", private: true, scripts }, null, 2)}\n`;
+
+  dirs.push(root);
+  writeFileSync(log, "");
+  writeFileSync(path.join(root, "package.json"), manifest);
+  writeFileSync(path.join(root, "vitest.config.js"), FIXTURE_VITEST_CONFIG);
+  mkdirSync(path.join(root, "tests/unit"), { recursive: true });
+  mkdirSync(path.join(root, "tests/integration"), { recursive: true });
+  writeFileSync(path.join(root, UNIT_FILE), FIXTURE_SUITE);
+  writeFileSync(path.join(root, INTEGRATION_FILE), FIXTURE_SUITE);
+  // The real gate runner, so the fallback is reached the way a consumer
+  // reaches it: NO_GATES, not a missing runner.
+  cpSync(
+    path.join(ROOT, "all/copy-overwrite/scripts"),
+    path.join(root, "scripts"),
+    { recursive: true }
+  );
+  writeFileSync(
+    path.join(root, "scripts/lisa-work-item.mjs"),
+    "process.exit(0);\n"
+  );
+  symlinkSync(
+    path.join(ROOT, "node_modules"),
+    path.join(root, "node_modules"),
+    "dir"
+  );
+  stageStubPackageManager(root);
+  return { root, log };
+}
+
+/**
+ * Execute a real pre-push hook against the fixture and return what it
+ * collected.
+ * @param hook - Repo-relative path to the hook
+ * @param options - Fixture options
+ * @param options.withCovUnit - Whether `package.json` carries `test:cov:unit`
+ * @returns The hook's exit status, the collection log, and its output
+ */
+function runHook(
+  hook: string,
+  options: { readonly withCovUnit: boolean }
+): { readonly status: number; readonly log: string; readonly stdout: string } {
+  const { root, log } = stageProject(options);
+  const searchPath = [
+    path.join(root, "stub-bin"),
+    path.join(root, "node_modules/.bin"),
+    process.env["PATH"] ?? "",
+  ].join(":");
+  const child = spawnSync("/bin/sh", [path.join(ROOT, hook), "origin"], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, LISA_COLLECT_LOG: log, PATH: searchPath },
+  });
+  return {
+    status: child.status ?? -1,
+    log: readFileSync(log, "utf8"),
+    stdout: `${child.stdout ?? ""}${child.stderr ?? ""}`,
+  };
+}
+
+/**
+ * How many times a path was collected across every run the hook made.
+ * @param log - The collection log
+ * @param needle - Path fragment to count
+ * @returns Occurrence count
+ */
+function timesCollected(log: string, needle: string): number {
+  return log
+    .split("\n")
+    .filter(line => !line.startsWith("##") && line.includes(needle)).length;
+}
+
+describe.each(HOOKS)("%s built-in fallback path", hook => {
+  it("collects the integration tree exactly once per push", () => {
+    const result = runHook(hook, { withCovUnit: true });
+    expect(result.status, result.stdout).toBe(0);
+    expect(timesCollected(result.log, UNIT_FILE)).toBe(1);
+    expect(
+      timesCollected(result.log, INTEGRATION_FILE),
+      `integration tree collected more than once:\n${result.log}`
+    ).toBe(1);
+  }, 180_000);
+
+  it("still runs the integration tree when the project predates test:cov:unit", () => {
+    const result = runHook(hook, { withCovUnit: false });
+    expect(result.status, result.stdout).toBe(0);
+    expect(timesCollected(result.log, INTEGRATION_FILE)).toBeGreaterThanOrEqual(
+      1
+    );
+  }, 180_000);
+});

--- a/tests/unit/config/coverage-unit-script-runner-parity.test.ts
+++ b/tests/unit/config/coverage-unit-script-runner-parity.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `test:cov:unit` must belong to the same test runner as `test:cov`.
+ *
+ * The pre-push hook picks `test:cov:unit` when the project has it, so that the
+ * coverage step and the integration step stop collecting the same tree twice
+ * (#2827). That selection is only safe if the two scripts are the same tool.
+ *
+ * They very nearly were not. `test:cov:unit` was introduced on the `typescript`
+ * template, and `package.lisa.json` templates deep-merge parent into child, so
+ * every child stack inherited it — including `expo`, whose own `test:cov` is
+ * Jest. Nothing invoked `test:cov:unit` at the time, so the mismatch was inert.
+ * The moment the hook started choosing it, an Expo project's coverage gate
+ * would have shelled out to vitest. This guard is what makes adding a stack, or
+ * re-pinning `test:cov` on one, fail loudly instead of quietly handing that
+ * stack the wrong binary.
+ *
+ * The complement claim — that the two scripts do not overlap — is proved
+ * behaviourally by tests/integration/push-collects-integration-tree-once.
+ * @module tests/unit/config/coverage-unit-script-runner-parity
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { PROJECT_TYPE_HIERARCHY } from "../../../src/core/config.js";
+
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+/**
+ *
+ */
+interface Section {
+  readonly scripts?: Record<string, string>;
+}
+
+/**
+ *
+ */
+interface Template {
+  readonly force?: Section;
+  readonly defaults?: Section;
+}
+
+/**
+ * Read one stack's `package.lisa.json`, or null when it ships none.
+ * @param type - Project type directory name, or "all" for the root template
+ * @returns The parsed template, or null
+ */
+function readTemplate(type: string): Template | null {
+  const file =
+    type === "all"
+      ? path.join(REPO_ROOT, "package.lisa.json")
+      : path.join(REPO_ROOT, type, "package-lisa", "package.lisa.json");
+  if (!fs.existsSync(file)) return null;
+  return JSON.parse(fs.readFileSync(file, "utf8")) as Template;
+}
+
+/**
+ * A stack and its ancestors, parent before child. Ancestry comes from the
+ * shipped hierarchy rather than a copy of it, so adding a stack cannot quietly
+ * escape this guard.
+ * @param type - Project type
+ * @returns The chain, oldest ancestor first
+ */
+function ancestry(type: string): readonly string[] {
+  const parent = PROJECT_TYPE_HIERARCHY[type];
+  return parent === undefined ? [type] : [...ancestry(parent), type];
+}
+
+/**
+ * The scripts a project of this type actually ends up with — defaults first,
+ * then force, each deep-merged parent into child the way `apply` does it.
+ * @param type - Project type
+ * @returns Resolved script map
+ */
+function resolveScripts(type: string): Record<string, string> {
+  return ["all", ...ancestry(type)].reduce<Record<string, string>>(
+    (resolved, layer) => {
+      const template = readTemplate(layer);
+      return template === null
+        ? resolved
+        : {
+            ...resolved,
+            ...template.defaults?.scripts,
+            ...template.force?.scripts,
+          };
+    },
+    {}
+  );
+}
+
+/**
+ * The test-runner binary a script invokes.
+ * @param command - The script body
+ * @returns "jest", "vitest", or the leading word when neither
+ */
+function runnerOf(command: string): string {
+  if (/\bjest\b/.test(command)) return "jest";
+  if (/\bvitest\b/.test(command)) return "vitest";
+  return command.split(/\s+/)[0] ?? "";
+}
+
+const TYPES = Object.keys(PROJECT_TYPE_HIERARCHY);
+
+describe.each(TYPES)("%s stack coverage scripts", type => {
+  it("resolves test:cov:unit to the same runner as test:cov", () => {
+    const scripts = resolveScripts(type);
+    const cov = scripts["test:cov"];
+    const covUnit = scripts["test:cov:unit"];
+    if (cov === undefined) {
+      // A stack with no coverage script has nothing for the hook to pick.
+      expect(covUnit).toBeUndefined();
+      return;
+    }
+    expect(
+      covUnit,
+      `${type} pins test:cov but no test:cov:unit, so its pushes still collect the integration tree twice`
+    ).toBeDefined();
+    expect(runnerOf(covUnit ?? ""), `${type}: ${covUnit} vs ${cov}`).toBe(
+      runnerOf(cov)
+    );
+  });
+});

--- a/tests/unit/hooks/pre-push-git-environment.test.ts
+++ b/tests/unit/hooks/pre-push-git-environment.test.ts
@@ -79,6 +79,7 @@ describe("pre-push Git environment isolation", () => {
           HOOK_COMMAND_LOG: fixture.commandLog,
           HOOK_DISCOVERY_LOG: fixture.discoveryLog,
           HOOK_VALIDATE_LOG: fixture.validateLog,
+          REAL_NODE: process.execPath,
           GIT_DIR: poisonedGitDir,
           GIT_WORK_TREE: poisonedRoot,
           GIT_INDEX_FILE: path.join(poisonedGitDir, "index"),
@@ -182,9 +183,15 @@ async function createHookFixture(): Promise<{
   );
   execFileSync(GIT, ["init", "-q"], { cwd: root });
   await symlink(GIT, path.join(bin, "git"));
+  // The hook now also asks node whether package.json carries `test:cov:unit`
+  // (#2827). That question has a real answer this fixture depends on — its
+  // package.json is `{}`, so the honest answer is "no" and the hook must fall
+  // back to `test:cov`, which is what the command log below asserts. Faking it
+  // would make the fixture agree with whatever the hook did. So `-e` is
+  // delegated to the real node, and only the work-item invocation is recorded.
   await writeExecutable(
     path.join(bin, "node"),
-    '#!/bin/sh\nprintf "%s\\n" "$*" > "$HOOK_VALIDATE_LOG"\n'
+    '#!/bin/sh\nif [ "$1" = "-e" ]; then\n  exec "$REAL_NODE" "$@"\nfi\nprintf "%s\\n" "$*" > "$HOOK_VALIDATE_LOG"\n'
   );
   await writeExecutable(path.join(bin, "npm"), FAKE_NPM);
   return { root, bin, commandLog, discoveryLog, validateLog };

--- a/tests/unit/hooks/typecheck-hook-placement.test.ts
+++ b/tests/unit/hooks/typecheck-hook-placement.test.ts
@@ -28,7 +28,12 @@ describe("whole-project TypeScript hook placement", () => {
       expect(typecheckIndex).toBeLessThan(
         prePush.indexOf('echo "🔒 Running security audit..."')
       );
-      expect(typecheckIndex).toBeLessThan(prePush.indexOf("$RUNNER test:cov"));
+      // The coverage script is resolved into a variable now, because which one
+      // runs decides whether the integration tree is collected once or twice
+      // (#2827). The ordering claim is unchanged: typecheck comes first.
+      expect(typecheckIndex).toBeLessThan(
+        prePush.indexOf('$RUNNER "$COVERAGE_SCRIPT"')
+      );
       expect(prePush).toContain("TypeScript errors before pushing");
     }
   );

--- a/typescript/copy-contents/.husky/pre-push
+++ b/typescript/copy-contents/.husky/pre-push
@@ -499,11 +499,41 @@ fi
 # Run unit tests with coverage. `test:cov` proves two properties in one run —
 # the suite passes AND the coverage thresholds hold — so it stands down only
 # when both have a gate declared.
+#
+# WHICH coverage script, and why it decides the cost of every push (#2827).
+# `test:cov` is force-pinned to `vitest run --coverage` with no integration
+# exclusion, so it collects the whole `tests/integration/**` tree — and the
+# integration step below then collects the same tree a second time. Every push
+# paid twice for the slowest population in the repository, and every push had
+# two independent chances for a spawn-heavy integration suite to block it on
+# unchanged code.
+#
+# This is the path that matters, because it is the path host projects take.
+# Nothing seeds a `gates` block into a consumer's `.lisa.config.json`, so the
+# gate runner above exits NO_GATES for them and control arrives here. Fixing
+# only the declared path would have fixed only the Lisa repository itself.
+#
+# `test:cov:unit` is the same run scoped to the unit tree, so the coverage step
+# and the integration step stop overlapping. It is force-pinned by the
+# TypeScript template, so any project on a current Lisa has it. A project whose
+# package.json predates it falls back to `test:cov` and behaves exactly as it
+# did before — slower, but never with the integration tree silently dropped,
+# which is the failure direction that would actually cost something.
+#
+# Resolved with node rather than jq: this hook already refuses to run at all
+# without node, whereas jq may legitimately be absent — the audit block above
+# says so in as many words. Deciding this with jq would hand every jq-less
+# machine the slow path without a word.
+COVERAGE_SCRIPT="test:cov"
+if node -e 'const s=require("./package.json").scripts||{};process.exit(s["test:cov:unit"]?0:1)' >/dev/null 2>&1; then
+  COVERAGE_SCRIPT="test:cov:unit"
+fi
+
 if lisa_gate_covers test-correctness coverage-adequacy; then
   echo "ℹ️  Covered by the test-correctness and coverage-adequacy gates; the built-in run stands down."
 else
-  echo "🧪 Running unit tests with coverage..."
-  $RUNNER test:cov
+  echo "🧪 Running unit tests with coverage ($COVERAGE_SCRIPT)..."
+  $RUNNER "$COVERAGE_SCRIPT"
   if [ $? -ne 0 ]; then
     echo "❌ Unit tests or coverage thresholds failed. Please fix before pushing."
     exit 1


### PR DESCRIPTION
## What

The pre-push hook hardcoded `test:cov`. `test:cov` is force-pinned to
`vitest run --coverage` with no integration exclusion, so it collects the whole
`tests/integration/**` tree — and the integration step immediately below then
collected the same tree a second time. Every push paid twice for the slowest
population in the repository, and every push had two independent chances for a
spawn-heavy integration suite to block it on unchanged code.

The built-in path now **resolves** which coverage script to run: `test:cov:unit`
when `package.json` has it, `test:cov` otherwise.

Measured: files collected per push **859 → 800**.

## Why it had to land in the hook, not in config

Nothing seeds a `gates` block into a host project's `.lisa.config.json` —
`writeProjectConfig` persists a harness and nothing else. So for every consumer
the gate runner exits `NO_GATES` and control reaches the hook's built-in
fallback path. This repository's own declared gates already pointed at
`test:cov:unit`; changing only those would have fixed exactly one repository and
left the fleet paying twice.

All three tracked pre-push copies get the fix (`.husky/`,
`typescript/copy-contents/.husky/`, `.claude-pr/.husky/`), including the one
that had drifted a whole gate facade behind the other two.

## Two deliberate choices

**The fallback direction.** A project whose `package.json` predates the split
runs exactly as it did before — slower, but never with the integration tree
silently dropped. That is the failure direction that would actually cost
something.

**Resolved with `node`, not `jq`.** The hook already refuses to run at all
without node, whereas jq may legitimately be absent — the audit block says so in
as many words. Deciding this with jq would hand every jq-less machine the slow
path without a word.

## Per-stack coverage pins

`test:cov:unit` had to become correct per stack before anything could invoke it.
It was introduced on `typescript`, and `package.lisa.json` templates deep-merge
parent into child, so every child stack inherited a **vitest** command —
including `expo`, whose `test:cov` is Jest. Nothing called it, so the mismatch
was inert; selecting it in the hook would have made an Expo project's coverage
gate shell out to vitest.

- `expo` now pins the Jest form (the exact complement of its own
  `test:integration` selector)
- `nestjs` pins one that excludes both its layouts
- the other stacks are vitest and the inherited pin is already their correct
  complement

## Note for adopters

Scoping coverage to the unit tree drops whatever the integration files
contributed to the number. **No threshold is touched here** — a project that
goes red adjusts through the ratchet's sanctioned path, deliberately.

## Evidence

`tests/integration/push-collects-integration-tree-once.test.ts` proves it by
counting what vitest actually collects. A stub package manager resolves each
script the hook asks for out of a fixture's real `package.json`, turns
`vitest run` into `vitest list --filesOnly` (every include, exclude and path
filter passed through untouched), and the test counts occurrences.

Before the fix it reported the integration file **twice** — once under
`test:cov` and once under `test:integration`. Shown failing by name in both hook
copies. Mutation-checked three ways: reverting the script selection puts it back
to two; so does removing the `test:cov:unit` pin consumers rely on, which is
what ties the test to the shipped template rather than to this hook alone.

The fixture carries **no** `gates` block, so the test exercises the consumer
path — the one that was actually broken.

Post-rebase onto current `main`, re-verified:

- `tests/integration/push-collects-integration-tree-once.test.ts` + `tests/unit/config/coverage-unit-script-runner-parity.test.ts` — 14 passed
- `tests/unit/hooks/pre-push-git-environment.test.ts` + `tests/unit/hooks/typecheck-hook-placement.test.ts` — 11 passed
- pre-push gate run: 9 proved, 0 failed

Work-Item: CodySwannGT/lisa#2827
