### PR TITLE
fix(gates): name the input that staled the manifest, not the manifest

### DIFF
--- a/.agents/rules/regenerating-derived-artifacts.md
+++ b/.agents/rules/regenerating-derived-artifacts.md
@@ -1,0 +1,77 @@
+# Regenerating the two derived artifacts
+
+**Stage first, regenerate second, stage again.** Both of Lisa's generated
+artifacts read the git INDEX, not your editor, so a regeneration that runs
+before `git add` records the file set you had a moment ago.
+
+```sh
+git add <the real changes>
+bun run build:lisa-owned-hash-ledger
+bun run build:upstream-evidence-manifest
+git add src/core/lisa-owned-hash-ledger.ts src/core/upstream-evidence-manifest.ts
+bun run check:artifacts
+```
+
+The two artifacts are:
+
+- `src/core/lisa-owned-hash-ledger.ts` — every content hash Lisa has ever
+  shipped at a Lisa-owned destination, built by
+  `scripts/generate-lisa-owned-hash-ledger.mjs`.
+- `src/core/upstream-evidence-manifest.ts` — the hash-pinned allowlist of public
+  upstream evidence, built by
+  `scripts/generate-upstream-evidence-manifest.mjs`.
+
+`bun run check:artifacts` runs both `--check`s. The same pair runs at commit
+time from `.husky/pre-commit` via `scripts/check-derived-artifacts.mjs`.
+
+## The trap: a check that passes by hand and fails at commit
+
+`lint-staged` runs `oxlint --fix`, `eslint --fix` and `prettier --write` over
+**every staged file** at commit time, and the artifact gate deliberately runs
+*after* it — a gate placed before the reformat would vouch for bytes that no
+longer exist. So a manifest you generated, verified by hand, and staged can be
+stale by the time it is checked, through no fault of yours: the reformat moved
+an input underneath it.
+
+The recovery is always the same, and it terminates: regenerate **now**, after
+the reformat, `git add`, and commit again. It converges because the second
+reformat is a no-op on already-formatted bytes.
+
+## Order between the two: it does not matter
+
+Folklore says ledger-before-manifest because "the manifest hashes the ledger".
+**Measured, the manifest does not hash the ledger.**
+`src/core/lisa-owned-hash-ledger.ts` sits outside
+every packaged-evidence prefix, so the manifest records its *path* and never its
+*bytes*; changing the ledger's contents leaves the manifest's `--check` passing.
+
+What actually couples them is a shared **input**. A `copy-overwrite` template is
+hashed by both, so editing one template stales both artifacts at once and each
+must be regenerated — in either order. Any other file stales at most one of
+them.
+
+Do not write the ordering claim back in. It sends whoever believes it to
+regenerate the wrong file, which is the exact cost that produced this rule.
+
+## A stale-manifest refusal tells you what moved
+
+Since CodySwannGT/lisa#2852 the manifest's refusal names the cause rather than
+only the file, and each cause has a different fix:
+
+- **an input's bytes moved** — usually the lint-staged reformat above.
+  Regenerate now.
+- **the tracked file set moved** — you staged or `git rm`'d something after
+  regenerating. Stage first, then regenerate.
+- **no input moved at all** — the generated file itself was rewritten after
+  generation, by a hand edit or a formatter. It is generated; do not edit it.
+
+When the listed files include a `copy-overwrite` template, the refusal also
+tells you to regenerate the ledger, because that template's bytes are recorded
+in both.
+
+## Why regenerating twice can be right
+
+Both generators read the **working tree**, on purpose: an author who edits a
+guard and regenerates gets *their* new hash recorded, rather than the pre-edit
+bytes from `HEAD`. That is what makes a second regeneration after a reformat the
+correct move rather than a workaround.

