### PR TITLE
fix(tests): size the suite's liveness budgets from an untruncated measurement

### DIFF
--- a/tests/unit/scripts/bdd-reporting.test.ts
+++ b/tests/unit/scripts/bdd-reporting.test.ts
@@ -268,11 +268,21 @@ describe("scale", () => {
   // flaky one that also cannot fail is the worst of both. The `timeout`
   // below remains the honest backstop: it catches a blowup severe enough to
   // matter, and claims nothing finer.
+  //
+  // Raised 60s -> 180s (#2885) for the reason this comment already gives one
+  // paragraph up: a bound that "could only fire when the machine stalled" is
+  // measuring the box. Measured on a quiet, serialised run with a fresh
+  // TMPDIR, this case takes 33,571ms — 1.79x under the old 60s cap, and the
+  // contended tail on this hardware runs about 1.8x the quiet one, which puts
+  // it exactly on the line. A per-case budget overrides the file-level one
+  // silently, so raising vitest.config.local.ts alone would have left this
+  // case to fail on its own and made the raise look ineffective. 180s is 5.4x
+  // the measured cost and still catches the blowup this is here for.
   it("handles a very large contract", () => {
     const count = 2000;
     const { run } = timeGateAtScale(count);
     expect(run.status).toBe(0);
     expect(run.envelope.summary.scenariosDeclared).toBe(count);
     expect(run.envelope.summary.traceabilityCovered).toBe(count);
-  }, 60_000);
+  }, 180_000);
 });

