### PR TITLE
fix(hooks): name every commit-msg gate family on any refusal

### DIFF
--- a/.claude-pr/.husky/commit-msg
+++ b/.claude-pr/.husky/commit-msg
@@ -20,6 +20,27 @@ fi
 # Get the commit message file path
 COMMIT_MSG_FILE=$1
 
+# Several INDEPENDENT gate families bite at this one moment, and each of the
+# checks below knows only its own. Whichever refuses first, the operator is told
+# about ALL of them here — otherwise satisfying every requirement the refusal
+# names still says nothing about whether the commit will be accepted, which is
+# exactly the property those checklists exist to provide. Owned by neither
+# check, because neither can know what the other installs.
+GATE_FAMILIES_SCRIPT="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs"
+if [ ! -f "$GATE_FAMILIES_SCRIPT" ]; then
+  GATE_FAMILIES_SCRIPT="scripts/lisa-commit-msg-gates.mjs"
+fi
+if [ ! -f "$GATE_FAMILIES_SCRIPT" ]; then
+  GATE_FAMILIES_SCRIPT="all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs"
+fi
+
+# Never the reason a commit fails: the caller has already decided to refuse.
+lisa_commit_gate_families() {
+  [ -f "$GATE_FAMILIES_SCRIPT" ] || return 0
+  command -v node >/dev/null 2>&1 || return 0
+  node "$GATE_FAMILIES_SCRIPT" list --hook "$0" --refused "$1" 2>/dev/null || true
+}
+
 # Get the current branch name
 BRANCH_NAME=$(git branch --show-current)
 
@@ -70,6 +91,7 @@ if [ $? -ne 0 ]; then
   echo "Format: <type>(<optional scope>): <subject>"
   echo ""
   echo "For more info, see: https://www.conventionalcommits.org/"
+  lisa_commit_gate_families commit-conformance
   exit 1
 fi
 
@@ -102,6 +124,7 @@ if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex)"; 
   echo "If you're using Claude Code, use the /git:commit command"
   echo "If you're using Codex, enable commit_attribution in .codex/config.toml"
   echo ""
+  lisa_commit_gate_families ai-coauthorship
   exit 1
 fi
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -24,11 +24,33 @@ WORK_ITEM_SCRIPT="scripts/lisa-work-item.mjs"
 if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
   WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
 fi
+
+# Several INDEPENDENT gate families bite at this one moment, and each of the
+# checks below knows only its own. Whichever refuses first, the operator is told
+# about ALL of them here — otherwise satisfying every requirement the refusal
+# names still says nothing about whether the commit will be accepted, which is
+# exactly the property those checklists exist to provide. Owned by neither
+# check, because neither can know what the other installs.
+GATE_FAMILIES_SCRIPT="scripts/lisa-commit-msg-gates.mjs"
+if [ ! -f "$GATE_FAMILIES_SCRIPT" ]; then
+  GATE_FAMILIES_SCRIPT="all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs"
+fi
+
+# Never the reason a commit fails: the caller has already decided to refuse.
+lisa_commit_gate_families() {
+  [ -f "$GATE_FAMILIES_SCRIPT" ] || return 0
+  command -v node >/dev/null 2>&1 || return 0
+  node "$GATE_FAMILIES_SCRIPT" list --hook "$0" --refused "$1" 2>/dev/null || true
+}
+
 if ! command -v node >/dev/null 2>&1; then
   echo "❌ Commit blocked: Node.js is required to validate tracker work items."
   exit 1
 fi
-node "$WORK_ITEM_SCRIPT" validate-commit "$COMMIT_MSG_FILE" || exit 1
+if ! node "$WORK_ITEM_SCRIPT" validate-commit "$COMMIT_MSG_FILE"; then
+  lisa_commit_gate_families traceability
+  exit 1
+fi
 
 echo "📝 Validating commit message with commitlint..."
 COMMITLINT_OUTPUT=$($EXECUTOR commitlint --edit "$COMMIT_MSG_FILE" 2>&1)
@@ -59,6 +81,7 @@ if [ $COMMITLINT_STATUS -ne 0 ]; then
   echo "Format: <type>(<optional scope>): <subject>"
   echo ""
   echo "For more info, see: https://www.conventionalcommits.org/"
+  lisa_commit_gate_families commit-conformance
   exit 1
 fi
 
@@ -110,6 +133,7 @@ if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex|Ope
   echo "If you're using Codex, enable commit_attribution in .codex/config.toml"
   echo "If you're using OpenCode, include the OpenCode trailer and AI-* metadata"
   echo ""
+  lisa_commit_gate_families ai-coauthorship
   exit 1
 fi
 
@@ -134,6 +158,7 @@ if printf '%s\n' "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*OpenCode"; then
     echo "  AI-Model: <provider/model>"
     echo "  AI-Effort: <effort or runtime value>"
     echo ""
+    lisa_commit_gate_families ai-coauthorship
     exit 1
   fi
 fi