--- a/scripts/check-derived-artifacts.mjs
+++ b/scripts/check-derived-artifacts.mjs
@@ -32,6 +32,12 @@
  *   `main` in (CodySwannGT/lisa#2556), and at this repository's concurrency that
  *   would mean every merge reddens every open PR. Do not tighten it back.
  *
+ * The regeneration procedure this gate demands — stage, regenerate, stage again,
+ * and regenerate a second time after `lint-staged` reformats — is written down
+ * in `.agents/rules/regenerating-derived-artifacts.md`. It also records what is
+ * NOT true: the manifest does not hash the ledger, so there is no required order
+ * between the two, and a stale manifest is not evidence of a stale ledger.
+ *
  * Both triggers below are deliberate **supersets** of what each artifact covers.
  * Re-deriving exact membership here would create a second copy of the rule that
  * could drift and silently stop firing; over-triggering only costs a few seconds
@@ -135,6 +141,13 @@ export function stagedPaths() {
  * message. The frames are noise to the person being blocked — and this gate is
  * read by operators who did not write either generator — so keep the lines that
  * say what is wrong and drop the ones that say where the throw was.
+ *
+ * Blank lines INSIDE the message are kept. They used to be dropped along with
+ * the ones bracketing the stack, which was invisible while the manifest's
+ * refusal was a single sentence and is not now: since CodySwannGT/lisa#2852 it
+ * is several paragraphs — what moved, why it usually moves, the command that
+ * clears it — and squeezing the blanks out runs them into one block that reads
+ * as noise. Trimming the ends removes the bracketing blanks on its own.
  * @param {string} raw - Combined stdout and stderr from the generator
  * @returns {string} Message lines, stack frames removed
  */
@@ -148,7 +161,6 @@ export function readableFailure(raw) {
     .filter(line => !/^\s+at\s/u.test(line))
     .filter(line => !line.startsWith("Node.js v"))
     .map(line => line.replace(/^Error:\s*/u, "").trimEnd())
-    .filter(Boolean)
     .join("\n")
     .trim();
 }
@@ -225,10 +237,16 @@ function main() {
     `\nA generated artifact no longer matches the sources in this commit:\n\n${failures.join(
       "\n\n"
     )}\n\n` +
-      `Both artifacts are regenerated from the working tree, so run the command\n` +
-      `above AFTER staging, and again after any reformat, then amend.\n` +
+      `The order is: git add the real changes, THEN regenerate, THEN git add the\n` +
+      `regenerated file. Both generators read the git index and the working tree,\n` +
+      `so regenerating before staging records the file set you had a moment ago.\n\n` +
+      `Passing by hand and failing here is expected, not a puzzle: lint-staged\n` +
+      `reformats every staged file just above, and this gate runs after it on\n` +
+      `purpose. Regenerate again now — the second pass converges, because\n` +
+      `reformatting already-formatted bytes changes nothing.\n\n` +
       `If the stale file is one you did not touch, an unstaged local edit to a\n` +
-      `tracked file can also trip this — commit or revert it first.\n`
+      `tracked file can also trip this — commit or revert it first.\n\n` +
+      `Full procedure: .agents/rules/regenerating-derived-artifacts.md\n`
   );
   process.exit(1);
 }

--- a/scripts/generate-upstream-evidence-manifest.mjs
+++ b/scripts/generate-upstream-evidence-manifest.mjs
@@ -5,6 +5,11 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
+import {
+  describeStaleManifest,
+  diagnoseStaleManifest,
+} from "./lib/upstream-manifest-staleness.mjs";
+
 const repoRoot = path.resolve(import.meta.dirname, "..");
 const outputPath = path.join(
   repoRoot,
@@ -188,8 +193,12 @@ ${commitEntries.join("\n")}
 if (process.argv.includes("--check")) {
   const current = readFileSync(outputPath, "utf8");
   if (current !== output) {
+    // Not just "this file is out of date" — WHICH input moved, and the recovery
+    // for that particular way of moving. Naming only the file that is stale
+    // points at regenerating it, which is the fix for one of three causes and a
+    // loop for the other two. See scripts/lib/upstream-manifest-staleness.mjs.
     throw new Error(
-      "src/core/upstream-evidence-manifest.ts is stale; run bun run build:upstream-evidence-manifest"
+      describeStaleManifest(diagnoseStaleManifest(current, output))
     );
   }
 } else {

--- a/scripts/lib/upstream-manifest-staleness.mjs
+++ b/scripts/lib/upstream-manifest-staleness.mjs
@@ -1,0 +1,235 @@
+/**
+ * upstream-manifest-staleness — turn "the manifest is out of date" into "here is
+ * what moved underneath it".
+ *
+ * @remarks
+ * `src/core/upstream-evidence-manifest.ts` is derived from two things: the set
+ * of TRACKED files (`git ls-files`, so the git index), and the working-tree
+ * bytes of every tracked file under a packaged-evidence prefix. Its `--check`
+ * regenerates and compares byte-for-byte, so it can say *that* the file is out
+ * of date, and until CodySwannGT/lisa#2852 that is all it said:
+ *
+ * ```
+ * src/core/upstream-evidence-manifest.ts is stale; run bun run build:upstream-evidence-manifest
+ * ```
+ *
+ * The refusal is accurate and points away from the cause. It names the file
+ * that is out of date, so the obvious response is to regenerate that file — and
+ * when the cause is an input that moves again afterwards, regenerating
+ * reproduces the identical refusal. That is a loop with no exit signposted from
+ * inside it, and it cost a full cycle.
+ *
+ * There are exactly two ways an input can move, and they need opposite fixes:
+ *
+ * - **The bytes of a hash-pinned file changed.** Overwhelmingly this is
+ *   `lint-staged`, which runs `oxlint --fix`, `eslint --fix` and
+ *   `prettier --write` over every staged file at commit time — *after* the
+ *   author regenerated, and *before* the artifact gate runs. The fix is to
+ *   regenerate again now, after the reformat.
+ * - **The tracked set changed.** A file staged (or `git rm`'d) after the
+ *   manifest was generated is a membership change, and regenerating before the
+ *   next `git add` will produce the same wrong answer. The fix is to stage
+ *   first and regenerate second.
+ *
+ * A third outcome is possible and worth naming: no input moved at all, which
+ * means the generated file itself was rewritten after generation — a hand edit,
+ * or a formatter reaching the artifact.
+ *
+ * ## What this module deliberately does not claim
+ *
+ * The obvious story — "the manifest hashes the ledger, so a stale manifest means
+ * a stale ledger" — is false, and was measured false while fixing #2852:
+ * `src/core/lisa-owned-hash-ledger.ts` lives outside every packaged-evidence
+ * prefix, so the manifest records its PATH and never its bytes. Mutating the
+ * ledger's contents leaves the manifest check passing. The two artifacts are
+ * independent in content; what couples them is a shared INPUT. Editing a
+ * `copy-overwrite` template moves bytes both of them record, so both go stale
+ * together — which is why the message below sends a template change to
+ * regenerate the ledger too, and says nothing of the sort for any other path.
+ *
+ * @module scripts/lib/upstream-manifest-staleness
+ */
+
+/** Marker identifying a template whose bytes the Lisa-owned hash ledger records. */
+const COPY_OVERWRITE = "/copy-overwrite/";
+
+/** Longest list of paths a refusal prints before summarizing the remainder. */
+const MAX_LISTED_PATHS = 10;
+
+/**
+ * @typedef {object} ManifestInputs
+ * @property {Map<string, string>} evidence - Hash-pinned path to sha256 digest.
+ * @property {Set<string>} surface - Every tracked path recorded at generation.
+ */
+
+/**
+ * @typedef {object} ManifestDiagnosis
+ * @property {string[]} changed - Pinned paths whose recorded digest no longer matches.
+ * @property {string[]} added - Paths present now and absent when the file was generated.
+ * @property {string[]} removed - Paths recorded then and absent now.
+ */
+
+/**
+ * The body of one `Object.freeze({ … })` block in the generated module.
+ *
+ * Sliced by export name rather than matched with one regex over the whole file,
+ * because the public-commit block renders `<sha>: true,` — the same shape as a
+ * tracked-surface entry. A single sweep reads 40-character SHAs as file paths
+ * and then reports thousands of phantom removals.
+ * @param {string} source - Generated module source.
+ * @param {string} exportName - Name of the exported constant to slice.
+ * @returns {string} The block body, or an empty string when it is absent.
+ */
+function blockFor(source, exportName) {
+  const start = source.indexOf(`export const ${exportName}`);
+  if (start === -1) return "";
+  const open = source.indexOf("Object.freeze({", start);
+  if (open === -1) return "";
+  const close = source.indexOf("\n  });", open);
+  if (close === -1) return "";
+  return source.slice(open, close);
+}
+
+/**
+ * The inputs a generated manifest says it was built from.
+ * @param {string} source - Contents of `src/core/upstream-evidence-manifest.ts`.
+ * @returns {ManifestInputs} Recorded evidence digests and tracked-surface paths.
+ */
+export function parseManifestInputs(source) {
+  const evidence = new Map();
+  for (const match of blockFor(source, "UPSTREAM_EVIDENCE_MANIFEST").matchAll(
+    /^ {4}"([^"]+)":\n {6}"([a-f0-9]{64})",$/gmu
+  )) {
+    evidence.set(match[1], match[2]);
+  }
+
+  const surface = new Set();
+  for (const match of blockFor(source, "UPSTREAM_SURFACE_MANIFEST").matchAll(
+    /^ {4}(?:"([^"]+)"|([A-Za-z_$][A-Za-z0-9_$]*)): true,$/gmu
+  )) {
+    surface.add(match[1] ?? match[2]);
+  }
+
+  return { evidence, surface };
+}
+
+/**
+ * What moved between the checked-in manifest and a fresh regeneration.
+ *
+ * Direction matters: `current` is what is on disk and `fresh` is the truth, so
+ * a path in `fresh` alone was staged after generation and a path in `current`
+ * alone was removed after it.
+ * @param {string} current - The manifest as it exists on disk.
+ * @param {string} fresh - The manifest as it would be generated right now.
+ * @returns {ManifestDiagnosis} Inputs that changed, were added, or were removed.
+ */
+export function diagnoseStaleManifest(current, fresh) {
+  const before = parseManifestInputs(current);
+  const after = parseManifestInputs(fresh);
+
+  const changed = [...after.evidence.entries()]
+    .filter(
+      ([file, digest]) =>
+        before.evidence.has(file) && before.evidence.get(file) !== digest
+    )
+    .map(([file]) => file)
+    .sort();
+  const added = [...after.surface]
+    .filter(file => !before.surface.has(file))
+    .sort();
+  const removed = [...before.surface]
+    .filter(file => !after.surface.has(file))
+    .sort();
+
+  return { changed, added, removed };
+}
+
+/**
+ * Render at most `MAX_LISTED_PATHS` paths, then say how many were withheld.
+ * @param {readonly string[]} paths - Paths to render, already sorted.
+ * @returns {string} Indented lines, one path each.
+ */
+function listPaths(paths) {
+  const shown = paths
+    .slice(0, MAX_LISTED_PATHS)
+    .map(file => `    ${file}`)
+    .join("\n");
+  const withheld = paths.length - MAX_LISTED_PATHS;
+  return withheld > 0 ? `${shown}\n    …and ${withheld} more` : shown;
+}
+
+/**
+ * The operator-facing refusal for a stale manifest.
+ *
+ * Written for whoever is standing at the gate, which is not necessarily whoever
+ * wrote the generator: it names the input that moved, why it usually moves, and
+ * the command that clears it.
+ * @param {ManifestDiagnosis} diagnosis - Output of {@link diagnoseStaleManifest}.
+ * @returns {string} Multi-line refusal text.
+ */
+export function describeStaleManifest(diagnosis) {
+  const sections = ["src/core/upstream-evidence-manifest.ts is stale."];
+
+  if (diagnosis.changed.length > 0) {
+    sections.push(
+      "  Its inputs moved after it was generated. These files no longer have\n" +
+        "  the bytes it recorded:\n" +
+        `${listPaths(diagnosis.changed)}\n` +
+        "  At commit time lint-staged reformats every staged file BEFORE this\n" +
+        "  check runs, so a manifest generated first is stale by the time it is\n" +
+        "  checked. Regenerate now, after the reformat."
+    );
+  }
+
+  if (diagnosis.added.length > 0 || diagnosis.removed.length > 0) {
+    const movements = [];
+    if (diagnosis.added.length > 0) {
+      movements.push(
+        `  Staged since it was generated:\n${listPaths(diagnosis.added)}`
+      );
+    }
+    if (diagnosis.removed.length > 0) {
+      movements.push(
+        `  Removed since it was generated:\n${listPaths(diagnosis.removed)}`
+      );
+    }
+    sections.push(
+      "  The tracked file set moved after it was generated.\n" +
+        `${movements.join("\n")}\n` +
+        "  The manifest reads TRACKED files, so `git add` (or `git rm`) first and\n" +
+        "  regenerate second — the other order records the pre-change file set."
+    );
+  }
+
+  if (
+    diagnosis.changed.length === 0 &&
+    diagnosis.added.length === 0 &&
+    diagnosis.removed.length === 0
+  ) {
+    sections.push(
+      "  None of its inputs moved — only the generated file's own bytes differ,\n" +
+        "  so something rewrote it after generation: a hand edit, or a formatter\n" +
+        "  reaching the artifact. It is generated; do not edit it by hand."
+    );
+  }
+
+  sections.push(
+    "  Fix: bun run build:upstream-evidence-manifest\n" +
+      "  Then: git add src/core/upstream-evidence-manifest.ts"
+  );
+
+  if (
+    [...diagnosis.changed, ...diagnosis.added, ...diagnosis.removed].some(
+      file => file.includes(COPY_OVERWRITE)
+    )
+  ) {
+    sections.push(
+      "  A copy-overwrite template is among the files above, so the Lisa-owned\n" +
+        "  hash ledger records those same bytes and is stale for the same reason.\n" +
+        "  Regenerate it in this commit too, or its own check fails next:\n" +
+        "  bun run build:lisa-owned-hash-ledger"
+    );
+  }
+
+  return sections.join("\n\n");
+}

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -2135,7 +2135,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/check-delivery-deletion-conflicts.mjs":
       "e7fe0064ad82a4dba17436657630a46891568a3d18930eb172fe9ee3f54196aa",
     "scripts/check-derived-artifacts.mjs":
