### PR TITLE
fix(hooks): pin #2850's reported cross-repo filing, and name the target as typed

### DIFF
--- a/all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh
+++ b/all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh
@@ -796,11 +796,17 @@ def normalise_repo(value):
     token would call the same repository two different places depending on how
     it was typed.
 
+    Casing is PRESERVED here and folded only at the point of comparison. The
+    refusal names this string back to an operator, and echoing
+    `codyswanngt/lisa` at someone who typed `CodySwannGT/lisa` reads as a
+    different repository — a message that has to be squinted at is the thing
+    this change is repairing.
+
     Args:
         value: The raw token.
 
     Returns:
-        A lowercased `owner/name`, or None when the token names no repository.
+        An as-typed `owner/name`, or None when the token names no repository.
     """
     text = value.strip().strip("'\"")
     if text.endswith(".git"):
@@ -808,7 +814,7 @@ def normalise_repo(value):
     parts = [part for part in text.split("/") if part and not part.endswith(":")]
     if len(parts) < 2:
         return None
-    return ("%s/%s" % (parts[-2], parts[-1])).lower()
+    return "%s/%s" % (parts[-2], parts[-1])
 
 
 def target_repository(args):
@@ -857,15 +863,19 @@ def roles_for(target):
     permissive about which token, never about whether one is required.
 
     Args:
-        target: The addressed repository, or None.
+        target: The addressed repository as typed, or None.
 
     Returns:
         A (roles, cross_repo_target) pair. The target is None when the calling
-        project is the one being written to.
+        project is the one being written to. When set it is the as-typed
+        spelling, because the refusal names it back to an operator.
     """
-    if target is None or (own_repo and target == own_repo):
+    # GitHub is case-insensitive about owner and name, so the comparison folds
+    # case while the reported string keeps the operator's own spelling.
+    folded = target.lower() if target is not None else None
+    if folded is None or (own_repo and folded == own_repo):
         return [ready_role], None
-    if upstream_repo and target == upstream_repo:
+    if upstream_repo and folded == upstream_repo:
         role = upstream_ready_role
     else:
         # Another repository Lisa has no configuration for. Its lane is

--- a/plugins/lisa-agy/hooks/block-direct-issue-create.sh
+++ b/plugins/lisa-agy/hooks/block-direct-issue-create.sh
@@ -793,11 +793,17 @@ def normalise_repo(value):
     token would call the same repository two different places depending on how
     it was typed.
 
+    Casing is PRESERVED here and folded only at the point of comparison. The
+    refusal names this string back to an operator, and echoing
+    `codyswanngt/lisa` at someone who typed `CodySwannGT/lisa` reads as a
+    different repository — a message that has to be squinted at is the thing
+    this change is repairing.
+
     Args:
         value: The raw token.
 
     Returns:
-        A lowercased `owner/name`, or None when the token names no repository.
+        An as-typed `owner/name`, or None when the token names no repository.
     """
     text = value.strip().strip("'\"")
     if text.endswith(".git"):
@@ -805,7 +811,7 @@ def normalise_repo(value):
     parts = [part for part in text.split("/") if part and not part.endswith(":")]
     if len(parts) < 2:
         return None
-    return ("%s/%s" % (parts[-2], parts[-1])).lower()
+    return "%s/%s" % (parts[-2], parts[-1])
 
 
 def target_repository(args):
@@ -854,15 +860,19 @@ def roles_for(target):
     permissive about which token, never about whether one is required.
 
     Args:
-        target: The addressed repository, or None.
+        target: The addressed repository as typed, or None.
 
     Returns:
         A (roles, cross_repo_target) pair. The target is None when the calling
-        project is the one being written to.
+        project is the one being written to. When set it is the as-typed
+        spelling, because the refusal names it back to an operator.
     """