--- a/all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs
+++ b/all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs
@@ -1,0 +1,251 @@
+#!/usr/bin/env node
+// This file is managed by Lisa and IS replaced on each `lisa` run.
+// Do not edit directly — durable changes belong upstream in Lisa.
+
+/**
+ * @file Name every gate family that runs at the commit-msg moment.
+ *
+ * ## The defect this removes
+ *
+ * More than one INDEPENDENT gate family bites at `commit-msg`, and until this
+ * file existed only one of them introduced itself. `lisa-work-item.mjs` prints
+ * a five-gate checklist on any traceability refusal — deliberately scoped to
+ * the traceability contract, which is the only contract it owns. At the same
+ * moment the hook also runs commitlint and an AI co-authorship check, and
+ * neither said so until it fired. An operator could satisfy every requirement
+ * the checklist named and still be refused, twice, for reasons nothing had
+ * mentioned. Measured: two sessions in one day each cleared the named gates and
+ * were bounced by the co-authorship trailer.
+ *
+ * ## Why it is a third file rather than a sixth line
+ *
+ * The obvious fix — append the co-authorship gate to `gateSummary` — was
+ * rejected upstream and the reasoning is worth keeping. `gateSummary` lives in
+ * `lisa-work-item.mjs`, which does not own the co-authorship check, cannot
+ * verify it, and cannot know whether a given host project installs it. A
+ * checklist that confidently names a gate a project does not have is worse than
+ * one that stays silent, for the same reason the traceability checklist reads
+ * role names from the resolved contract instead of hardcoding Lisa's defaults.
+ * And folding an unrelated family into a list headed "All five gates" makes the
+ * count wrong in a new direction, which is the precise defect that list exists
+ * to remove.
+ *
+ * So this module is owned by neither check. It answers one question — what runs
+ * at commit-msg in THIS project — and both families call it on refusal.
+ *
+ * ## Why the answer is read off the hook rather than declared
+ *
+ * The families are detected from the INVOCATIONS in the project's own
+ * `commit-msg` hook: `validate-commit`, `commitlint --edit`, the co-authorship
+ * `grep`. That is the file that is doing the refusing, so it is the only
+ * honest authority on what a commit here must survive.
+ *
+ * A marker comment the hook declares would read more cleanly and was the first
+ * design. It fails on the case that matters: a host that deletes a block keeps
+ * whatever the block was declared to be somewhere else, and an installed hook
+ * predating the marker declares nothing at all — so the summary would either
+ * name a gate that no longer runs or name none of them. Detecting the call
+ * degrades the right way in both directions.
+ *
+ * Every candidate hook path is read and the results unioned, because "the
+ * commit-msg hook" is not one path: husky 8 points git straight at
+ * `.husky/commit-msg`, husky 9 interposes `.husky/_/commit-msg`, and a project
+ * using neither has `.git/hooks/commit-msg`. Reading only the one git invoked
+ * would answer "no families" for the husky 9 shim, which contains no gate at
+ * all.
+ *
+ * Usage:
+ *   lisa-commit-msg-gates.mjs list [--hook <path>] [--refused <family-id>]
+ *
+ * Always exits 0. This runs only on a refusal that has already decided to fail
+ * the commit; it must never be the reason a commit is refused, and it must
+ * never turn a refusal into a crash.
+ */
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { invokedAsScript } from "./lib/invoked-as-script.mjs";
+
+/**
+ * The gate families that can run at `commit-msg`, in the order the hook runs
+ * them — which is the order an operator meets them, one refusal at a time.
+ *
+ * `detect` matches the ENFORCING invocation, never prose. The co-authorship
+ * block in particular carries a long comment that names the trailer it checks
+ * for; a project that deleted the check and left the comment would still be
+ * told the gate runs, which is the failure this whole file exists to remove.
+ *
+ * `id` is the registry gate id where the registry has one. `ai-coauthorship`
+ * has none — no declaration in `.lisa.config.json` governs it — and that is
+ * recorded here rather than papered over with an invented name.
+ */
+export const FAMILIES = Object.freeze([
+  Object.freeze({
+    id: "traceability",
+    title: "Work-Item traceability",
+    detect: /validate-commit/,
+    requirement:
+      "Every commit message carries one matching `Work-Item:` trailer for a live tracker item. Its own refusal prints the full five-gate checklist.",
+  }),
+  Object.freeze({
+    id: "commit-conformance",
+    title: "Conventional commit format",
+    detect: /commitlint[\s\S]{0,40}--edit/,
+    requirement:
+      "The subject reads `<type>(<optional scope>): <subject>`, and the body obeys the project's commitlint rules.",
+  }),
+  Object.freeze({
+    id: "ai-coauthorship",
+    title: "AI co-authorship",
+    detect: /grep[^\n]{0,20}-Eiq[^\n]{0,10}"Co-authored-by:/i,
+    requirement:
+      "The message carries a `Co-authored-by:` trailer naming a supported coding agent — Claude, Codex, or OpenCode. OpenCode also needs `AI-Agent`, `AI-Model` and `AI-Effort` trailers.",
+  }),
+]);
+
+/**
+ * Where a `commit-msg` hook can live, cwd-relative.
+ *
+ * git runs hooks from the repository root, so relative paths are the right
+ * spelling and they keep this readable in the diagnostics a test asserts on.
+ */
+const HOOK_NAME = "commit-msg";
+const HOOK_CANDIDATES = Object.freeze([
+  join(".husky", HOOK_NAME),
+  join(".husky", "_", HOOK_NAME),
+  join(".git", "hooks", HOOK_NAME),
+]);
+
+/**
+ * Read every commit-msg hook this project has.
+ * @param {string | null} explicitPath - A hook path the caller knows, or null.
+ * @returns {string[]} Hook sources; empty when none can be read.
+ */
+export function readHookSources(explicitPath) {
+  const paths = explicitPath
+    ? [explicitPath, ...HOOK_CANDIDATES]
+    : [...HOOK_CANDIDATES];
+  const seen = new Set();
+  const sources = [];
+  for (const path of paths) {
+    if (seen.has(path)) continue;
+    seen.add(path);
+    if (!existsSync(path)) continue;
+    try {
+      sources.push(readFileSync(path, "utf8"));
+    } catch {
+      // Unreadable is the same as absent for this purpose. A permissions error
+      // on one candidate must not cost the operator the families the others
+      // would have named.
+    }
+  }
+  return sources;
+}
+
+/**
+ * Which families any of these hook sources actually installs.
+ * @param {string[]} sources - Hook sources.
+ * @returns {object[]} Families present, in registry order.
+ */
+export function detectFamilies(sources) {
+  return FAMILIES.filter(family =>
+    sources.some(source => family.detect.test(source))
+  );
+}
+
+/**
+ * Wrap one requirement to a readable width under a hanging indent.
+ * @param {string} text - The requirement sentence.
+ * @param {number} width - Column to wrap at.
+ * @returns {string[]} Wrapped lines, without the indent.
+ */
+function wrap(text, width) {
+  const lines = [];
+  let line = "";
+  for (const word of text.split(" ")) {
+    if (line.length > 0 && line.length + 1 + word.length > width) {
+      lines.push(line);
+      line = word;
+      continue;
+    }
+    line = line.length === 0 ? word : `${line} ${word}`;
+  }
+  if (line.length > 0) lines.push(line);
+  return lines;
+}
+
+/** Width the requirement sentences wrap at, under a five-space indent. */
+const WRAP_WIDTH = 68;
+
+/**
+ * The operator-facing summary.
+ *
+ * It says the count, says that clearing one proves nothing about the rest, and
+ * marks the family that just refused — which is the question an operator
+ * reading a wall of hook output actually has. It names ONLY the families
+ * detected, so a project that installs one of them is never told it has three.
+ * @param {object[]} families - Families this project installs.
+ * @param {string | null} refusedId - Family that refused this commit, if known.
+ * @returns {string} The summary, or "" when nothing was detected.
+ */
+export function summary(families, refusedId) {
+  if (families.length === 0) return "";
+  const plural = families.length === 1 ? "family runs" : "families run";
+  const lines = [
+    "",
+    "──────────────────────────────────────────────────────────────",
+    `${families.length} gate ${plural} at the commit-msg moment in this project, and a`,
+    "commit must satisfy every one of them. The first refusal stops the",
+    "commit, so clearing this one proves nothing about the others.",
+    "",
+  ];
+  families.forEach((family, index) => {
+    const mark = family.id === refusedId ? "  ← refused this commit" : "";
+    lines.push(`  ${index + 1}. ${family.title}${mark}`);
+    for (const wrapped of wrap(family.requirement, WRAP_WIDTH)) {
+      lines.push(`     ${wrapped}`);
+    }
+  });
+  lines.push(
+    "",
+    "Read off what this project's commit-msg hook actually runs, so a",
+    "family it does not install is never named here.",
+    "──────────────────────────────────────────────────────────────"
+  );
+  return lines.join("\n");
+}
+
+/**
+ * Read a `--flag value` pair out of an argument list.
+ * @param {string[]} argv - Arguments.
+ * @param {string} flag - Flag to read, including its leading dashes.
+ * @returns {string | null} The value, or null when absent.
+ */
+function flagValue(argv, flag) {
+  const index = argv.indexOf(flag);
+  if (index < 0 || index + 1 >= argv.length) return null;
+  return argv[index + 1];
+}
+
+/**
+ * Print the summary for this project.
+ *
+ * Never throws and never exits non-zero: see the file remarks. The caller is a
+ * hook that has already decided to refuse, and a diagnostic that can fail is a
+ * diagnostic that turns a clear refusal into a stack trace.
+ * @param {string[]} [argv] - Arguments after the command name.
+ */
+export function runCli(argv = process.argv.slice(2)) {
+  try {
+    const families = detectFamilies(readHookSources(flagValue(argv, "--hook")));
+    const text = summary(families, flagValue(argv, "--refused"));
+    if (text.length > 0) process.stdout.write(`${text}\n`);
+  } catch {
+    // Silence is the correct degradation. The refusal the caller is about to
+    // print is the message that matters.
+  }
+}
+
+if (invokedAsScript(import.meta.url)) {
+  runCli();
+}

