### PR TITLE
fix(ci): reconcile the live ruleset with the template it derives from

### DIFF
--- a/plugins/lisa-agy/skills/lisa-setup-github-repo/SKILL.md
+++ b/plugins/lisa-agy/skills/lisa-setup-github-repo/SKILL.md
@@ -28,6 +28,7 @@ Apply the fleet-standard GitHub repository configuration to this project's repo.
    - `quality checks` — the stack's CI checks (TypeScript emoji names or Rails names)
    - `prevent delete`, `protect tags` (`v*`), plus stack overlays (`cdk validation`, staging-only `playwright`)
    - Repos without `.github/workflows/` get only app-based required checks — an Actions check that can never report would block every PR forever
+   - **A template change never reaches an already-configured repo on its own** — re-running this step is the migration. Reconciliation is additive (a live-only required context is preserved, never dropped) and legible: each context the run newly makes blocking is printed as `+ now required: <context>`, and a ruleset that already satisfies its template reports `nothing to do` and is not sent at all, so a second run is visibly a no-op
 3. **Deploy key** (`scripts/setup-deploy-key.sh --yes`) — write-access deploy key + `DEPLOY_KEY` secret, skipped when already configured. The `base` ruleset's `DeployKey: always` bypass is what lets CI version-bump pushes through protected branches.
 4. **Deployment environments** (`scripts/lisa-github-environments.sh`) — entirely optional; only runs when `.lisa.config.json` declares environments:
    ```json

--- a/plugins/lisa-copilot/skills/lisa-setup-github-repo/SKILL.md
+++ b/plugins/lisa-copilot/skills/lisa-setup-github-repo/SKILL.md
@@ -28,6 +28,7 @@ Apply the fleet-standard GitHub repository configuration to this project's repo.
    - `quality checks` — the stack's CI checks (TypeScript emoji names or Rails names)
    - `prevent delete`, `protect tags` (`v*`), plus stack overlays (`cdk validation`, staging-only `playwright`)
    - Repos without `.github/workflows/` get only app-based required checks — an Actions check that can never report would block every PR forever
+   - **A template change never reaches an already-configured repo on its own** — re-running this step is the migration. Reconciliation is additive (a live-only required context is preserved, never dropped) and legible: each context the run newly makes blocking is printed as `+ now required: <context>`, and a ruleset that already satisfies its template reports `nothing to do` and is not sent at all, so a second run is visibly a no-op
 3. **Deploy key** (`scripts/setup-deploy-key.sh --yes`) — write-access deploy key + `DEPLOY_KEY` secret, skipped when already configured. The `base` ruleset's `DeployKey: always` bypass is what lets CI version-bump pushes through protected branches.
 4. **Deployment environments** (`scripts/lisa-github-environments.sh`) — entirely optional; only runs when `.lisa.config.json` declares environments:
    ```json

--- a/plugins/lisa-cursor/skills/lisa-setup-github-repo/SKILL.md
+++ b/plugins/lisa-cursor/skills/lisa-setup-github-repo/SKILL.md
@@ -28,6 +28,7 @@ Apply the fleet-standard GitHub repository configuration to this project's repo.
    - `quality checks` — the stack's CI checks (TypeScript emoji names or Rails names)
    - `prevent delete`, `protect tags` (`v*`), plus stack overlays (`cdk validation`, staging-only `playwright`)
    - Repos without `.github/workflows/` get only app-based required checks — an Actions check that can never report would block every PR forever