-      "62c895baffad41c25fa919b798a53e2e969163897bcbb09b0e26345c61f61320",
+      "86cca46aa7f055ae149b5a378d56d2c4e5dbbbe48e020b79883e21cae50c5956",
     "scripts/check-duplicate-versions.mjs":
       "26b26351dd2735dfd8d9a2436b89e876ce2ed93871d0b264f611215dd03d70ae",
     "scripts/check-learnings-budget.ts":
@@ -2187,7 +2187,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "scripts/generate-lisa-owned-hash-ledger.mjs":
       "4e7a6dd9325fff77faec49c1dcbf8a8cfeb987052eeed89885deb4f7b0a107bc",
     "scripts/generate-upstream-evidence-manifest.mjs":
-      "005ff3ef61e63aab9ed466a3e545df5e8f46e369fdcff94b6e7723161148bc82",
+      "a33bd0ee344782a9b2f400f5adfeecd9e7e201b61b073a9e85cc69311b8721e0",
     "scripts/github-status-check.sh":
       "c6a4a13ff5cf689fcbd7a6aca718f9e7d46d54ccb6687f662b055c1ca20e792f",
     "scripts/install-claude-plugins.sh":
@@ -2214,6 +2214,8 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
       "791f01b55dd7a6b5d9a5f4cb9c44167caa146c2fc3c31a2ae4c2d8a350adc2f1",
     "scripts/lib/reusable-workflow-contract.mjs":
       "134ee2a327290f066f1eb318b5ed53c711557c3e10ed462c00ff5c97cfb20863",
