### PR TITLE
test(ci): pin the live-read refusal that keeps reconciliation additive

### DIFF
--- a/tests/unit/scripts/lisa-github-rulesets.test.ts
+++ b/tests/unit/scripts/lisa-github-rulesets.test.ts
@@ -574,6 +574,59 @@ describe("lisa-github-rulesets.sh", () => {
 
     // GitHub fills in rule parameters no template names and echoes them back.
     // Treating those as drift would make "nothing to do" unreachable.
+    // The live read is what makes reconciliation additive. If it fails, the
+    // payload has no live checks to preserve, so sending it anyway would
+    // REPLACE the repository's required checks with the template's — the exact
+    // silent unrequiring the read exists to prevent.
+    it("sends nothing and fails when the live ruleset cannot be read", () => {
+      const projectDir = createProject();
+      const captureDir = mkdtempSync(path.join(tmpdir(), "lisa-gh-unread-"));
+      const lisaInstall = createLisaInstall();
+      const ghBin = createUpdatingGhBin(captureDir, {});
+      const ghPath = path.join(ghBin, "gh");
+
+      mkdirSync(path.join(projectDir, ".github", "workflows"), {
+        recursive: true,
+      });
+      const rulesetDir = path.join(
+        lisaInstall.root,
+        "typescript",
+        "github-rulesets"
+      );
+      rmSync(path.join(rulesetDir, "extra.json"));
+      writeFileSync(
+        path.join(rulesetDir, "base.json"),
+        JSON.stringify(rulesetRequiring([LINT_CONTEXT]))
+      );
+      writeFileSync(
+        ghPath,
+        readFileSync(ghPath, "utf8").replace(
+          `if [[ "$1 $2 $3" == "api -X GET" && "$4" == "repos/${REPO_NAME}/rulesets/7" ]]; then`,
+          `if [[ "$1 $2 $3" == "api -X GET" && "$4" == "repos/${REPO_NAME}/rulesets/7" ]]; then\n  exit 1`
+        ),
+        { mode: 0o755 }
+      );
+
+      try {
+        const result = runRulesetScript(
+          lisaInstall.scriptPath,
+          ["--yes", projectDir],
+          ghBin
+        );
+
+        expect(result.status).toBe(1);
+        expect(result.stdout).toContain(
+          "refusing to silently replace required checks"
+        );
+        expect(readdirSync(captureDir)).not.toContain("updated.json");
+      } finally {
+        rmSync(projectDir, { recursive: true, force: true });
+        rmSync(captureDir, { recursive: true, force: true });
+        rmSync(ghBin, { recursive: true, force: true });
+        rmSync(lisaInstall.root, { recursive: true, force: true });
+      }
+    });
+
     it("treats parameters GitHub added itself as matching, not as drift", () => {
       const { captured, stdout } = reconcile(
         [LINT_CONTEXT],


### PR DESCRIPTION
Follow-up to #2870, same work item. Test-only.

## What #2870 changed here

Reading the live ruleset before writing it is what makes reconciliation **additive**: the live-only required checks are unioned into the payload, so a template naming fewer contexts than the repository requires cannot unrequire the difference. #2870 moved that read out of `preserve_live_required_checks` and into `apply_ruleset`, because that is where the decision to send is made.

That move fixed a live fail-open, and this PR is the case that holds it fixed.

## The fail-open

The refusal was written but unreachable. `preserve_live_required_checks` returned 1 on a failed read, but its caller consumed it as `clean_template=$(preserve_live_required_checks ...)`, and `apply_ruleset` runs inside an `if`, where `set -e` does not apply. The non-zero landed in a variable nobody inspected: `clean_template` became the empty string and the script went on to PUT it.

Measured against `origin/main` before #2870 — a gh whose ruleset GET exits non-zero produced **exit 0, an empty payload sent to the PUT, and the warning printed only to stderr**. A repository whose live read failed would have had its required checks replaced by whatever the template said, reported as a success.

## The test

`sends nothing and fails when the live ruleset cannot be read` asserts all three: exit 1, the reason on stdout, and no update captured. It fails against the pre-#2870 script on every one of them.

Run against the pre-fix script, the four cases added for this work item fail by name:

```
FAIL  drift reporting > names each context it makes required when the live ruleset has drifted
FAIL  drift reporting > reports nothing to do and sends no update when the live ruleset matches
FAIL  drift reporting > sends nothing and fails when the live ruleset cannot be read
FAIL  drift reporting > treats parameters GitHub added itself as matching, not as drift
```

All 11 cases in the file pass on this branch.

## Why it is a separate PR

#2870 auto-merged while this commit was still held at the pre-push gate by a 60s timeout in an unrelated load-sensitive suite (`lisa-owned-hash-ledger.test.ts` — the known-marginal budget family recorded in `.github/required-check-promotions.json`). Rebased onto the merged main and sent on its own rather than reopened.

Work-Item: CodySwannGT/lisa#2828


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for ruleset reconciliation when the live ruleset cannot be read.
  * Verified existing required checks are preserved and no update is submitted in this scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->