+   - **A template change never reaches an already-configured repo on its own** — re-running this step is the migration. Reconciliation is additive (a live-only required context is preserved, never dropped) and legible: each context the run newly makes blocking is printed as `+ now required: <context>`, and a ruleset that already satisfies its template reports `nothing to do` and is not sent at all, so a second run is visibly a no-op
 3. **Deploy key** (`scripts/setup-deploy-key.sh --yes`) — write-access deploy key + `DEPLOY_KEY` secret, skipped when already configured. The `base` ruleset's `DeployKey: always` bypass is what lets CI version-bump pushes through protected branches.
 4. **Deployment environments** (`scripts/lisa-github-environments.sh`) — entirely optional; only runs when `.lisa.config.json` declares environments:
    ```json

--- a/plugins/lisa/.codex-plugin/skills/lisa-setup-github-repo/SKILL.md
+++ b/plugins/lisa/.codex-plugin/skills/lisa-setup-github-repo/SKILL.md
@@ -28,6 +28,7 @@ Apply the fleet-standard GitHub repository configuration to this project's repo.
    - `quality checks` — the stack's CI checks (TypeScript emoji names or Rails names)
    - `prevent delete`, `protect tags` (`v*`), plus stack overlays (`cdk validation`, staging-only `playwright`)
    - Repos without `.github/workflows/` get only app-based required checks — an Actions check that can never report would block every PR forever
+   - **A template change never reaches an already-configured repo on its own** — re-running this step is the migration. Reconciliation is additive (a live-only required context is preserved, never dropped) and legible: each context the run newly makes blocking is printed as `+ now required: <context>`, and a ruleset that already satisfies its template reports `nothing to do` and is not sent at all, so a second run is visibly a no-op
 3. **Deploy key** (`scripts/setup-deploy-key.sh --yes`) — write-access deploy key + `DEPLOY_KEY` secret, skipped when already configured. The `base` ruleset's `DeployKey: always` bypass is what lets CI version-bump pushes through protected branches.
 4. **Deployment environments** (`scripts/lisa-github-environments.sh`) — entirely optional; only runs when `.lisa.config.json` declares environments:
    ```json

--- a/plugins/lisa/skills/lisa-setup-github-repo/SKILL.md
+++ b/plugins/lisa/skills/lisa-setup-github-repo/SKILL.md
@@ -28,6 +28,7 @@ Apply the fleet-standard GitHub repository configuration to this project's repo.
    - `quality checks` — the stack's CI checks (TypeScript emoji names or Rails names)
    - `prevent delete`, `protect tags` (`v*`), plus stack overlays (`cdk validation`, staging-only `playwright`)
    - Repos without `.github/workflows/` get only app-based required checks — an Actions check that can never report would block every PR forever
+   - **A template change never reaches an already-configured repo on its own** — re-running this step is the migration. Reconciliation is additive (a live-only required context is preserved, never dropped) and legible: each context the run newly makes blocking is printed as `+ now required: <context>`, and a ruleset that already satisfies its template reports `nothing to do` and is not sent at all, so a second run is visibly a no-op
 3. **Deploy key** (`scripts/setup-deploy-key.sh --yes`) — write-access deploy key + `DEPLOY_KEY` secret, skipped when already configured. The `base` ruleset's `DeployKey: always` bypass is what lets CI version-bump pushes through protected branches.
 4. **Deployment environments** (`scripts/lisa-github-environments.sh`) — entirely optional; only runs when `.lisa.config.json` declares environments:
    ```json

--- a/plugins/src/base/skills/lisa-setup-github-repo/SKILL.md
+++ b/plugins/src/base/skills/lisa-setup-github-repo/SKILL.md
@@ -28,6 +28,7 @@ Apply the fleet-standard GitHub repository configuration to this project's repo.
    - `quality checks` — the stack's CI checks (TypeScript emoji names or Rails names)
    - `prevent delete`, `protect tags` (`v*`), plus stack overlays (`cdk validation`, staging-only `playwright`)
    - Repos without `.github/workflows/` get only app-based required checks — an Actions check that can never report would block every PR forever
+   - **A template change never reaches an already-configured repo on its own** — re-running this step is the migration. Reconciliation is additive (a live-only required context is preserved, never dropped) and legible: each context the run newly makes blocking is printed as `+ now required: <context>`, and a ruleset that already satisfies its template reports `nothing to do` and is not sent at all, so a second run is visibly a no-op
 3. **Deploy key** (`scripts/setup-deploy-key.sh --yes`) — write-access deploy key + `DEPLOY_KEY` secret, skipped when already configured. The `base` ruleset's `DeployKey: always` bypass is what lets CI version-bump pushes through protected branches.
 4. **Deployment environments** (`scripts/lisa-github-environments.sh`) — entirely optional; only runs when `.lisa.config.json` declares environments:
    ```json

--- a/scripts/lisa-github-rulesets.sh
+++ b/scripts/lisa-github-rulesets.sh
@@ -39,6 +39,11 @@ YES_MODE=false
 VERBOSE=false
 PROJECT_PATH=""
 