--- a/scripts/lisa-commit-msg-gates.mjs
+++ b/scripts/lisa-commit-msg-gates.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+// The installed copy lives under all/copy-overwrite. Keeping this tiny entrypoint
+// makes the exact same implementation available to Lisa's own hooks and CI.
+//
+// runCli() is called explicitly rather than left to the implementation's own
+// "am I the program?" check: from in there, import.meta.url names that file
+// while argv[1] names this one, so the check cannot fire through this path and
+// Lisa's own commit-msg refusals would name no gate families at all.
+import { runCli } from "../all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs";
+
+runCli();

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -223,6 +223,10 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "6b198f088cd3cd862d4357fbb069b1ad5d3afeb7be594f2bf1ff603b092a8354",
     "e06cb11f1418fe94564cea527a22b039f53b7ab10c1cd182264a31e52bba9fa8",
   ]),
+  "scripts/lisa-commit-msg-gates.mjs": Object.freeze([
+    "5d587fd849cef02e9706d084ac2b508f3885da0ba59b76311e3b666f4fbff01e",
+    "99422b4912cd660ddeb5ec5ab9fc333e57fa5763e711117a00b06dd2eda0bbb7",
+  ]),
   "scripts/lisa-destructive-guard.mjs": Object.freeze([
     "4fb431a3c58f443e303d613934d023d9e95ddae5c42710bb7009f7c080c82a64",
     "66ade2c9cc0554c4934ed94a44563fd9d648b37cacfa9a5d31f17ac4f181e5a3",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -14,6 +14,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "fbb9b88fc85a3e22f21af39e1c17acf67ff83fc6b5a6cdc8081bde333c48faa7",
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs":
       "014a94647efc636cbce961364a82f03c1f3c1e54a55e9d21508fded88dce49c4",
+    "all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs":
+      "5d587fd849cef02e9706d084ac2b508f3885da0ba59b76311e3b666f4fbff01e",
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs":
       "f0f3c43bbb6d1e389135b0205a051e64891e539d4272df2a87841ee82a8b7a55",
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh":
@@ -2218,6 +2220,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "624e40d7f33ca17208fc6b7a19320a785cff19da5d2ff8062b67a432b2a34022",
     "scripts/lisa-commit-and-pr-local.sh":
       "605409c3ce6ec38ad3275604291a1ceae98f7807a605654263bc14f811c03903",
+    "scripts/lisa-commit-msg-gates.mjs":
+      "f961cb70a525e7b0a94b8ca7a76d1e2bb5b1929d5477417e159dbf58312ce0d8",
     "scripts/lisa-enforcement-fallback.sh":
       "c065e1fb3b07addc2c6d14d4436bd9c64aa3d0112e6d9dbea4561cc8072895df",
     "scripts/lisa-github-environments.sh":
@@ -2287,7 +2291,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "tsconfig/typescript.json":
       "8cf66a6535640e0a723e24bdf7a2d8e58a634c451f0754875c7880811381a914",
     "typescript/copy-contents/.husky/commit-msg":
-      "7c925044ba7c38e6ffc9f981f743f7d7a8ba7b2b587fc71b23f1b08c115556e6",
+      "1885cc0f655a5a336078db510ceb8854582c628cb813c14fd052a1f6aa3bab07",
     "typescript/copy-contents/.husky/post-checkout":
       "f3abc4528e12d3ad2bc48b236d19f105e2817595c744156a558c62ae5551ccfb",
     "typescript/copy-contents/.husky/pre-commit":
@@ -2305,7 +2309,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "typescript/copy-overwrite/.nvmrc":
       "0775c6feb7638122e8b68d611cd709bf270f7b5adb5d0d2baa9afab8a6c0fc42",
     "typescript/copy-overwrite/.prettierignore":
-      "cbb2b76ffd7f6e1d63030e4c9d2ea2a9925954dbd402e6914c0a4e190722a779",
+      "92fa6096492cb508be2bdc0d6f9c1a155143a1147b9031b96757ed5f2e8fb99c",
     "typescript/copy-overwrite/.prettierrc.json":
       "a20621f79a064486fba53cc0ea3000a2ece3f312ff38495c6a6606a27d2a727c",
     "typescript/copy-overwrite/.versionrc":
@@ -2550,6 +2554,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "all/copy-overwrite/scripts/lib/gate-failure-diagnosis.mjs": true,
     "all/copy-overwrite/scripts/lib/invoked-as-script.mjs": true,
     "all/copy-overwrite/scripts/lisa-command-envelope.mjs": true,
+    "all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs": true,
     "all/copy-overwrite/scripts/lisa-destructive-guard.mjs": true,
     "all/copy-overwrite/scripts/lisa-enforcement-fallback.sh": true,
     "all/copy-overwrite/scripts/lisa-environment-prepare.mjs": true,
@@ -8274,6 +8279,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/lib/reusable-workflow-contract.mjs": true,
     "scripts/lisa-assert-eas-profile.mjs": true,
     "scripts/lisa-commit-and-pr-local.sh": true,
+    "scripts/lisa-commit-msg-gates.mjs": true,
     "scripts/lisa-enforcement-fallback.sh": true,
     "scripts/lisa-github-environments.sh": true,
     "scripts/lisa-github-repo-settings.sh": true,
@@ -9103,6 +9109,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/hooks/block-shell-json-parsing.test.ts": true,
     "tests/unit/hooks/blocking-hook-exit.test.ts": true,
     "tests/unit/hooks/cleanup-stale-worktrees.test.ts": true,
+    "tests/unit/hooks/commit-msg-gate-families.test.ts": true,
     "tests/unit/hooks/commit-msg.test.ts": true,
     "tests/unit/hooks/enforce-config-extensions.test.ts": true,
     "tests/unit/hooks/enforce-team-first.test.ts": true,

--- a/tests/unit/hooks/commit-msg-gate-families.test.ts
+++ b/tests/unit/hooks/commit-msg-gate-families.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Every commit-msg refusal names every gate family the project installs.
+ *
+ * More than one INDEPENDENT family bites at this one moment, and only one of
+ * them used to introduce itself: `lisa-work-item.mjs` prints a five-gate
+ * traceability checklist, while commitlint and the AI co-authorship trailer
+ * said nothing until they fired. An operator could satisfy every requirement
+ * the checklist named and still be refused — which is precisely the property
+ * that checklist exists to provide. Measured twice in one day, by two sessions
+ * working on opposite sides of the same change.
+ *
+ * These tests run the real hooks. A summary asserted only against the shared
+ * module would pass while no hook called it.
+ * @module tests/unit/hooks/commit-msg-gate-families
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  detectFamilies,
+  FAMILIES,
+  summary,
+} from "../../../all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs";
+import { cleanGitEnv } from "../../helpers/test-utils.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
+
+const GIT = "/usr/bin/git";
+const BASH = "/bin/bash";
+const HOOK_PATH = path.join(REPO_ROOT, ".husky", "commit-msg");
+const TRACKER_SCRIPT = path.join(
+  REPO_ROOT,
+  "all/copy-overwrite/scripts/lisa-work-item.mjs"
+);
+const GATES_SCRIPT = path.join(
+  REPO_ROOT,
+  "all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs"
+);
+const ENTRY_GUARD_SCRIPT = path.join(
+  REPO_ROOT,
+  "all/copy-overwrite/scripts/lib/invoked-as-script.mjs"
+);
+
+const TRACEABILITY_TITLE = "Work-Item traceability";
+const CONFORMANCE_TITLE = "Conventional commit format";
+const COAUTHORSHIP_TITLE = "AI co-authorship";
+
+const WORK_ITEM_TRAILER = "Work-Item: acme/widgets#42";
+const CLAUDE_TRAILER = "Co-authored-by: Claude <noreply@anthropic.com>";
+const VALID_SUBJECT = "fix: clarify hook output";
+const PASSING_COMMITLINT_BIN = "exit 0\n";
+const FAILING_COMMITLINT_BIN = [
+  "printf '%s\\n' '✖   subject may not be empty [subject-empty]'",
+  "exit 1",
+].join("\n");
+
+let tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs) rmSync(dir, { force: true, recursive: true });
+  tempDirs = [];
+});
+
+describe("what the summary reads off a hook", () => {
+  const HOOK_SOURCE = readFileSync(HOOK_PATH, "utf8");
+
+  it("finds every family this repository's own hook runs", () => {
+    expect(detectFamilies([HOOK_SOURCE]).map(family => family.id)).toEqual([
+      "traceability",
+      "commit-conformance",
+      "ai-coauthorship",
+    ]);
+  });
+
+  it("names only the families a hook actually installs", () => {
+    // A hook that runs commitlint alone must not be described as running three
+    // gates. Naming a gate a project does not have is the failure mode that
+    // kept this out of the traceability checklist in the first place.
+    const detected = detectFamilies(['npx commitlint --edit "$1"']);
+
+    expect(detected.map(family => family.id)).toEqual(["commit-conformance"]);
+  });
+
+  it("does not mistake the co-authorship comment for the check", () => {
+    // The real hook carries a long comment naming the `Co-Authored-By:`
+    // trailer. Matching prose would report the gate as installed in a project
+    // that deleted the check and kept the note explaining it.
+    const commentOnly = [
+      "# The `Co-Authored-By:` trailer is always the last line, so it is",
+      "# always the part lost when the message is truncated.",
+    ].join("\n");
+
+    expect(detectFamilies([commentOnly])).toEqual([]);
+  });
+
+  it("says nothing at all when no family is installed", () => {
+    expect(summary([], null)).toBe("");
+  });
+
+  it("marks the family that refused, and only that one", () => {
+    const text = summary([...FAMILIES], "ai-coauthorship");
+    const marked = text
+      .split("\n")
+      .filter(line => line.includes("← refused this commit"));
+
+    expect(marked).toHaveLength(1);
+    expect(marked[0]).toContain(COAUTHORSHIP_TITLE);
+  });
+
+  it("counts in the singular when one family is installed", () => {
+    expect(summary([FAMILIES[0]], null)).toContain("1 gate family runs");
+  });
+});
+
+describe("every commit-msg refusal names every family installed", () => {
+  it("names all three when the traceability gate refuses", () => {
+    const project = createProject({
+      commitlintBody: PASSING_COMMITLINT_BIN,
+      message: `${VALID_SUBJECT}\n\n${CLAUDE_TRAILER}\n`,
+    });
+
+    const result = runHook(project);
+
+    expect(result.status).toBe(1);
+    expectAllThreeNamed(String(result.stdout));
+    expect(result.stdout).toContain("1. Work-Item traceability  ←");
+  });
+
+  it("names all three when commitlint refuses", () => {
+    const project = createProject({
+      commitlintBody: FAILING_COMMITLINT_BIN,
+      message: `${VALID_SUBJECT}\n\n${WORK_ITEM_TRAILER}\n${CLAUDE_TRAILER}\n`,
+    });
+
+    const result = runHook(project);
+
+    expect(result.status).toBe(1);
+    expectAllThreeNamed(String(result.stdout));
+    expect(result.stdout).toContain("2. Conventional commit format  ←");
+  });
+
+  it("names all three when the co-authorship gate refuses", () => {
+    // The measured case: every named requirement satisfied, refused anyway, by
+    // a family nothing had mentioned.
+    const project = createProject({
+      commitlintBody: PASSING_COMMITLINT_BIN,
+      message: `${VALID_SUBJECT}\n\n${WORK_ITEM_TRAILER}\n`,
+    });
+
+    const result = runHook(project);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("must include AI co-authorship");
+    expectAllThreeNamed(String(result.stdout));
+    expect(result.stdout).toContain("3. AI co-authorship  ←");
+  });
+
+  it("names all three when the OpenCode metadata gate refuses", () => {
+    const project = createProject({
+      commitlintBody: PASSING_COMMITLINT_BIN,
+      message: [
+        VALID_SUBJECT,
+        "",
+        WORK_ITEM_TRAILER,
+        "Co-authored-by: OpenCode <noreply@opencode.ai>",
+        "",
+      ].join("\n"),
+    });
+
+    const result = runHook(project);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("must include AI metadata trailers");
+    expectAllThreeNamed(String(result.stdout));
+  });
+
+  it("names only the two families a hook without co-authorship installs", () => {
+    // The second half of the contract: the summary must never name a gate the
+    // project does not have. Proved by deleting a family from a real hook and
+    // refusing on a different one.
+    const project = createProject({
+      commitlintBody: FAILING_COMMITLINT_BIN,
+      message: `${VALID_SUBJECT}\n\n${WORK_ITEM_TRAILER}\n${CLAUDE_TRAILER}\n`,
+    });
+    const stripped = installStrippedHook(project);
+
+    const result = runHook(project, stripped);
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("2 gate families run");
+    expect(result.stdout).toContain(TRACEABILITY_TITLE);
+    expect(result.stdout).toContain(CONFORMANCE_TITLE);
+    expect(result.stdout).not.toContain(COAUTHORSHIP_TITLE);
+  });
+
+  it("still accepts a commit that satisfies every family", () => {
+    // The control. A diagnostic that also turned refusals into passes would
+    // satisfy every assertion above.
+    const project = createProject({
+      commitlintBody: PASSING_COMMITLINT_BIN,
+      message: `${VALID_SUBJECT}\n\n${WORK_ITEM_TRAILER}\n${CLAUDE_TRAILER}\n`,
+    });
+
+    const result = runHook(project);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).not.toContain("gate families run");
+  });
+});
+
+describe("every tracked commit-msg hook introduces what it installs", () => {
+  // Derived, never listed. A hardcoded roster is how a third copy of a hook
+  // drifts for six commits with every parity test green.
+  const HOOKS = execFileSync(
+    GIT,
+    ["ls-files", "*.husky/commit-msg", ".husky/commit-msg"],
+    { cwd: REPO_ROOT, encoding: "utf8" }
+  )
+    .split("\n")
+    .filter(line => line.length > 0);
+
+  it("finds hooks to check at all", () => {
+    expect(HOOKS.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it.each(HOOKS)("%s calls the summary for every family it runs", hook => {
+    const source = readFileSync(path.join(REPO_ROOT, hook), "utf8");
+
+    for (const family of detectFamilies([source])) {
+      expect(source).toContain(`lisa_commit_gate_families ${family.id}`);
+    }
+  });
+});
+
+/**
+ * Assert the three families this repository installs are all named.
+ * @param stdout - Hook output.
+ */
+function expectAllThreeNamed(stdout: string): void {
+  expect(stdout).toContain("3 gate families run");
+  expect(stdout).toContain(TRACEABILITY_TITLE);
+  expect(stdout).toContain(CONFORMANCE_TITLE);
+  expect(stdout).toContain(COAUTHORSHIP_TITLE);
+}
+
+/** How to build a temporary project the real hook can run inside. */
+type ProjectOptions = {
+  readonly commitlintBody: string;
+  readonly message: string;
+};
+
+/**
+ * Create a temporary git project the real commit-msg hook can run against.
+ * @param options - Commit message and commitlint behaviour.
+ * @returns The temporary project directory.
+ */
+function createProject(options: ProjectOptions): string {
+  const project = mkdtempSync(path.join(tmpdir(), "lisa-gate-families-"));
+  const gitEnv = cleanGitEnv(process.env);
+  tempDirs.push(project);
+  mkdirSync(path.join(project, "node_modules", ".bin"), { recursive: true });
+  mkdirSync(path.join(project, "scripts/lib"), { recursive: true });
+  writeFileSync(path.join(project, "package-lock.json"), "{}\n");
+  writeFileSync(
+    path.join(project, ".lisa.config.json"),
+    '{"tracker":"github","github":{"org":"acme","repo":"widgets"}}\n'
+  );
+  writeFileSync(path.join(project, "COMMIT_EDITMSG"), options.message);
+  copyFileSync(
+    TRACKER_SCRIPT,
+    path.join(project, "scripts/lisa-work-item.mjs")
+  );
+  copyFileSync(
+    GATES_SCRIPT,
+    path.join(project, "scripts/lisa-commit-msg-gates.mjs")
+  );
+  copyFileSync(
+    ENTRY_GUARD_SCRIPT,
+    path.join(project, "scripts/lib/invoked-as-script.mjs")
+  );
+  writeBin(project, "npx", options.commitlintBody);
+  writeBin(
+    project,
+    "gh",
+    `if [ "\${1:-} \${2:-}" = "api graphql" ]; then
+  printf '%s\\n' '{"data":{"repository":{"issue":{"subIssues":{"nodes":[]}}}}}'
+else
+  printf '%s\\n' '{"number":42,"url":"https://github.com/acme/widgets/issues/42","state":"OPEN","labels":[{"name":"status:in-progress"},{"name":"type:Task"}],"comments":[],"closedByPullRequestsReferences":[]}'
+fi\n`
+  );
+  spawnSync(GIT, ["init"], { cwd: project, encoding: "utf8", env: gitEnv });
+  spawnSync(GIT, ["checkout", "-b", "codex/issue-1264"], {
+    cwd: project,
+    encoding: "utf8",
+    env: gitEnv,
+  });
+  return project;
+}
+
+/**
+ * Install a copy of the real hook with the co-authorship family removed.
+ *
+ * Cut at the block's own opening comment and closed with an explicit success,
+ * so what remains is a hook that genuinely runs two families rather than a
+ * hook with a disabled third.
+ * @param project - Temporary project directory.
+ * @returns Path to the stripped hook.
+ */
+function installStrippedHook(project: string): string {
+  const source = readFileSync(HOOK_PATH, "utf8");
+  const marker = "# Check for Co-Authored-By line";
+  const cut = source.indexOf(marker);
+  if (cut < 0) throw new Error(`${HOOK_PATH} no longer has ${marker}`);
+  const hookPath = path.join(project, ".husky", "commit-msg");
+  mkdirSync(path.dirname(hookPath), { recursive: true });
+  writeFileSync(hookPath, `${source.slice(0, cut)}exit 0\n`);
+  return hookPath;
+}
+
+/**
+ * Run a commit-msg hook against the temp project's commit message.
+ * @param project - Temporary project directory.
+ * @param hook - Hook to run; the repository's own by default.
+ * @returns The completed hook process.
+ */
+function runHook(
+  project: string,
+  hook: string = HOOK_PATH
+): ReturnType<typeof spawnSync> {
+  return spawnSync(BASH, [hook, "COMMIT_EDITMSG"], {
+    cwd: project,
+    encoding: "utf8",
+    env: cleanGitEnv(process.env, {
+      PATH: `${path.join(project, "node_modules", ".bin")}:${process.env.PATH}`,
+    }),
+  });
+}
+
+/**
+ * Write an executable fake binary into the temp project's local bin directory.
+ * @param project - Temporary project directory.
+ * @param name - Binary filename.
+ * @param body - Shell body to execute after the shebang.
+ */
+function writeBin(project: string, name: string, body: string): void {
+  const binPath = path.join(project, "node_modules", ".bin", name);
+  writeFileSync(binPath, `#!/usr/bin/env bash\n${body}`);
+  chmodSync(binPath, 0o755);
+}

--- a/typescript/copy-contents/.husky/commit-msg
+++ b/typescript/copy-contents/.husky/commit-msg
@@ -27,11 +27,36 @@ fi
 if [ ! -f "$WORK_ITEM_SCRIPT" ]; then
   WORK_ITEM_SCRIPT="all/copy-overwrite/scripts/lisa-work-item.mjs"
 fi
+
+# Several INDEPENDENT gate families bite at this one moment, and each of the
+# checks below knows only its own. Whichever refuses first, the operator is told
+# about ALL of them here — otherwise satisfying every requirement the refusal
+# names still says nothing about whether the commit will be accepted, which is
+# exactly the property those checklists exist to provide. Owned by neither
+# check, because neither can know what the other installs.
+GATE_FAMILIES_SCRIPT="node_modules/@codyswann/lisa/all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs"
+if [ ! -f "$GATE_FAMILIES_SCRIPT" ]; then
+  GATE_FAMILIES_SCRIPT="scripts/lisa-commit-msg-gates.mjs"
+fi
+if [ ! -f "$GATE_FAMILIES_SCRIPT" ]; then
+  GATE_FAMILIES_SCRIPT="all/copy-overwrite/scripts/lisa-commit-msg-gates.mjs"
+fi
+
+# Never the reason a commit fails: the caller has already decided to refuse.
+lisa_commit_gate_families() {
+  [ -f "$GATE_FAMILIES_SCRIPT" ] || return 0
+  command -v node >/dev/null 2>&1 || return 0
+  node "$GATE_FAMILIES_SCRIPT" list --hook "$0" --refused "$1" 2>/dev/null || true
+}
+
 if ! command -v node >/dev/null 2>&1; then
   echo "❌ Commit blocked: Node.js is required to validate tracker work items."
   exit 1
 fi
-node "$WORK_ITEM_SCRIPT" validate-commit "$COMMIT_MSG_FILE" || exit 1
+if ! node "$WORK_ITEM_SCRIPT" validate-commit "$COMMIT_MSG_FILE"; then
+  lisa_commit_gate_families traceability
+  exit 1
+fi
 
 echo "📝 Validating commit message with commitlint..."
 $EXECUTOR commitlint --edit $1
@@ -52,6 +77,7 @@ if [ $? -ne 0 ]; then
   echo "Format: <type>(<optional scope>): <subject>"
   echo ""
   echo "For more info, see: https://www.conventionalcommits.org/"
+  lisa_commit_gate_families commit-conformance
   exit 1
 fi
 
@@ -91,6 +117,7 @@ if ! printf '%s\n' "$COMMIT_MSG" | grep -Eiq "Co-authored-by:.*(Claude|Codex)"; 
   echo "If you're using Claude Code, use the /git:commit command"
   echo "If you're using Codex, enable commit_attribution in .codex/config.toml"
   echo ""
+  lisa_commit_gate_families ai-coauthorship
   exit 1
 fi
 

--- a/typescript/copy-overwrite/.prettierignore
+++ b/typescript/copy-overwrite/.prettierignore
@@ -72,6 +72,7 @@ scripts/check-threshold-ratchet.mjs
 scripts/check-verification-coverage.mjs
 scripts/classify-maestro-failures.mjs
 scripts/lisa-command-envelope.mjs
+scripts/lisa-commit-msg-gates.mjs
 scripts/lisa-destructive-guard.mjs
 scripts/lisa-environment-prepare.mjs
 scripts/lisa-floor-collisions.mjs


### PR DESCRIPTION
## The defect

Several **independent** gate families bite at the `commit-msg` moment, and only one of them introduced itself.

`lisa-work-item.mjs` prints a five-gate checklist on any traceability refusal. At the same moment the hook also runs commitlint and an AI co-authorship trailer check, and neither said so until it fired. An operator could satisfy every requirement the checklist named and still be refused — which is exactly the property that checklist was built to provide. Measured twice in one day, by two sessions working opposite sides of the same change.

## The fix

A third file, `lisa-commit-msg-gates.mjs`, owned by neither check. It answers one question — what runs at `commit-msg` in **this** project — and every refusal path in every tracked `commit-msg` hook calls it.

```
──────────────────────────────────────────────────────────────
3 gate families run at the commit-msg moment in this project, and a
commit must satisfy every one of them. The first refusal stops the
commit, so clearing this one proves nothing about the others.

  1. Work-Item traceability
     Every commit message carries one matching `Work-Item:` trailer for a
     live tracker item. Its own refusal prints the full five-gate
     checklist.
  2. Conventional commit format
     The subject reads `<type>(<optional scope>): <subject>`, and the
     body obeys the project's commitlint rules.
  3. AI co-authorship  ← refused this commit
     The message carries a `Co-authored-by:` trailer naming a supported
     coding agent — Claude, Codex, or OpenCode. OpenCode also needs
     `AI-Agent`, `AI-Model` and `AI-Effort` trailers.

Read off what this project's commit-msg hook actually runs, so a
family it does not install is never named here.
──────────────────────────────────────────────────────────────
```

That block is real output, from a deliberately trailer-less commit of this very branch.

## Two decisions worth recording

**Why not a sixth line in `gateSummary`.** The issue rules this out and the reasoning holds: `gateSummary` lives in `lisa-work-item.mjs`, which does not own the co-authorship check, cannot verify it, and cannot know whether a host installs it. A checklist that confidently names a gate a project does not have is worse than one that stays silent. And a list headed "All five gates" carrying six entries is the counting defect that list exists to remove.

**Why the families are read off the hook rather than declared.** Detection matches the *enforcing invocation* — `validate-commit`, `commitlint --edit`, the co-authorship `grep` — never prose. The real hook carries a long comment naming the trailer it checks for; matching that would report the gate as installed in a project that deleted the check and kept the note. A declared marker comment was the first design and fails the case that matters: an installed hook predating the marker declares nothing, and a deleted block can leave its declaration behind. Detecting the call degrades correctly in both directions.

Every candidate hook path is read and the results unioned, because "the commit-msg hook" is not one path — husky 8 points git at `.husky/commit-msg`, husky 9 interposes `.husky/_/commit-msg`, and a project using neither has `.git/hooks/commit-msg`.

The summary always exits 0 and swallows its own errors. It runs only on a refusal that has already decided to fail; it must never be the reason a commit is refused, nor turn a clear refusal into a stack trace.

## Acceptance criteria

> **Then** the refusal names every commit-msg gate family the project installs

Covered by four end-to-end tests through the real hook — one per refusal path, including the OpenCode-metadata path.

> **And** it names only gates that project actually installs

Covered by running a copy of the real hook with the co-authorship block deleted and refusing on a different family: the summary reports two, and never mentions the third.

## Verified by mutation, not by passing

Each mutation was applied to the shipped code and the named tests confirmed to die with it:

| mutation | tests that died |
|---|---|
| remove every `lisa_commit_gate_families` call (the pre-fix state) | 6 |
| remove only the co-authorship call (the exact reported defect) | 3 |
| detector stops filtering — every project told it has all three | 4 |
| co-authorship detected from prose instead of the invocation | 1 |

The roster test derives its list from `git ls-files` rather than hardcoding it — a hardcoded two-copy roster is how a third copy of a hook drifts with every parity test green. Under the third mutation it was the third copy that failed.

There is also a control asserting a fully valid commit still passes and prints no summary: a diagnostic that turned refusals into passes would satisfy every other assertion here.

## Scope

Out of scope, per the issue: the five traceability gates themselves, and whether the co-authorship requirement should exist at all.

Noted but not changed: no registry gate in `.lisa.config.json` governs the co-authorship family — `traceability` and `commit-conformance` have registry ids, that one has none. Recorded in the module rather than papered over with an invented name.

Work-Item: CodySwannGT/lisa#2840
