### PR TITLE
fix(tests): let the measured budget reach the case that most needs it

### DIFF
--- a/tests/unit/hooks/sonar-secrets.test.ts
+++ b/tests/unit/hooks/sonar-secrets.test.ts
@@ -353,7 +353,31 @@ describe("the resolver deadline is enforced, not just declared", () => {
     );
 
     expect(survivors.stdout.trim()).toBe("");
-  }, 40_000);
+    // No per-case budget here on purpose. This case carried `}, 40_000)`, and a
+    // per-case literal OVERRIDES the file-level budget silently — so the one
+    // case in this file that most needs `useIoLatencyBudget()`'s scaling was
+    // the only one it could not reach. That is the failure mode #2822 recorded
+    // as a carry-forward, still live in the file that owns the helper.
+    //
+    // Deleting the literal is not a raise. The helper's budget is
+    // `base x measured spawn slowdown`, so a quiet box still fails a hang in
+    // roughly `base` while a loaded one gets proportionate room; a literal can
+    // do neither. Measured cost of this case, serialised on a fresh TMPDIR at
+    // load ~29: 38,043ms against the old 40,000ms cap — 4.9% of headroom, which
+    // is not a margin, it is a coin toss. It lost three times in one night, on
+    // three branches with unrelated diffs (62,350ms / 50,965ms / timeout),
+    // blocking all three from pushing at all.
+    //
+    // The cost is not this case being wasteful. It has a hard floor at the
+    // hook's own `read -r -t 10` ceiling (sonar-secrets.sh:111) — a fixed
+    // wall-clock wait that neither shrinks on a fast box nor scales on a slow
+    // one — plus a `bash` spawn whose cost on this hardware is unbounded: the
+    // identical single-`run()` operation ranged 1,109ms to 38,711ms WITHIN one
+    // run of this file. Sharing fixtures across cases was measured and rejected
+    // rather than skipped: `stubSonar` is one mkdtemp, one write and one chmod,
+    // about 1ms, so hoisting all six repeats would recover ~6ms out of 38,000.
+    // That is theatre, and it would have made this file look addressed.
+  });
 });
 
 describe("when the wrapper must stand aside", () => {


### PR DESCRIPTION
`sonar-secrets.test.ts` was the single largest blocker to landing work in this
repository. Of seven branches pushed through the pre-push gate in one night,
five were refused and four died in this file — three of them on one case:

  FAIL  sonar-secrets.test.ts > the resolver deadline is enforced, not just
        declared > kills and reaps a resolver that outlives the ceiling
  Error: Test timed out in 40000ms.

62,350ms, 50,965ms, and a third at the same signature, on three branches with
unrelated diffs. Zero assertion failures.

The file already calls `useIoLatencyBudget()` (#2822), which installs
`base x measured spawn slowdown` through `vi.setConfig`. The case then carried
`}, 40_000)`. A per-case budget overrides the file-level one SILENTLY, so the
one case in this file that most needed the helper's scaling was the only one it
could not reach — the failure mode #2822 recorded as a carry-forward, still live
in the file that owns the helper.

Deleting the literal is not a raise. A measured ratio still fails a genuine hang
in roughly `base` on a quiet box, which is precisely what a bigger literal would
not do.

Measured before changing anything, serialised on a fresh TMPDIR at load ~29:

  kills and reaps a resolver that outlives the ceiling   38,043ms
  never prints the value it resolved                     38,711ms
  passes a real finding through                           5,838ms
  swallows an inactive scanner and warns instead          1,109ms

38,043ms against a 40,000ms cap is 4.9% of headroom. That is not a margin, it is
a coin toss, and it lost three times in one night.

Ruled out by measurement rather than reasoning:

- fixture sharing — the helper's own suggested remedy, measured and REJECTED
  rather than skipped: `stubSonar` is one mkdtemp, one write and one chmod,
  about 1ms. Hoisting all six identical repeats recovers ~6ms out of 38,000. It
  would have made this file look addressed while changing nothing.
- case waste — the cost has a hard floor at the hook's own `read -r -t 10`
  ceiling (sonar-secrets.sh:111), a fixed wall-clock wait that neither shrinks
  on a fast box nor scales on a slow one. The case must wait it out to prove the
  child is killed and reaped, which is the behaviour under test.
- a bigger literal — the identical single-`run()` operation ranged 1,109ms to
  38,711ms WITHIN one run of this file, and a case with no hang and no process
  table scan took 38,711ms. No fixed number tracks a 35x within-file swing.

The assertion is untouched: a resolver that never writes and never exits must
still be killed and reaped, and the `ps` survivor check that proves it is
unchanged. Only the clock around it moved, from a literal to the measurement the
suite already performs.

Left deliberately undone: `passes a real finding through` tripped the helper's
margin guard on one branch at 31.1s quiet-equivalent against a 30.0s ceiling.
That guard is working as designed and its instruction is to reduce the work, not
to raise anything — but the reduction available here is the ~6ms above, so it
needs a different answer than this commit can give. Not papered over, and not
worked around by touching the guard.


## Verification

The pre-push gate reads the working tree, so this change governed its own push.
**All nine required gates PASSED at load 67.31** — including `test-correctness`,
`coverage-adequacy` and `test-integration`. The case that refused three branches at a
40,000ms literal passed on a box more than twice as loaded as the one where it failed.

One earlier attempt failed on an unrelated flake and is recorded rather than hidden:
`tests/unit/health/deadline.test.ts > waits out a hanging collaborator without spending CPU
on it` — `AssertionError: expected 492.585667 to be greater than or equal to 499`, a sleep
that fired 7ms early. It did not reproduce on the next run. That is a sixth clock in this
repository (an assertion that a wait lasted at least as long as requested, which timer
coalescing can defeat) and it deserves its own ticket, but it is not this change.

Work-Item: CodySwannGT/lisa#2895