+# Rulesets that already matched and were therefore not sent, and the payload
+# GitHub last accepted (set by apply_with_integration_fallback).
+UNCHANGED_COUNT=0
+APPLIED_PAYLOAD=""
+
 # Project type hierarchy (child -> parent)
 # Using a function to avoid associative array issues with set -u
 get_parent_type() {
@@ -428,20 +433,12 @@ add_config_required_checks() {
 }
 
 preserve_live_required_checks() {
-  local repo="$1"
-  local existing_id="$2"
-  local json="$3"
-  local ruleset_name="$4"
+  local live="$1"
+  local json="$2"
 
-  if [[ -z "$existing_id" ]]; then
+  if [[ -z "$live" ]]; then
     echo "$json"
     return 0
-  fi
-
-  local live
-  if ! live=$(gh api -X GET "repos/$repo/rulesets/$existing_id" 2>/dev/null); then
-    log_warning "Could not read existing ruleset '$ruleset_name' details — refusing to silently replace required checks" >&2
-    return 1
   fi
 
   echo "$json" | jq --argjson live "$live" '
@@ -475,6 +472,73 @@ preserve_live_required_checks() {
       end'
 }
 
+# The contexts the outgoing payload requires that the live ruleset does not.
+# This is the drift a template change opens: a context added to a template never
+# reaches an already-configured repository on its own (#2641), so the operator
+# needs the reconciliation to SAY which checks it just made blocking rather than
+# to report an opaque "applied".
+ruleset_added_contexts() {
+  local live="$1"
+  local payload="$2"
+
+  jq -r -n --argjson live "${live:-null}" --argjson want "$payload" '
+    def contexts:
+      [ (.rules // [])[]
+        | select(.type == "required_status_checks")
+        | (.parameters.required_status_checks // [])[]
+        | .context ];
+
+    (if $live == null then [] else ($live | contexts) end) as $have
+    | ($want | contexts)
+    | map(select(. as $context | ($have | index($context)) | not))
+    | .[]'
+}
+
+# True when everything the payload asks for is ALREADY true of the live ruleset.
+#
+# Deliberately a subset test rather than an equality test: GitHub echoes back
+# parameters it filled in with its own defaults (`required_reviewers`,
+# `require_extra_approval_for_unattributed_changes`, ...) which no template
+# names. Comparing whole documents would report drift on every run and make
+# "nothing to do" unreachable — the AC's second scenario would then never hold
+# even on a repository that needs no change.
+ruleset_is_current() {
+  local live="$1"
+  local payload="$2"
+
+  [[ -n "$live" ]] || return 1
+
+  jq -e -n \
+    --argjson live "$(strip_readonly_fields "$live")" \
+    --argjson want "$payload" '
+    def covers($have; $need):
+      if ($need | type) == "object" then
+        ($have | type) == "object"
+        and ([$need | keys_unsorted[]]
+             | all(. as $key | ($have | has($key)) and covers($have[$key]; $need[$key])))
+      elif ($need | type) == "array" then
+        ($have | type) == "array"
+        and ($have | length) == ($need | length)
+        and ([range(0; $need | length)]
+             | all(. as $index | covers($have[$index]; $need[$index])))
+      else $have == $need
+      end;
+    covers($live; $want)' > /dev/null
+}
+
+# Print one line per context this run makes blocking. Reads the payload that
+# GitHub actually ACCEPTED, so a context dropped by the integration fallback is
+# never reported as added.
+report_added_contexts() {
+  local live="$1"
+  local payload="$2"
+
+  local context
+  while IFS= read -r context; do
+    [[ -n "$context" ]] && log_info "  + now required: $context"
+  done < <(ruleset_added_contexts "$live" "$payload")
+}
+
 apply_ruleset() {
   local repo="$1"
   local template_file="$2"
@@ -499,10 +563,22 @@ apply_ruleset() {
     return 0
   fi
 
-  local existing_id
+  local existing_id live=""
   existing_id=$(find_ruleset_by_name "$existing_rulesets" "$ruleset_name")
   if [[ -n "$existing_id" ]]; then
-    clean_template=$(preserve_live_required_checks "$repo" "$existing_id" "$clean_template" "$ruleset_name")
+    if ! live=$(gh api -X GET "repos/$repo/rulesets/$existing_id" 2>/dev/null); then
+      log_warning "Could not read existing ruleset '$ruleset_name' details — refusing to silently replace required checks"
+      return 1
+    fi
+    clean_template=$(preserve_live_required_checks "$live" "$clean_template")
+  fi
+
+  # Idempotence: a run that would change nothing must say so and send nothing,
+  # so a second run is visibly a no-op rather than an indistinguishable write.
+  if ruleset_is_current "$live" "$clean_template"; then
+    log_success "Ruleset '$ruleset_name' already matches the template — nothing to do"
+    UNCHANGED_COUNT=$((UNCHANGED_COUNT + 1))
+    return 0
   fi
 
   if [[ "$DRY_RUN" == "true" ]]; then
@@ -511,6 +587,7 @@ apply_ruleset() {
     else
       log_info "[DRY RUN] Would create ruleset '$ruleset_name'"
     fi
+    report_added_contexts "$live" "$clean_template"
     log_verbose "Template: $template_file"
     return 0
   fi
@@ -521,7 +598,9 @@ apply_ruleset() {
     log_info "Creating ruleset '$ruleset_name'..."
   fi
 
+  APPLIED_PAYLOAD=""
   if apply_with_integration_fallback "$repo" "$ruleset_name" "$clean_template" "$existing_id"; then
+    report_added_contexts "$live" "${APPLIED_PAYLOAD:-$clean_template}"
     return 0
   fi
   log_error "Failed to apply ruleset '$ruleset_name'"
@@ -546,6 +625,7 @@ apply_with_integration_fallback() {
   # Capture stdout AND stderr — gh prints the API error body (which carries
   # the "Invalid integration ids" detail) on stdout, not stderr.
   send_ruleset() {
+    APPLIED_PAYLOAD="$1"
     echo "$1" > "$temp_file"
     if [[ -n "$existing_id" ]]; then
       error_output=$(gh api -X PUT "repos/$repo/rulesets/$existing_id" --input "$temp_file" 2>&1)
@@ -772,7 +852,10 @@ main() {
   if [[ "$DRY_RUN" == "true" ]]; then
     log_info "Dry run complete. ${#templates[@]} ruleset(s) would be applied."
   else
-    log_success "Applied $success_count ruleset(s)"
+    log_success "Applied $((success_count - UNCHANGED_COUNT)) ruleset(s), $UNCHANGED_COUNT already current"
+    if [[ $UNCHANGED_COUNT -eq $success_count ]]; then
+      log_info "Nothing to do — every ruleset already matches its template"
+    fi
     if [[ $fail_count -gt 0 ]]; then
       log_warning "$fail_count ruleset(s) failed"
       exit 1

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -1327,7 +1327,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/skills/lisa-setup-confluence/SKILL.md":
       "e92d762dbdaeae671c3e52dfe8e10d40a10b606b5e050589181a3898649faedc",
     "plugins/src/base/skills/lisa-setup-github-repo/SKILL.md":
-      "b9b223a5ffad2f88e3fde5831b60fea9bdc2c981750c49d03bb046d43772a0d3",
+      "1e343418a59e54ac1e2b6d542ddbecfa53adb370d6bfe558818d5960f9701bc8",
     "plugins/src/base/skills/lisa-setup-github/SKILL.md":
       "75435e81130abd21c678d302b7a220da95a19868d122ca93168278628b200666",
     "plugins/src/base/skills/lisa-setup-jira/SKILL.md":
@@ -2227,7 +2227,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/lisa-github-repo-setup.sh":
       "dc2f1c9d718aa34ba57161120d9319b5f78fe6b0b496d8e3c77226a08795aa36",
     "scripts/lisa-github-rulesets.sh":
-      "3e496f8d2d294d68c9f4d156684943dd2c7e35f2aaccf476ea4c7309c3a57b77",
+      "5899206cb187d877026d7980356a28214dcad4f1d90d855206a95f448900b333",
     "scripts/lisa-mutation.mjs":
       "74603e61f493d700318feb862f61ee1653430700b5edf232e70241ccdedac587",
     "scripts/lisa-remote-env/session-start.sh":

--- a/tests/unit/scripts/lisa-github-rulesets.test.ts
+++ b/tests/unit/scripts/lisa-github-rulesets.test.ts
@@ -460,5 +460,132 @@ describe("lisa-github-rulesets.sh", () => {
       }
     });
   });
+
+  // #2828: a context added to a template never reaches an already-configured
+  // repository on its own, so the reconciliation has to be legible — it must
+  // name the checks it just made blocking, and a second run must be visibly a
+  // no-op rather than an indistinguishable write.
+  describe("drift reporting", () => {
+    const LINT_CONTEXT = "🔍 Quality Checks / 🧹 Lint";
+    const SG_CONTEXT = "🔍 Quality Checks / 🔎 AST Grep Scan";
+    const ACTIONS_INTEGRATION_ID = 15_368;
+
+    /**
+     * Builds a ruleset document requiring the given contexts.
+     *
+     * @param contexts Contexts the ruleset requires.
+     * @param extraParameters Fields GitHub echoes back that no template names.
+     * @returns A ruleset document.
+     */
+    function rulesetRequiring(
+      contexts: readonly string[],
+      extraParameters: Readonly<Record<string, unknown>> = {}
+    ): Record<string, unknown> {
+      return {
+        name: "base",
+        enforcement: ACTIVE_ENFORCEMENT,
+        rules: [
+          {
+            type: "required_status_checks",
+            parameters: {
+              ...extraParameters,
+              required_status_checks: contexts.map(context => ({
+                context,
+                integration_id: ACTIONS_INTEGRATION_ID,
+              })),
+            },
+          },
+        ],
+      };
+    }
+
+    /**
+     * Runs the script against a live `base` ruleset the mock gh serves.
+     *
+     * @param templateContexts Contexts the shipped template requires.
+     * @param live The live ruleset GitHub returns for the existing id.
+     * @returns The script stdout and the files the mock captured.
+     */
+    function reconcile(
+      templateContexts: readonly string[],
+      live: Record<string, unknown>
+    ): { captured: readonly string[]; stdout: string } {
+      const projectDir = createProject();
+      const captureDir = mkdtempSync(path.join(tmpdir(), "lisa-gh-drift-"));
+      const lisaInstall = createLisaInstall();
+      const ghBin = createUpdatingGhBin(captureDir, live as RulesetPayload);
+
+      mkdirSync(path.join(projectDir, ".github", "workflows"), {
+        recursive: true,
+      });
+      const rulesetDir = path.join(
+        lisaInstall.root,
+        "typescript",
+        "github-rulesets"
+      );
+      rmSync(path.join(rulesetDir, "extra.json"));
+      writeFileSync(
+        path.join(rulesetDir, "base.json"),
+        JSON.stringify(rulesetRequiring(templateContexts))
+      );
+
+      try {
+        const result = runRulesetScript(
+          lisaInstall.scriptPath,
+          ["--yes", projectDir],
+          ghBin
+        );
+        expect(result.status).toBe(0);
+        return {
+          captured: readdirSync(captureDir),
+          stdout: result.stdout as string,
+        };
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+        rmSync(captureDir, { recursive: true, force: true });
+        rmSync(ghBin, { recursive: true, force: true });
+        rmSync(lisaInstall.root, { recursive: true, force: true });
+      }
+    }
+
+    it("names each context it makes required when the live ruleset has drifted", () => {
+      const { captured, stdout } = reconcile(
+        [LINT_CONTEXT, SG_CONTEXT],
+        rulesetRequiring([LINT_CONTEXT])
+      );
+
+      expect(stdout).toContain(`+ now required: ${SG_CONTEXT}`);
+      expect(stdout).not.toContain(`+ now required: ${LINT_CONTEXT}`);
+      expect(captured).toContain("updated.json");
+    });
+
+    it("reports nothing to do and sends no update when the live ruleset matches", () => {
+      const { captured, stdout } = reconcile(
+        [LINT_CONTEXT, SG_CONTEXT],
+        rulesetRequiring([LINT_CONTEXT, SG_CONTEXT])
+      );
+
+      expect(stdout).toContain(
+        "Ruleset 'base' already matches the template — nothing to do"
+      );
+      expect(stdout).not.toContain("+ now required:");
+      expect(captured).not.toContain("updated.json");
+    });
+
+    // GitHub fills in rule parameters no template names and echoes them back.
+    // Treating those as drift would make "nothing to do" unreachable.
+    it("treats parameters GitHub added itself as matching, not as drift", () => {
+      const { captured, stdout } = reconcile(
+        [LINT_CONTEXT],
+        rulesetRequiring([LINT_CONTEXT], {
+          do_not_enforce_on_create: true,
+          strict_required_status_checks_policy: false,
+        })
+      );
+
+      expect(stdout).toContain("nothing to do");
+      expect(captured).not.toContain("updated.json");
+    });
+  });
 });
 /* eslint-enable sonarjs/no-duplicate-string, max-lines -- restore repository defaults */


### PR DESCRIPTION
## What

The live `quality checks` ruleset on `main` required **nine** contexts; the stack template it derives from requires **eleven**. Three template-declared contexts were not in force live, with no `dropRequiredChecks` opt-out — measured drift, not a decision:

- `🔍 Quality Checks / 🔎 AST Grep Scan`
- `🔍 Quality Checks / 🐢 Slow Lint Rules`
- `🔍 Quality Checks / 🗑️ Dead Code Detection`

A template change never reaches an already-configured repository on its own, and nothing had re-run the setup script.

## Why the script changed too

Reconciling by hand would have settled this repository and left the next one to be found by hand as well. The reconciliation was also the thing that was illegible: `lisa-github-rulesets.sh` PUT the ruleset unconditionally and printed `Applied ruleset 'x'` whether it had changed one context, all of them, or nothing. An operator could not tell a migration from a no-op — which is how drift of this shape survives.

So the script now reports what it did:

- each context a run newly makes blocking prints as `+ now required: <context>`, read off the payload GitHub **accepted** rather than the one it was offered, so a context dropped by the integration fallback is never claimed as added
- a ruleset that already satisfies its template prints `nothing to do` and **is not sent at all**, so a second run is visibly a no-op

"Already satisfies" is a **subset** test, not document equality. GitHub fills in rule parameters no template names (`required_reviewers`, `require_extra_approval_for_unattributed_changes`) and echoes them back; comparing whole documents would report drift on every run and make `nothing to do` unreachable even where nothing needs changing. Measured here: `base`, `prevent delete` and `protect tags` all carry such fields and all correctly report nothing to do.

Reconciliation stays **additive** — a live-only required context is still unioned in, never dropped — so this cannot silently unrequire a check.

## Acceptance criteria — both proved live

**Scenario 1 — the live ruleset matches the template it derives from.** Reconciled through the sanctioned path (`scripts/lisa-github-rulesets.sh --yes .`):

```
✓ Ruleset 'base' already matches the template — nothing to do
✓ Ruleset 'prevent delete' already matches the template — nothing to do
✓ Ruleset 'protect tags' already matches the template — nothing to do
ℹ Updating ruleset 'quality checks' (id: 18805189)...
✓ Applied ruleset 'quality checks'
ℹ   + now required: 🔍 Quality Checks / 🔎 AST Grep Scan
ℹ   + now required: 🔍 Quality Checks / 🐢 Slow Lint Rules
ℹ   + now required: 🔍 Quality Checks / 🗑️ Dead Code Detection

✓ Applied 1 ruleset(s), 3 already current
```

`gh api repos/.../rules/branches/main` now lists all eleven template contexts plus the repo-only `🧩 Plugin artifacts match source`, which was preserved rather than replaced.

**Scenario 2 — the reconciliation is reproducible.** Immediately re-run, unchanged:

```
✓ Ruleset 'quality checks' already matches the template — nothing to do

✓ Applied 0 ruleset(s), 4 already current
ℹ Nothing to do — every ruleset already matches its template
```

## Promotion budget (#2509)

All three contexts are already `proven` in `.github/required-check-promotions.json` — 15.0x, 15.2x and 10.9x headroom against their job budgets, each sized on the job itself from runs that completed. This PR requires them; it does not newly claim headroom for them.

They are also checks that **report**: all three ride the unconditional `skip_jobs: ''` path in `ci.yml`, and all three concluded `success` on each of the five most recently merged pull requests. Promoting a context that can never arrive would block every PR forever (#2476); these arrive.

## Tests

Three new cases in `tests/unit/scripts/lisa-github-rulesets.test.ts`, all three verified failing against the pre-fix script at `origin/main` and passing after:

- `names each context it makes required when the live ruleset has drifted`
- `reports nothing to do and sends no update when the live ruleset matches`
- `treats parameters GitHub added itself as matching, not as drift`

The seven pre-existing cases in the file still pass, including `preserves live-only required checks when updating a ruleset` — the guard against this change turning an additive reconciliation into a replacing one.

Work-Item: CodySwannGT/lisa#2828