-    if target is None or (own_repo and target == own_repo):
+    # GitHub is case-insensitive about owner and name, so the comparison folds
+    # case while the reported string keeps the operator's own spelling.
+    folded = target.lower() if target is not None else None
+    if folded is None or (own_repo and folded == own_repo):
         return [ready_role], None
-    if upstream_repo and target == upstream_repo:
+    if upstream_repo and folded == upstream_repo:
         role = upstream_ready_role
     else:
         # Another repository Lisa has no configuration for. Its lane is

--- a/plugins/lisa-copilot/hooks/block-direct-issue-create.sh
+++ b/plugins/lisa-copilot/hooks/block-direct-issue-create.sh
@@ -793,11 +793,17 @@ def normalise_repo(value):
     token would call the same repository two different places depending on how
     it was typed.
 
+    Casing is PRESERVED here and folded only at the point of comparison. The
+    refusal names this string back to an operator, and echoing
+    `codyswanngt/lisa` at someone who typed `CodySwannGT/lisa` reads as a
+    different repository — a message that has to be squinted at is the thing
+    this change is repairing.
+
     Args:
         value: The raw token.
 
     Returns:
-        A lowercased `owner/name`, or None when the token names no repository.
+        An as-typed `owner/name`, or None when the token names no repository.
     """
     text = value.strip().strip("'\"")
     if text.endswith(".git"):
@@ -805,7 +811,7 @@ def normalise_repo(value):
     parts = [part for part in text.split("/") if part and not part.endswith(":")]
     if len(parts) < 2:
         return None
-    return ("%s/%s" % (parts[-2], parts[-1])).lower()
+    return "%s/%s" % (parts[-2], parts[-1])
 
 
 def target_repository(args):
@@ -854,15 +860,19 @@ def roles_for(target):
     permissive about which token, never about whether one is required.
 
     Args:
-        target: The addressed repository, or None.
+        target: The addressed repository as typed, or None.
 
     Returns:
         A (roles, cross_repo_target) pair. The target is None when the calling
-        project is the one being written to.
+        project is the one being written to. When set it is the as-typed
+        spelling, because the refusal names it back to an operator.
     """
-    if target is None or (own_repo and target == own_repo):
+    # GitHub is case-insensitive about owner and name, so the comparison folds
+    # case while the reported string keeps the operator's own spelling.
+    folded = target.lower() if target is not None else None
+    if folded is None or (own_repo and folded == own_repo):
         return [ready_role], None
-    if upstream_repo and target == upstream_repo:
+    if upstream_repo and folded == upstream_repo:
         role = upstream_ready_role
     else:
         # Another repository Lisa has no configuration for. Its lane is

--- a/plugins/lisa-cursor/hooks/block-direct-issue-create.sh
+++ b/plugins/lisa-cursor/hooks/block-direct-issue-create.sh
@@ -793,11 +793,17 @@ def normalise_repo(value):
     token would call the same repository two different places depending on how
     it was typed.
 
+    Casing is PRESERVED here and folded only at the point of comparison. The
+    refusal names this string back to an operator, and echoing
+    `codyswanngt/lisa` at someone who typed `CodySwannGT/lisa` reads as a
+    different repository — a message that has to be squinted at is the thing
+    this change is repairing.
+
     Args:
         value: The raw token.
 
     Returns:
-        A lowercased `owner/name`, or None when the token names no repository.
+        An as-typed `owner/name`, or None when the token names no repository.
     """
     text = value.strip().strip("'\"")
     if text.endswith(".git"):
@@ -805,7 +811,7 @@ def normalise_repo(value):
     parts = [part for part in text.split("/") if part and not part.endswith(":")]
     if len(parts) < 2:
         return None
-    return ("%s/%s" % (parts[-2], parts[-1])).lower()
+    return "%s/%s" % (parts[-2], parts[-1])
 
 
 def target_repository(args):
@@ -854,15 +860,19 @@ def roles_for(target):
     permissive about which token, never about whether one is required.
 
     Args:
-        target: The addressed repository, or None.
+        target: The addressed repository as typed, or None.
 
     Returns:
         A (roles, cross_repo_target) pair. The target is None when the calling
-        project is the one being written to.
+        project is the one being written to. When set it is the as-typed
+        spelling, because the refusal names it back to an operator.
     """