--- a/vitest.config.local.ts
+++ b/vitest.config.local.ts
@@ -44,8 +44,79 @@ const config: ViteUserConfig = {
     // Scoped to Lisa's create-only local config on purpose — downstream projects
     // do not carry these suites and must not inherit a looser budget they have
     // no evidence for (#2509).
-    testTimeout: 60_000,
-    hookTimeout: 60_000,
+    // RAISED AGAIN, 60s -> 300s (#2885), for the same signature one band up.
+    // Nine push gates run; six pass. Only `test:cov:unit` fails, and because
+    // `test-correctness` and `coverage-adequacy` share a prover, one death
+    // reports as two red verdicts and leaves `test-integration` NOT-RUN:
+    //   FAILED required test-correctness — 2 test(s)/hook(s) exceeded the
+    //   60000ms budget, so the suite did not finish — NOT a coverage shortfall
+    // Zero assertion failures, and the named files differ every attempt.
+    //
+    // The 60s number was measured against a TRUNCATED distribution: at a 60s
+    // budget every case that would have exceeded it is recorded as exactly 60s.
+    // Re-measured with the budget lifted out of the way (--testTimeout=600000,
+    // fresh TMPDIR, fleet heavy-work serialised, load ~19 on 18 cores) the whole
+    // unit suite is GREEN — 770 files, 13,797 tests, 0 failures, 418s wall —
+    // and the real tail is:
+    //   max 100,254ms  p99.99 61,491ms  p99.9 35,492ms  p99 1,887ms  p50 0.45ms
+    //   21 cases over 30s, 3 over 60s, 1 over 90s
+    // So three cases exceed the old budget on a quiet machine. It was never
+    // passable here; WHICH cases lose was the only variable.
+    //
+    // Ruled out by measurement, not by reasoning, each re-verified today rather
+    // than inherited from #2522:
+    //   disk        — 515Gi free of 1.8Ti
+    //   memory      — 5.7GB free + 50GB inactive of 128GB
+    //   spawn       — 3.4ms /bin/echo, 12.7ms git, 34.4ms node (healthy)
+    //   fsync       — 4.77ms/write over 20 open+write+fsync+close cycles
+    //   parallelism — ruled out in #2522: --maxWorkers=4 was WORSE, 124 vs 54
+    //   temp-dir    — the saturated shared $TMPDIR (mkdtemp 8,110.3ms there vs
+    //                 0.3ms fresh; a single `stat` on it blocks 6.35s at 0% CPU)
+    //                 is real, is lisa#2883, and is ALREADY mitigated: the run
+    //                 above used a fresh one and still produced a 100,254ms case
+    // What is left is not ours and is not going away: a browser, a power daemon
+    // and a VM hold the box at load ~21 while every Lisa test process together
+    // accounts for ~102%. That is the condition this budget must hold under,
+    // permanently — so it is sized for it rather than against an idle machine.
+    //
+    // Margin, stated: 300s is 3.0x the 100,254ms worst case measured with the
+    // fleet serialised, and 1.7x the worst INDIVIDUAL case observed today with
+    // it not serialised (~178s, in the work-item CLI suites). The contended
+    // tail runs ~1.8x the quiet tail; 300s covers that with headroom rather
+    // than landing on it.
+    //
+    // Still a LIVENESS bound, not a performance assertion, and still not a
+    // quality threshold — `threshold-monotonicity` does not govern it. A hung
+    // test still fails, just later. Tests that genuinely assert performance
+    // pass their own per-test timeout, which overrides this and is deliberately
+    // left alone.
+    testTimeout: 300_000,
+    hookTimeout: 300_000,
+    env: {
+      // The SECOND duration band, and vitest cannot reach it. Fourteen failures
+      // clustered at 30,034-30,376ms are not vitest's budget expiring — they are
+      // `CHILD_TIMEOUT_MS` inside the code under test
+      // (all/copy-overwrite/scripts/lisa-work-item.mjs), which SIGKILLs its own
+      // child at 30s. Raising testTimeout fixes exactly zero of them: the child
+      // is already dead. Anyone who raises only the budget above will watch this
+      // gate fail again with a different file list and conclude the raise did
+      // not work.
+      //
+      // 30s is the right deadline for a real commit or push, where it stops a
+      // tracker that has stopped answering from hanging a human's hook with no
+      // output. It is the wrong deadline for a fixture spawning real `git` and
+      // stubbed `gh` on an 18-core box at load 21. So this is set for the TEST
+      // RUN only — the shipped default in the script is untouched, and no
+      // downstream project inherits a looser one.
+      //
+      // 120s: 4x the shipped default, and deliberately 2.5x UNDER the 300s
+      // vitest budget above, so a genuinely hung child still dies first and
+      // reports as the CLI's own timeout diagnostic rather than as an anonymous
+      // vitest test timeout. Cases that stage a hang on purpose set their own
+      // value (tests/unit/scripts/lisa-work-item.test.ts uses 1500) and that
+      // override still wins — it is applied after the inherited environment.
+      LISA_WORK_ITEM_TIMEOUT_MS: "120000",
+    },
     coverage: {
       include: ["src/**/*.ts"],
       exclude: ["src/index.ts"],


### PR DESCRIPTION
## Why

Lisa's pre-push gate could not pass on this hardware. Nine gates run and **six PASS**
(`code-style-slow`, `conflict-residue`, `dead-code`, `threshold-monotonicity`,
`traceability`, `type-correctness`). Only `bun run test:cov:unit` failed — and because
`test-correctness` and `coverage-adequacy` share a prover, one death reported as two red
verdicts and left `test-integration` NOT-RUN. Zero assertion failures; the named files
differed every attempt.

## The measurement that changed the answer

The 60s budget from #2522 was chosen against a **truncated** distribution: at a 60s budget,
every case that would have exceeded it records as exactly 60s, so the tail is invisible.

Re-measured with the budget lifted out of the way — `--testTimeout=600000`, fresh TMPDIR,
fleet heavy-work serialised, load ~19 on 18 cores — the entire unit suite is **green**:
**770 files, 13,797 tests, 0 failures, 418s wall**. The real distribution:

| statistic | value |
| --- | --- |
| max | **100,254 ms** |
| p99.99 | 61,491 ms |
| p99.9 | 35,492 ms |
| p99 | 1,887 ms |
| p50 | 0.45 ms |

21 cases over 30s, **3 over 60s**, 1 over 90s. Three cases exceed the old budget on a
*quiet* machine. It was never passable here; which cases lost was the only variable.

## Ruled out by measurement, not by reasoning

Each re-verified in this session rather than inherited from #2522:

| candidate | measurement |
| --- | --- |
| disk | 515Gi free of 1.8Ti |
| memory | 5.7GB free + 50GB inactive of 128GB |
| subprocess spawn | 3.4ms `/bin/echo`, 12.7ms `git`, 34.4ms `node` |
| filesystem | 4.77 ms/fsync over 20 open+write+fsync+close cycles |
| parallelism | ruled out in #2522: `--maxWorkers=4` was WORSE, 124 vs 54 |
| temp directory | **real, already mitigated, and not the remaining cause** — mkdtemp costs 8,110.3ms in the saturated shared dir vs 0.3ms fresh, and a bare `stat` on it blocks 6.35s at 0% CPU. The measurement above used a fresh one and still produced a 100,254ms case. |

What remains is not ours and is not going away: a browser, a power daemon and a VM hold the
box at load ~21 while every Lisa test process together accounts for ~102%. That is the
condition the budget must hold under, permanently.

## Three clocks, three changes

Fixing one does nothing for the others.

**1. `testTimeout`/`hookTimeout` 60s → 300s** in the create-only local config.
Margin, stated: **3.0x** the 100,254ms worst case measured with the fleet serialised, and
**1.7x** the worst individual case observed with it not serialised (~178s). The contended
tail runs ~1.8x the quiet tail; 300s covers that rather than landing on it.

**2. `LISA_WORK_ITEM_TIMEOUT_MS=120000` for the test run only.**
Fourteen failures clustered at 30,034–30,376 ms are **not** vitest expiring — they are
`CHILD_TIMEOUT_MS` inside the code under test SIGKILLing its own child at 30s. Raising
`testTimeout` fixes exactly zero of them: the child is already dead. 30s is the right
deadline for a real commit, where it stops a tracker that has stopped answering from hanging
a human's hook with no output — so **the shipped default is untouched and no consumer
inherits a looser one**. 120s is 4x that default and deliberately 2.5x *under* the vitest
budget, so a genuinely hung child still dies first, with the CLI's own diagnostic.

**3. One per-case inline budget** — `bdd-reporting` "handles a very large contract", 60s → 180s.
Per-case budgets override the file-level one **silently**, so raising only the config would
have left this case to fail alone and made the raise look ineffective (#2822's carry-forward).
Measured at 33,571ms quiet — 1.79x under its cap against a contended tail of ~1.8x, i.e.
exactly on the line. Its own comment already made this argument when it was raised 30s → 60s.

## Verification

Verified the config merge actually delivers both values rather than assuming it, and verified
each would fail without the change:

- a deliberate 70s test **passes** under the new budget; under `--testTimeout=60000` the same
  test dies with `Test timed out in 60000ms`
- `LISA_WORK_ITEM_TIMEOUT_MS` reads `"120000"` in the worker and in a child spawned from it;
  with the config entry renamed away: `expected undefined to be '120000'`
- the eight affected suites — including the case that stages a hang on purpose with its own
  1500ms override — pass together: **168 tests, 0 failures, at load 44**
- **this PR's own push is the verification**: the pre-push gate reads the working tree, so the
  raised budget governed its own push. All nine gates PASSED, including `coverage-adequacy`,
  `test-correctness` and `test-integration`, which had not completed in any attempt today.

## Scope and what this is not

- Scoped to Lisa's create-only `vitest.config.local.ts`, deliberately **not** the fleet factory
  default: downstream projects do not carry these suites and must not inherit a looser budget
  they have no evidence for (#2509).
- **Not a quality threshold**, so `threshold-monotonicity` does not govern it. This is a
  *liveness* bound — a hung test still fails, just later. Tests that genuinely assert
  performance pass their own per-test timeout, which overrides the global and is left alone.
- Per the ruling on #2829: **no per-moment budgets, and no check switched off at push.** Every
  gate still runs, in full, at the same moment, with the same strictness.

Work-Item: CodySwannGT/lisa#2885


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout limits for large-contract scale tests to accommodate longer runtimes.
  * Extended local test and hook timeouts to improve reliability under contention.
  * Added a test-only work-item timeout configuration for local validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ⚠️ Follow-up: 300s was sized against a shim-inflated tail — re-measure after #2889

Recorded after merge so nobody later reads `300_000` as a considered value for a healthy
machine. An unexplained large number in a config is how the 60s got there in the first place.

`tests/unit/scripts/bdd/support.ts:74` picks its git binary from a hardcoded preference list
with **`/usr/bin/git` first** — which on macOS is Apple's `xcrun` shim. Everything else in the
suite resolves git through `resolveGit()` (`tests/support/git-executable.ts`), which scans
`PATH` and lands on a real binary. So the suite is a **mix**, and the tail this budget was
sized against is dominated by the shim half: of the top cases, `bdd-adoption` (100,254 ms),
`bdd-reporting`, `bdd-nonregression`, `bdd-ratchet-removal`, `bdd-discovery`, `bdd-failopen`
and `bdd-envelope` all dispatch through the shim.

**The mechanism is a tail, not a multiplier.** Measured here, randomized call order, n=10 each,
`git --version` — which does no work at all:

| binary | quiet median | quiet max | under load median | under load **max** |
| --- | --- | --- | --- | --- |
| `/usr/bin/git` (shim) | 24 ms | 26 ms | 24 ms | **20,727 ms** |
| `/opt/homebrew/bin/git` | 13 ms | 15 ms | 9 ms | **11 ms** |

The shim's *median* is unremarkable — about 2x. Its *maximum* explodes to ~20 s under load
while the direct binary stays flat at 11 ms. That is a better explanation of this gate's
behaviour than any constant slowdown: a case making a handful of git calls needs one bad draw
from a ~20 s tail to cross the budget, and **which** case draws it is random. That is exactly
the "timeouts only, zero assertion failures, never in the pushing author's own suites" shape,
and exactly why the losing set changed every attempt.

**What still stands, unchanged:** the 60s budget was not passable — three cases exceeded it on
a quiet, serialised machine with a fresh TMPDIR. The measurement above explains *why* the tail
was long; it does not make the old budget adequate.

**What should change:** #2889 removes the shim from the bdd fixtures, and notably **passed the
push gate carrying the old 60s budget** — the fix made the tests fast rather than the limit
bigger. Once it lands, the distribution must be re-measured on the fixed fixtures and this
budget tightened to whatever the real tail says. 300s is a deliberately generous *liveness*
bound, and a too-generous liveness bound is the cheap kind of wrong — a hung test still fails,
just later — but it is not a considered number for a healthy machine and must not be treated
as one.

Follow-up tracked in #2892.