+    "scripts/lib/upstream-manifest-staleness.mjs":
+      "c69fc5ba10228b7f4f8d0068db27ee8a289143094fa8718b14af83f4af31f76d",
     "scripts/lisa-assert-eas-profile.mjs":
       "624e40d7f33ca17208fc6b7a19320a785cff19da5d2ff8062b67a432b2a34022",
     "scripts/lisa-commit-and-pr-local.sh":
@@ -2416,6 +2418,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
 export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
   Object.freeze({
     ".agents/rules/never-name-downstream-projects.md": true,
+    ".agents/rules/regenerating-derived-artifacts.md": true,
     ".agents/skills/claude-code-action/SKILL.md": true,
     ".agents/skills/claude-code-action/references/inputs.md": true,
     ".agents/skills/harness-parity-council/SKILL.md": true,
@@ -8272,6 +8275,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "scripts/lib/per-agent-hook-filter.mjs": true,
     "scripts/lib/reusable-workflow-contract.d.mts": true,
     "scripts/lib/reusable-workflow-contract.mjs": true,
+    "scripts/lib/upstream-manifest-staleness.mjs": true,
     "scripts/lisa-assert-eas-profile.mjs": true,
     "scripts/lisa-commit-and-pr-local.sh": true,
     "scripts/lisa-enforcement-fallback.sh": true,
@@ -9290,6 +9294,7 @@ export const UPSTREAM_SURFACE_MANIFEST: Readonly<Record<string, true>> =
     "tests/unit/scripts/threshold-ratchet-wiring.test.ts": true,
     "tests/unit/scripts/threshold-ratchet.test.ts": true,
     "tests/unit/scripts/upstream-evidence-manifest.test.ts": true,
+    "tests/unit/scripts/upstream-manifest-staleness.test.ts": true,
     "tests/unit/scripts/vacuous-required-checks.test.ts": true,
     "tests/unit/scripts/verification-coverage.test.ts": true,
     "tests/unit/scripts/work-item-backlink-exactness.test.ts": true,

--- a/tests/unit/scripts/derived-artifact-staleness.test.ts
+++ b/tests/unit/scripts/derived-artifact-staleness.test.ts
@@ -29,6 +29,8 @@ const LEDGER_COMMAND = "bun run build:lisa-owned-hash-ledger";
 const MANIFEST_COMMAND = "bun run build:upstream-evidence-manifest";
 const LISA_OWNED_SOURCE =
   "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh";
+const PACKAGED_EVIDENCE_SOURCE = "scripts/build-plugins.sh";
+const GATE_SCRIPT = "scripts/check-derived-artifacts.mjs";
 
 describe("derived-artifact staleness gate: which checks a commit owes", () => {
   it("owes the ledger check when it stages a copy-overwrite source", () => {
@@ -60,7 +62,7 @@ describe("derived-artifact staleness gate: which checks a commit owes", () => {
   });
 
   it("owes the manifest check when it stages a packaged evidence source", () => {
-    expect(requiresManifestCheck(["scripts/build-plugins.sh"])).toBe(true);
+    expect(requiresManifestCheck([PACKAGED_EVIDENCE_SOURCE])).toBe(true);
     expect(
       requiresManifestCheck(["typescript/copy-contents/.husky/pre-commit"])
     ).toBe(true);
@@ -81,22 +83,47 @@ describe("derived-artifact staleness gate: readable failure output", () => {
   // The person blocked by this gate did not write either generator, and Lisa's
   // gates are read by non-technical operators. A Node stack trace tells them
   // where the throw was, which is never the thing they need.
+  // Shaped like what the manifest generator actually throws since #2852: a
+  // multi-paragraph refusal naming the input that moved, not one sentence.
   const thrown = [
-    "file:///repo/scripts/generate-upstream-evidence-manifest.mjs:190",
-    "    throw new Error(",
+    "file:///repo/scripts/generate-upstream-evidence-manifest.mjs:200",
+    "    throw new Error(describeStaleManifest(",
     "          ^",
     "",
-    "Error: src/core/upstream-evidence-manifest.ts is stale; run bun run build:upstream-evidence-manifest",
-    "    at file:///repo/scripts/generate-upstream-evidence-manifest.mjs:190:11",
+    "Error: src/core/upstream-evidence-manifest.ts is stale.",
+    "",
+    "  Its inputs moved after it was generated. These files no longer have",
+    "  the bytes it recorded:",
+    `    ${PACKAGED_EVIDENCE_SOURCE}`,
+    "",
+    "  Fix: bun run build:upstream-evidence-manifest",
+    "    at file:///repo/scripts/generate-upstream-evidence-manifest.mjs:200:11",
     "    at ModuleJob.run (node:internal/modules/esm/module_job:343:25)",
     "",
     "Node.js v22.22.0",
   ].join("\n");
 
-  it("keeps the sentence that says what is wrong", () => {
+  it("keeps every line that says what is wrong", () => {
     expect(readableFailure(thrown)).toBe(
-      "src/core/upstream-evidence-manifest.ts is stale; run bun run build:upstream-evidence-manifest"
+      [
+        "src/core/upstream-evidence-manifest.ts is stale.",
+        "",
+        "  Its inputs moved after it was generated. These files no longer have",
+        "  the bytes it recorded:",
+        `    ${PACKAGED_EVIDENCE_SOURCE}`,
+        "",
+        "  Fix: bun run build:upstream-evidence-manifest",
+      ].join("\n")
     );
+  });
+
+  it("keeps the blank lines that separate the refusal's paragraphs", () => {
+    // Dropping every empty line strips the stack's bracketing blanks and the
+    // message's own paragraph breaks alike, which ran a multi-section refusal
+    // into one wall of text. Trimming the ends does the first job without the
+    // second.
+    expect(readableFailure(thrown)).toContain("recorded:\n    scripts");
+    expect(readableFailure(thrown)).toContain("\n\n  Fix: ");
   });
 
   it("drops the code frame, stack frames, and runtime banner", () => {
@@ -149,11 +176,10 @@ describe("derived-artifact staleness gate: prefix list stays in step", () => {
 describe("derived-artifact staleness gate: end to end", () => {
   it("passes on a tree whose artifacts are current", () => {
     expect(() =>
-      execFileSync(
-        process.execPath,
-        ["scripts/check-derived-artifacts.mjs", "--staged"],
-        { cwd: repoRoot, stdio: "pipe" }
-      )
+      execFileSync(process.execPath, [GATE_SCRIPT, "--staged"], {
+        cwd: repoRoot,
+        stdio: "pipe",
+      })
     ).not.toThrow();
   });
 
@@ -161,10 +187,7 @@ describe("derived-artifact staleness gate: end to end", () => {
     // The whole point of moving the gate earlier is that the developer is told
     // what to run. #2557's failure surfaced as a buried assertion error that
     // named neither command.
-    const source = readFileSync(
-      path.join(repoRoot, "scripts/check-derived-artifacts.mjs"),
-      "utf8"
-    );
+    const source = readFileSync(path.join(repoRoot, GATE_SCRIPT), "utf8");
 
     expect(source).toContain(LEDGER_COMMAND);
     expect(source).toContain(MANIFEST_COMMAND);
@@ -189,7 +212,7 @@ describe("derived-artifact staleness gate: wired into pre-commit", () => {
       // the existence guard the fleet's every commit would fail on a missing file.
       const source = readFileSync(path.join(repoRoot, hook), "utf8");
 
-      expect(source).toContain('[ -f "scripts/check-derived-artifacts.mjs" ]');
+      expect(source).toContain(`[ -f "${GATE_SCRIPT}" ]`);
     });
 
     it(`runs the gate after lint-staged in ${hook}`, () => {
@@ -203,6 +226,42 @@ describe("derived-artifact staleness gate: wired into pre-commit", () => {
       );
     });
   }
+});
+
+describe("derived-artifact staleness gate: the procedure is written down", () => {
+  const RULE = ".agents/rules/regenerating-derived-artifacts.md";
+
+  it("ships a durable note stating stage-before-regenerate", () => {
+    const rule = readFileSync(path.join(repoRoot, RULE), "utf8");
+
+    expect(rule).toContain("git add");
+    expect(rule).toContain(LEDGER_COMMAND);
+    expect(rule).toContain(MANIFEST_COMMAND);
+  });
+
+  it("records that lint-staged is why a hand-verified artifact fails at commit", () => {
+    const rule = readFileSync(path.join(repoRoot, RULE), "utf8");
+
+    expect(rule).toContain("lint-staged");
+  });
+
+  it("records that the manifest does not hash the ledger", () => {
+    // The folklore this rule replaces. Measured false in #2852: the ledger sits
+    // outside every packaged-evidence prefix, so the manifest records its path
+    // and never its bytes. Believing otherwise sends an author to regenerate
+    // the file that is not the cause, which is what cost the cycle.
+    const rule = readFileSync(path.join(repoRoot, RULE), "utf8");
+
+    expect(rule).toMatch(/does not hash the ledger/u);
+  });
+
+  it("is pointed at from the gate that blocks the commit", () => {
+    // A note nobody is sent to is a note nobody reads. The person who needs it
+    // is standing at this gate, so the gate has to name it.
+    const source = readFileSync(path.join(repoRoot, GATE_SCRIPT), "utf8");
+
+    expect(source).toContain(RULE);
+  });
 });
 
 describe("local test command covers the same files as CI", () => {

--- a/tests/unit/scripts/upstream-manifest-staleness.test.ts
+++ b/tests/unit/scripts/upstream-manifest-staleness.test.ts
@@ -1,0 +1,205 @@
+/**
+ * What a stale upstream-evidence-manifest refusal is allowed to say.
+ *
+ * The refusal used to be one line — "src/core/upstream-evidence-manifest.ts is
+ * stale; run bun run build:upstream-evidence-manifest" — which names the file
+ * that is out of date and nothing about why. The obvious response is to
+ * regenerate that file, and when the cause is an input that keeps moving
+ * underneath it, regenerating reproduces the same refusal. CodySwannGT/lisa#2852
+ * is what that costs: a whole cycle spent regenerating the named file, twice.
+ *
+ * These tests pin the replacement: the refusal names the INPUT that moved, and
+ * the recovery that clears it. The parser is exercised against the real
+ * checked-in manifest rather than a hand-written sample, so a change to the
+ * generator's output shape fails here instead of silently emitting a refusal
+ * with an empty cause.
+ * @module tests/unit/scripts/upstream-manifest-staleness
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  describeStaleManifest,
+  diagnoseStaleManifest,
+  parseManifestInputs,
+} from "../../../scripts/lib/upstream-manifest-staleness.mjs";
+
+const MANIFEST_PATH = "src/core/upstream-evidence-manifest.ts";
+const currentManifest = readFileSync(path.resolve(MANIFEST_PATH), "utf8");
+
+/** A hash-pinned evidence path that the real manifest is known to record. */
+const PINNED_EVIDENCE = "scripts/generate-upstream-evidence-manifest.mjs";
+/** A tracked path recorded in the surface manifest and hashed by neither. */
+const LEDGER_PATH = "src/core/lisa-owned-hash-ledger.ts";
+/** A copy-overwrite template, whose bytes both artifacts record. */
+const TEMPLATE_SOURCE =
+  "all/copy-overwrite/scripts/lisa-hooks/block-no-verify.sh";
+
+describe("upstream manifest staleness: parsing the generated file", () => {
+  it("reads hash-pinned evidence entries out of the real manifest", () => {
+    const inputs = parseManifestInputs(currentManifest);
+
+    expect(inputs.evidence.get(PINNED_EVIDENCE)).toMatch(/^[a-f0-9]{64}$/u);
+  });
+
+  it("reads the tracked-surface entries out of the real manifest", () => {
+    const inputs = parseManifestInputs(currentManifest);
+
+    expect(inputs.surface.has(LEDGER_PATH)).toBe(true);
+    expect(inputs.surface.has(PINNED_EVIDENCE)).toBe(true);
+  });
+
+  it("does not mistake public commit SHAs for tracked paths", () => {
+    const inputs = parseManifestInputs(currentManifest);
+
+    // The commit section renders `<sha>: true,` — the same shape as a surface
+    // entry. A parser that reads the whole file with one regex swallows 40-char
+    // SHAs as file paths and then reports thousands of phantom removals.
+    const shaShaped = [...inputs.surface].filter(entry =>
+      /^[a-f0-9]{40}$/u.test(entry)
+    );
+    expect(shaShaped).toEqual([]);
+  });
+});
+
+describe("upstream manifest staleness: classifying what moved", () => {
+  it("reports an input whose bytes moved, not the manifest itself", () => {
+    const stale = currentManifest.replace(
+      /("scripts\/generate-upstream-evidence-manifest\.mjs":\n {6}")[a-f0-9]{64}/u,
+      `$1${"0".repeat(64)}`
+    );
+    expect(stale).not.toBe(currentManifest);
+
+    const diagnosis = diagnoseStaleManifest(stale, currentManifest);
+
+    expect(diagnosis.changed).toEqual([PINNED_EVIDENCE]);
+    expect(diagnosis.added).toEqual([]);
+    expect(diagnosis.removed).toEqual([]);
+  });
+
+  it("reports a path staged after generation as an addition", () => {
+    const stale = currentManifest.replace(
+      /^ {4}"src\/core\/lisa-owned-hash-ledger\.ts": true,\n/mu,
+      ""
+    );
+    expect(stale).not.toBe(currentManifest);
+
+    const diagnosis = diagnoseStaleManifest(stale, currentManifest);
+
+    expect(diagnosis.added).toEqual([LEDGER_PATH]);
+    expect(diagnosis.changed).toEqual([]);
+  });
+
+  it("reports a path removed after generation as a removal", () => {
+    const diagnosis = diagnoseStaleManifest(
+      currentManifest,
+      currentManifest.replace(
+        /^ {4}"src\/core\/lisa-owned-hash-ledger\.ts": true,\n/mu,
+        ""
+      )
+    );
+
+    expect(diagnosis.removed).toEqual([LEDGER_PATH]);
+    expect(diagnosis.added).toEqual([]);
+  });
+
+  it("finds nothing to blame when only the generated file's own bytes differ", () => {
+    const diagnosis = diagnoseStaleManifest(
+      `${currentManifest}\n// reformatted by hand\n`,
+      currentManifest
+    );
+
+    expect(diagnosis.changed).toEqual([]);
+    expect(diagnosis.added).toEqual([]);
+    expect(diagnosis.removed).toEqual([]);
+  });
+});
+
+describe("upstream manifest staleness: what the refusal says", () => {
+  it("names the moved input and the reformat that usually moved it", () => {
+    const message = describeStaleManifest({
+      changed: [TEMPLATE_SOURCE],
+      added: [],
+      removed: [],
+    });
+
+    expect(message).toContain(MANIFEST_PATH);
+    expect(message).toContain(TEMPLATE_SOURCE);
+    expect(message).toContain("lint-staged");
+    expect(message).toContain("bun run build:upstream-evidence-manifest");
+  });
+
+  it("tells a commit that moved a copy-overwrite template to regenerate the ledger too", () => {
+    const message = describeStaleManifest({
+      changed: [TEMPLATE_SOURCE],
+      added: [],
+      removed: [],
+    });
+
+    expect(message).toContain("bun run build:lisa-owned-hash-ledger");
+  });
+
+  it("does not send a non-template change chasing the ledger", () => {
+    const message = describeStaleManifest({
+      changed: ["scripts/build-plugins.sh"],
+      added: [],
+      removed: [],
+    });
+
+    expect(message).not.toContain("bun run build:lisa-owned-hash-ledger");
+  });
+
+  it("names staging, not regeneration, when the tracked set moved", () => {
+    const message = describeStaleManifest({
+      changed: [],
+      added: ["scripts/lib/new-helper.mjs"],
+      removed: ["scripts/lib/old-helper.mjs"],
+    });
+
+    expect(message).toContain("scripts/lib/new-helper.mjs");
+    expect(message).toContain("scripts/lib/old-helper.mjs");
+    expect(message).toContain("git add");
+  });
+
+  it("says so plainly when no input moved at all", () => {
+    const message = describeStaleManifest({
+      changed: [],
+      added: [],
+      removed: [],
+    });
+
+    expect(message).toContain("None of its inputs moved");
+    expect(message).toContain("bun run build:upstream-evidence-manifest");
+  });
+
+  it("truncates a long list instead of printing hundreds of paths", () => {
+    const changed = Array.from(
+      { length: 25 },
+      (_unused, index) => `scripts/lib/file-${index}.mjs`
+    );
+
+    const message = describeStaleManifest({ changed, added: [], removed: [] });
+
+    expect(message).toContain("and 15 more");
+    expect(message).not.toContain("scripts/lib/file-24.mjs");
+  });
+});
+
+describe("upstream manifest staleness: the diagnosis is actually wired in", () => {
+  it("is what the generator's --check branch reports", () => {
+    // The pure functions above are only worth anything if the refusal path
+    // calls them. The generator refuses to load outside the canonical
+    // repository and does its work at module scope, so it cannot be imported
+    // for a direct assertion; its source is read instead.
+    const generator = readFileSync(
+      path.resolve("scripts/generate-upstream-evidence-manifest.mjs"),
+      "utf8"
+    );
+
+    expect(generator).toContain("upstream-manifest-staleness.mjs");
+    expect(generator).toContain("describeStaleManifest(");
+    expect(generator).toContain("diagnoseStaleManifest(");
+  });
+});


### PR DESCRIPTION
## What this fixes

`src/core/upstream-evidence-manifest.ts` going stale used to produce one sentence:

```
src/core/upstream-evidence-manifest.ts is stale; run bun run build:upstream-evidence-manifest
```

It is accurate and it points away from the cause. It names the file that is out of date, so the obvious response is to regenerate that file — and when the cause is an input that moves again afterwards, regenerating reproduces the identical refusal. A loop with no exit signposted from inside it.

## What the refusal says now

Three ways the file can be out of date, three different fixes, and the refusal now diagnoses which one happened by diffing the checked-in manifest's own parsed contents against a fresh regeneration:

```
src/core/upstream-evidence-manifest.ts is stale.

  Its inputs moved after it was generated. These files no longer have
  the bytes it recorded:
    scripts/check-derived-artifacts.mjs
    scripts/generate-upstream-evidence-manifest.mjs
  At commit time lint-staged reformats every staged file BEFORE this
  check runs, so a manifest generated first is stale by the time it is
  checked. Regenerate now, after the reformat.

  Fix: bun run build:upstream-evidence-manifest
  Then: git add src/core/upstream-evidence-manifest.ts
```

That output is real — it is what this branch's own commit produced before its artifacts were regenerated.

The other two verdicts:

- **the tracked file set moved** — something was staged or `git rm`'d after generation. The manifest reads TRACKED files, so stage first and regenerate second.
- **no input moved at all** — the generated file itself was rewritten after generation, by a hand edit or a formatter reaching the artifact.

When the listed files include a `copy-overwrite` template, the refusal also sends you to `bun run build:lisa-owned-hash-ledger`, because that template's bytes are recorded in both artifacts. It says nothing of the sort for any other path.

## A measured correction to the issue's premise

The issue proposes documenting **ledger-before-manifest**, on the grounds that "the manifest hashes the ledger". **Measured, it does not**, and this PR deliberately does not write that down:

- `src/core/lisa-owned-hash-ledger.ts` lives outside every entry in `packagedEvidencePrefixes`, so the manifest records its **path** in `UPSTREAM_SURFACE_MANIFEST` and never its **bytes**.
- Directly probed: appending a line to the ledger and running `bun run check:upstream-evidence-manifest` **exits 0**. The manifest is indifferent to the ledger's contents.
- This branch demonstrates it a second time. Nothing here touches a `copy-overwrite` template, so regenerating the ledger produced no diff at all while the manifest changed.

There is therefore **no required order between the two generators**. What couples them is a shared *input*: a `copy-overwrite` template is hashed by both, so editing one template stales both at once — in either order. Writing the ordering claim down would send whoever believes it to regenerate the file that is not the cause, which is the exact cost the issue is asking to remove.

The half of the premise that **is** real, and is documented: **`git add` before regenerating.** Both generators read the git index via `git ls-files`, so regenerating before staging records the file set you had a moment ago.

And the trap that actually produces "passes by hand, fails at commit": `lint-staged` runs `oxlint --fix`, `eslint --fix` and `prettier --write` over every staged file, and the artifact gate runs *after* it on purpose — a gate placed before the reformat would vouch for bytes that no longer exist. Regenerating again after the reformat converges, because reformatting already-formatted bytes changes nothing.

## Where the note lives

`.agents/rules/regenerating-derived-artifacts.md` — and the gate names that path in its own failure output, so the person blocked by it is sent there rather than left to find it. A test pins that the pointer stays.

## Also

`readableFailure` in `scripts/check-derived-artifacts.mjs` stopped squeezing blank lines. It dropped every empty line, which removed the stack's bracketing blanks and the message's paragraph breaks alike — invisible while the refusal was one sentence, and it would have run this multi-section one into a wall of text. Trimming the ends does the first job without the second.

## Acceptance criteria

- **the ordering is written down** — satisfied, with the measured order (`git add` → regenerate → `git add`, and regenerate again after the reformat) rather than the ledger-before-manifest one, which is false.
- **the refusal names the real cause** — satisfied and generalised: rather than always blaming the ledger, the refusal computes which inputs moved and names them, which is correct for all three causes.

## Verification

- `bun run test tests/unit/scripts/upstream-manifest-staleness.test.ts tests/unit/scripts/derived-artifact-staleness.test.ts` — 41 passed.
- TDD RED confirmed first: the new suite reported `Cannot find module '../../../scripts/lib/upstream-manifest-staleness.mjs'`, 0 tests, before the module existed.
- The blank-line tests were mutated against: restoring `.filter(Boolean)` kills both by name (`keeps every line that says what is wrong`, `keeps the blank lines that separate the refusal's paragraphs`); restoring the fix revives them.
- The parser is exercised against the **real** checked-in manifest, not a hand-written sample, so a change to the generator's output shape fails here instead of silently emitting a refusal with an empty cause. One test proves the commit-SHA block is not mistaken for tracked paths — a single-regex parser reads 40-character SHAs as file paths and reports thousands of phantom removals.
- End to end against the real generator: perturbing one recorded digest makes `--check` print the new diagnosis naming that path.
- `bun run lint`, `bun run typecheck`, `bun run check:artifacts` clean. Full suite: 14,758 passed, with the only failures being the two artifact-freshness assertions that this change's own edits staled, both green after regeneration.

Work-Item: CodySwannGT/lisa#2852