-    if target is None or (own_repo and target == own_repo):
+    # GitHub is case-insensitive about owner and name, so the comparison folds
+    # case while the reported string keeps the operator's own spelling.
+    folded = target.lower() if target is not None else None
+    if folded is None or (own_repo and folded == own_repo):
         return [ready_role], None
-    if upstream_repo and target == upstream_repo:
+    if upstream_repo and folded == upstream_repo:
         role = upstream_ready_role
     else:
         # Another repository Lisa has no configuration for. Its lane is

--- a/plugins/lisa/hooks/block-direct-issue-create.sh
+++ b/plugins/lisa/hooks/block-direct-issue-create.sh
@@ -793,11 +793,17 @@ def normalise_repo(value):
     token would call the same repository two different places depending on how
     it was typed.
 
+    Casing is PRESERVED here and folded only at the point of comparison. The
+    refusal names this string back to an operator, and echoing
+    `codyswanngt/lisa` at someone who typed `CodySwannGT/lisa` reads as a
+    different repository — a message that has to be squinted at is the thing
+    this change is repairing.
+
     Args:
         value: The raw token.
 
     Returns:
-        A lowercased `owner/name`, or None when the token names no repository.
+        An as-typed `owner/name`, or None when the token names no repository.
     """
     text = value.strip().strip("'\"")
     if text.endswith(".git"):
@@ -805,7 +811,7 @@ def normalise_repo(value):
     parts = [part for part in text.split("/") if part and not part.endswith(":")]
     if len(parts) < 2:
         return None
-    return ("%s/%s" % (parts[-2], parts[-1])).lower()
+    return "%s/%s" % (parts[-2], parts[-1])
 
 
 def target_repository(args):
@@ -854,15 +860,19 @@ def roles_for(target):
     permissive about which token, never about whether one is required.
 
     Args:
-        target: The addressed repository, or None.
+        target: The addressed repository as typed, or None.
 
     Returns:
         A (roles, cross_repo_target) pair. The target is None when the calling
-        project is the one being written to.
+        project is the one being written to. When set it is the as-typed
+        spelling, because the refusal names it back to an operator.
     """
-    if target is None or (own_repo and target == own_repo):
+    # GitHub is case-insensitive about owner and name, so the comparison folds
+    # case while the reported string keeps the operator's own spelling.
+    folded = target.lower() if target is not None else None
+    if folded is None or (own_repo and folded == own_repo):
         return [ready_role], None
-    if upstream_repo and target == upstream_repo:
+    if upstream_repo and folded == upstream_repo:
         role = upstream_ready_role
     else:
         # Another repository Lisa has no configuration for. Its lane is

--- a/plugins/src/base/hooks/block-direct-issue-create.sh
+++ b/plugins/src/base/hooks/block-direct-issue-create.sh
@@ -793,11 +793,17 @@ def normalise_repo(value):
     token would call the same repository two different places depending on how
     it was typed.
 
+    Casing is PRESERVED here and folded only at the point of comparison. The
+    refusal names this string back to an operator, and echoing
+    `codyswanngt/lisa` at someone who typed `CodySwannGT/lisa` reads as a
+    different repository — a message that has to be squinted at is the thing
+    this change is repairing.
+
     Args:
         value: The raw token.
 
     Returns:
-        A lowercased `owner/name`, or None when the token names no repository.
+        An as-typed `owner/name`, or None when the token names no repository.
     """
     text = value.strip().strip("'\"")
     if text.endswith(".git"):
@@ -805,7 +811,7 @@ def normalise_repo(value):
     parts = [part for part in text.split("/") if part and not part.endswith(":")]
     if len(parts) < 2:
         return None
-    return ("%s/%s" % (parts[-2], parts[-1])).lower()
+    return "%s/%s" % (parts[-2], parts[-1])
 
 
 def target_repository(args):
@@ -854,15 +860,19 @@ def roles_for(target):
     permissive about which token, never about whether one is required.
 
     Args:
-        target: The addressed repository, or None.
+        target: The addressed repository as typed, or None.
 
     Returns:
         A (roles, cross_repo_target) pair. The target is None when the calling
-        project is the one being written to.
+        project is the one being written to. When set it is the as-typed
+        spelling, because the refusal names it back to an operator.
     """
-    if target is None or (own_repo and target == own_repo):
+    # GitHub is case-insensitive about owner and name, so the comparison folds
+    # case while the reported string keeps the operator's own spelling.
+    folded = target.lower() if target is not None else None
+    if folded is None or (own_repo and folded == own_repo):
         return [ready_role], None
-    if upstream_repo and target == upstream_repo:
+    if upstream_repo and folded == upstream_repo:
         role = upstream_ready_role
     else:
         # Another repository Lisa has no configuration for. Its lane is

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -291,6 +291,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   ]),
   "scripts/lisa-hooks/block-direct-issue-create.sh": Object.freeze([
     "014510942610f36b17f006dee4b96c7737abad3e3acc4f5b416ab6d52403c793",
+    "17c442bf60259d8183c7359bc54f992e8b7f305798704af1ed33f3e22e1a6006",
     "22184f1dd1b96e818741bd4ae659446299535d7ce594817155edebac4172a7ba",
     "60a4f94ec671b2372f7492680ab327d97aff686588ce85791f54e0fbd098b0ca",
     "63c2f9b54ea30997905bc6e17709dd1300436204ac82ad16717d7cc215af262b",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -27,7 +27,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "all/copy-overwrite/scripts/lisa-gates.mjs":
       "96077d0bbcf53ccc6b1baadef319cb9fa9979413bcff418ecea5abd136ff3491",
     "all/copy-overwrite/scripts/lisa-hooks/block-direct-issue-create.sh":
-      "8df0ebd0d9b248d74683ed3a39da84c7348dd8ca08d0bb651f69f1987b554412",
+      "17c442bf60259d8183c7359bc54f992e8b7f305798704af1ed33f3e22e1a6006",
     "all/copy-overwrite/scripts/lisa-hooks/block-instruction-file-edits.sh":
       "3e709e1ec8a5843c00684bc477ad32ddab2c5fdb11f71d5aeec0c49609eaf025",
     "all/copy-overwrite/scripts/lisa-hooks/block-managed-file-edits.sh":
@@ -687,7 +687,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/hooks/block-direct-issue-create.agy.sh":
       "2adaf15910b6d00e69c202d263d407a21b31c0afce0039c6c042e51c278d2325",
     "plugins/src/base/hooks/block-direct-issue-create.sh":
-      "bbd56552e4570813693bc0045f33b0092440565c88822ab785f8349e49bf64e4",
+      "ccf9594392c6450afac82052f26803d405c939c9044e34f7248ca253a42570e7",
     "plugins/src/base/hooks/block-instruction-file-edits.agy.sh":
       "aa249cae53caeb3e0fb6d6af114e2756084f45a2896332fb063a9f20e4902125",
     "plugins/src/base/hooks/block-instruction-file-edits.sh":

--- a/src/opencode/plugin-templates/lisa-block-direct-issue-create.ts
+++ b/src/opencode/plugin-templates/lisa-block-direct-issue-create.ts
@@ -198,7 +198,10 @@ const LisaBlockDirectIssueCreate = async () => {
     const text = value.replace(/\.git$/, "");
     const parts = text.split("/").filter(part => part && !part.endsWith(":"));
     if (parts.length < 2) return undefined;
-    return `${parts.at(-2)}/${parts.at(-1)}`.toLowerCase();
+    // Casing preserved; folded only where it is compared. The refusal names
+    // this back to an operator, and echoing a lowercased slug at someone who
+    // typed the canonical spelling reads as a different repository.
+    return `${parts.at(-2)}/${parts.at(-1)}`;
   };
 
   /**
@@ -233,10 +236,13 @@ const LisaBlockDirectIssueCreate = async () => {
     resolved: FilingPolicy,
     target: string | undefined
   ): Verdict => {
-    if (target === undefined || target === resolved.ownRepo)
+    // GitHub is case-insensitive about owner and name, so the comparison folds
+    // case while the reported string keeps the operator's own spelling.
+    const folded = target?.toLowerCase();
+    if (folded === undefined || folded === resolved.ownRepo)
       return { roles: [resolved.readyRole], named: undefined };
     const role =
-      target === resolved.upstreamRepo
+      folded === resolved.upstreamRepo
         ? resolved.upstreamReadyRole
         : DEFAULT_READY_ROLE;
     if (resolved.ownRepo !== undefined || !resolved.callerIsGithub)

--- a/tests/unit/hooks/block-direct-issue-create-cross-repo.test.ts
+++ b/tests/unit/hooks/block-direct-issue-create-cross-repo.test.ts
@@ -33,6 +33,8 @@ import {
 const OWN_REPO = "own-org/own-repo";
 /** The repository upstream defects are filed at. */
 const UPSTREAM_REPO = "up-org/up-repo";
+/** The local filing flow, which cannot address another repository. */
+const LOCAL_FLOW = "/lisa:track";
 /** The ready role the upstream repository runs its build queue off. */
 const UPSTREAM_ROLE = "status:ready";
 
@@ -139,7 +141,7 @@ describe("block-direct-issue-create.sh cross-repository filing", () => {
     ).toBe(EXIT_BLOCKED);
     const { stderr } = runHook(bash('gh issue create --title "x"'), { cwd });
     expect(stderr).toContain(CUSTOM_ROLE);
-    expect(stderr).toContain("/lisa:track");
+    expect(stderr).toContain(LOCAL_FLOW);
   });
 
   it("points a refused cross-repo filing at a route that reaches the target", () => {
@@ -152,7 +154,7 @@ describe("block-direct-issue-create.sh cross-repository filing", () => {
     expect(stderr).toContain("file-upstream");
     // `/lisa:track` writes to the caller's own tracker and cannot reach the
     // target, so recommending it is the remediation pointing away from the fix.
-    expect(stderr).not.toContain("/lisa:track");
+    expect(stderr).not.toContain(LOCAL_FLOW);
     expect(stderr).not.toContain(CUSTOM_ROLE);
   });
 
@@ -208,6 +210,72 @@ describe("block-direct-issue-create.sh cross-repository filing", () => {
     );
     expect(stderr).not.toContain("ANOTHER REPOSITORY");
     expect(stderr).toContain(CUSTOM_ROLE);
+  });
+
+  // The shape two consumer sessions hit in production, on two different
+  // trackers, each unable to file an upstream defect at all. Reproduced here
+  // with the DEFAULT upstream repo and no `hardening` block, because that is
+  // what a consumer actually has — a fixture that configures the upstream repo
+  // explicitly would pass while the real case stayed broken.
+  describe("the reported consumer reproduction", () => {
+    const LINEAR_CONSUMER: Record<string, unknown> = {
+      tracker: "linear",
+      linear: { workflow: { ready: "Ready" } },
+    };
+    const UPSTREAM = "CodySwannGT/lisa";
+
+    it("refuses an undeclared upstream filing", () => {
+      expect(
+        runHook(bash(`gh issue create --repo ${UPSTREAM} --title "x"`), {
+          cwd: projectWithTracker(LINEAR_CONSUMER),
+        }).status
+      ).toBe(EXIT_BLOCKED);
+    });
+
+    it("permits the target's own role — the step that used to fail", () => {
+      // The caller passes exactly the label the target repository uses, which
+      // is what the guard's own remedy text instructs. Before the fix this was
+      // still refused, because it was compared against the Linear workflow
+      // state `Ready` resolved from the CALLING project. An instruction that
+      // does not work when followed is worse than no instruction.
+      const { status, stderr } = runHook(
+        bash(
+          `gh issue create --repo ${UPSTREAM} --title "x" --label "status:ready"`
+        ),
+        { cwd: projectWithTracker(LINEAR_CONSUMER) }
+      );
+      expect(stderr).not.toContain("BLOCKED");
+      expect(status).toBe(EXIT_ALLOWED);
+    });
+
+    it("does not accept the caller's Linear state against a GitHub target", () => {
+      // The reporter declined to pass this precisely because it would satisfy
+      // the guard while filing into a lane the target's build-intake never
+      // scans — causing the exact harm the guard exists to prevent, by
+      // complying with it. It must not become the path of least resistance.
+      expect(
+        runHook(
+          bash(
+            `gh issue create --repo ${UPSTREAM} --title "x" --label "Ready"`
+          ),
+          { cwd: projectWithTracker(LINEAR_CONSUMER) }
+        ).status
+      ).toBe(EXIT_BLOCKED);
+    });
+
+    it("names the target and a role that works, in the operator's spelling", () => {
+      const { stderr } = runHook(
+        bash(`gh issue create --repo ${UPSTREAM} --title "x"`),
+        { cwd: projectWithTracker(LINEAR_CONSUMER) }
+      );
+      // As typed, not case-folded — a lowercased slug reads as another repo.
+      expect(stderr).toContain(UPSTREAM);
+      expect(stderr).toContain("status:ready");
+      expect(stderr).not.toContain("Ready\n");
+      // The operator must not be told to reach for the human override, nor
+      // sent to a local flow that cannot address another repository.
+      expect(stderr).not.toContain(LOCAL_FLOW);
+    });
   });
 
   it("ignores a target named past a bare -- , where it cannot reach the item", () => {


### PR DESCRIPTION
Follow-up to #2850 (merged in #2891). Two items remained after that merge.

## 1. Pin the reported consumer reproduction

#2850 was reproduced in production by two consumer sessions on two different trackers, each unable to file an upstream defect at all. The merged tests cover the mechanism, but none reproduced the shape those consumers actually hit — **the default upstream repository with no `hardening` block**, which is what a consumer has. A fixture that configures the upstream repo explicitly passes while the real case stays broken, so it proves nothing about the reported failure.

| # | command | before #2850 | now |
|---|---|---|---|
| 1 | `--repo <upstream> --title x` | refused | refused |
| 2 | + the target's own `--label status:ready` | **refused** | **permitted** |
| 3 | + the caller's `--label Ready` | permitted | refused |

**Step 2** is the case that mattered: the caller passes exactly the label the target uses — which the guard's own remedy text instructs — and was refused anyway. An instruction that does not work when followed is worse than no instruction.

**Step 3** is the harm. Accepting the caller's own role would *satisfy* the guard while filing into a lane the target's build-intake never scans, causing the exact incomplete handoff the guard exists to prevent, by complying with it. One reporter declined to do this by hand; the guard now declines it too.

## 2. Report the target as typed

Case is folded to compare repository names, which is right — GitHub is case-insensitive about owner and name. But the folded string was then reported back to the operator, so someone who typed the canonical spelling got a lowercased slug, which reads as a different repository. Case is now folded only where it is compared.

## Verification

Mutation-checked rather than merely passing: forcing the target lookup to `None` kills **12** tests, including all three reproduction cases above. Both implementations stay in parity — the canonical bash hook (regenerated into its nine shipped copies) and the OpenCode port.

Work-Item: CodySwannGT/lisa#2899
