### PR TITLE
fix(bdd): let a complete retirement record authorize a coverage reduction on its own

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1119,11 +1119,6 @@ jobs:
           # mode requires it; bootstrap runs without one silently, because it
           # is non-blocking by construction.
           BDD_BASE_SHA: ${{ steps.bdd_base.outputs.sha }}
-          # Labels authorize giving coverage back — a retirement or a waiver
-          # over an obligation that used to be mapped. They are
-          # maintainer-applied, so an author cannot reduce the contract and
-          # authorize the reduction in the same pull request.
-          BDD_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           # Joins the standard command envelope to this run's CI log.
           BDD_CORRELATION_ID: ${{ github.run_id }}-${{ github.run_attempt }}
           BDD_ENVIRONMENT: ${{ github.repository }}@${{ github.ref_name }}

--- a/docs/bdd-coverage-schema.md
+++ b/docs/bdd-coverage-schema.md
@@ -382,18 +382,19 @@ waivers retire instead of accumulating.
 mapping, narrowing its platform list, tagging a covered scenario `@blocked`, or
 swapping an accepted obligation for an easier one while the headline holds steady.
 
-Giving coverage back is legitimate, and takes **two artifacts one author cannot
-produce alone**:
+Giving coverage back is legitimate, and takes a **recorded route**: a `retirements`
+record (`{ scenario, reason, ticket, approvedBy, recordedAt }`) for a behavior the
+product no longer has, or a `platformWaivers` entry for a runner that cannot decide
+it. A `retirements` record is refused unless **every** field is present.
 
-1. A recorded route — a `retirements` record
-   (`{ scenario, reason, ticket, approvedBy, recordedAt }`) for a behavior the
-   product no longer has, or a `platformWaivers` entry for a runner that cannot
-   decide it.
-2. The maintainer-applied `bdd-floor-baseline` label on the pull request.
-
-Recording the reduction in the same PR that makes it is not an authorization. No
-check contacts CI or a tracker, so a merge can never depend on an external service
-being reachable.
+This used to also require a maintainer-applied `bdd-floor-baseline` PR label, on the
+reasoning that two artifacts one author cannot produce alone is the stronger
+guarantee. The label was dropped because it guarantees the wrong thing: it records
+that a second person clicked, not that the behavior is actually gone, and it stalls
+the case it was most needed for — retiring coverage for a feature the product
+genuinely no longer has. The record is the half that carries information, and it
+lands in the diff where it can be read and challenged. No check contacts CI or a
+tracker, so a merge can never depend on an external service being reachable.
 
 `obligation-uncovered` deliberately ignores gaps that predate the change: those are
 **burndown**, listed in the report's `gaps`, and demanding they close here is what
@@ -466,7 +467,6 @@ comes due is a quieter coverage gap.
 |---|---|
 | `BDD_MODE` | Adoption state. Unset means `not-adopted`; an unrecognized value exits 2. |
 | `BDD_BASE_SHA` | Base revision for the non-regression and deletion checks. **Required in enforced mode.** |
-| `BDD_PR_LABELS` | Comma-separated PR labels, for the `bdd-floor-baseline` authorization. |
 | `BDD_EXECUTION_RESULTS` | Comma-separated execution-result documents, same as repeated `--results`. |
 | `BDD_COVERAGE_ROOT` | Repo root override, for tests. |
 | `BDD_TODAY` | ISO date used for expiry evaluation, for tests and deterministic reruns. |

--- a/expo/copy-overwrite/scripts/bdd/baseline.mjs
+++ b/expo/copy-overwrite/scripts/bdd/baseline.mjs
@@ -41,9 +41,6 @@ const defect = (code, message) => ({ code, message });
 /** Defect / evidence code, named once. */
 const SCENARIO_DELETED = "scenario-deleted";
 
-/** The maintainer-applied PR label that authorizes giving coverage back. */
-export const BASELINE_LABEL = "bdd-floor-baseline";
-
 /**
  * Fixed absolute locations git is installed at, tried before anything on PATH.
  *
@@ -301,15 +298,23 @@ const RETIREMENT_FIELDS = ["reason", "ticket", "approvedBy", "recordedAt"];
 
 /**
  * Whether a scenario has been retired the way the contract requires: a
- * complete `retirements` record AND the maintainer-applied label. Either alone
- * is not an authorization — that is the whole point of asking for two
- * artifacts one author cannot produce by editing one file.
+ * COMPLETE `retirements` record.
+ *
+ * This used to also demand a maintainer-applied PR label, on the reasoning that
+ * two artifacts one author cannot produce alone is a stronger guarantee than
+ * one. The label was dropped because it guarantees the wrong thing: it verifies
+ * that a second person clicked, not that the behavior is actually gone, and it
+ * stalls the case it was most needed for — an agent retiring coverage for a
+ * feature the product genuinely no longer has.
+ *
+ * The record is the part that carries information. It still owes every field in
+ * {@link RETIREMENT_FIELDS}, is still refused when incomplete, and still lands
+ * in the diff where it can be read and challenged.
  * @param {object|undefined} record - The retirements entry, if any.
- * @param {readonly string[]} labels - PR labels.
- * @returns {boolean} True when the retirement is authorized and complete.
+ * @returns {boolean} True when the retirement is complete.
  */
-function isRetired(record, labels) {
-  if (!record || !labels.includes(BASELINE_LABEL)) return false;
+function isRetired(record) {
+  if (!record) return false;
   return RETIREMENT_FIELDS.every(field => Boolean(record[field]));
 }
 
@@ -324,15 +329,10 @@ function isRetired(record, labels) {
  * Keys whose scenario disappeared from the contract entirely are left to
  * {@link checkDeletions}, which names that act precisely; reporting both would
  * describe one deletion as two different failures.
- * @param {object} input - Baseline, head contract and scenarios, and PR labels.
+ * @param {object} input - Baseline, and head contract and scenarios.
  * @returns {object[]} Defects found.
  */
-export function checkCoverageRegression({
-  baseline,
-  contract,
-  scenarios,
-  labels,
-}) {
+export function checkCoverageRegression({ baseline, contract, scenarios }) {
   const before = acceptedKeys(baseline.scenarios, baseline.contract);
   const after = acceptedKeys(scenarios, contract);
   const present = new Set(scenarios.map(scenario => scenario.id));
@@ -343,42 +343,42 @@ export function checkCoverageRegression({
   return [...before]
     .filter(key => !after.has(key) && present.has(partsOf(key).scenario))
     .sort(byCodeUnit)
-    .flatMap(key => regressionDefect(key, { retired, waived, labels }));
+    .flatMap(key => regressionDefect(key, { retired, waived }));
 }
 
 /**
  * The defect for one obligation whose accepted coverage disappeared, or none
  * when it left the denominator through an authorized route.
  * @param {string} key - The `SCENARIO:platform` key.
- * @param {object} input - Retirement records, waived keys, and PR labels.
+ * @param {object} input - Retirement records and waived keys.
  * @returns {object[]} Zero or one defect.
  */
-function regressionDefect(key, { retired, waived, labels }) {
+function regressionDefect(key, { retired, waived }) {
   const { scenario, platform } = partsOf(key);
-  if (isRetired(retired.get(scenario), labels)) return [];
-  if (waived.has(key) && labels.includes(BASELINE_LABEL)) return [];
+  if (isRetired(retired.get(scenario))) return [];
+  if (waived.has(key)) return [];
   return [
     defect(
       "coverage-regression",
-      `${scenario}:${platform} was covered at the base revision and is not covered here. Coverage this repository already accepted cannot be handed back quietly. Restore the mapping, or take one of the two recorded routes out — a retirements record (${RETIREMENT_FIELDS.join(", ")}) for a behavior the product no longer has, or a platformWaivers entry for a runner that cannot decide it — and get the maintainer-applied "${BASELINE_LABEL}" label on this pull request. ${routeTaken(key, { retired, waived, labels })}`
+      `${scenario}:${platform} was covered at the base revision and is not covered here. Coverage this repository already accepted cannot be handed back quietly. Restore the mapping, or take one of the two recorded routes out — a retirements record (${RETIREMENT_FIELDS.join(", ")}) for a behavior the product no longer has, or a platformWaivers entry for a runner that cannot decide it. ${routeTaken(key, { retired })}`
     ),
   ];
 }
 
 /**
- * Say which half of the authorization is missing, so the operator is told what
- * to do rather than only what went wrong.
+ * Say what is missing from the authorization, so the operator is told what to
+ * do rather than only what went wrong.
+ *
+ * Only reached for a key that took NEITHER route: {@link regressionDefect}
+ * returns early for a waived one, so the waiver set cannot inform this
+ * sentence and is not passed.
  * @param {string} key - The `SCENARIO:platform` key.
- * @param {object} input - Retirement records, waived keys, labels, contract.
+ * @param {object} input - Retirement records.
  * @returns {string} A one-sentence next step.
  */
-function routeTaken(key, { retired, waived, labels }) {
+function routeTaken(key, { retired }) {
   const { scenario } = partsOf(key);
   const record = retired.get(scenario);
-  const authorized = labels.includes(BASELINE_LABEL);
-  if ((record || waived.has(key)) && !authorized) {
-    return `A record is present but the "${BASELINE_LABEL}" label is not: recording a reduction in the same pull request that makes it is not an authorization.`;
-  }
   if (record) {
     const missing = RETIREMENT_FIELDS.filter(field => !record[field]);
     return `Its retirements record is incomplete (no ${missing.join(", no ")}).`;
@@ -419,10 +419,10 @@ export function checkNewObligations({ baseline, contract, scenarios }) {
  * The contract's answer to a retired behavior is `@superseded`, which keeps
  * the audit trail. Deleting the scenario instead makes coverage look better
  * by describing less of the product.
- * @param {object} input - Base IDs, head scenarios, and the PR labels.
+ * @param {object} input - Base IDs and head scenarios.
  * @returns {object[]} Defects found.
  */
-export function checkDeletions({ baseIds, scenarios, contract, labels }) {
+export function checkDeletions({ baseIds, scenarios, contract }) {
   const present = new Set(scenarios.map(scenario => scenario.id));
   const retired = new Map(
     (contract.retirements ?? []).map(entry => [entry.scenario, entry])
@@ -430,22 +430,21 @@ export function checkDeletions({ baseIds, scenarios, contract, labels }) {
   return [...baseIds]
     .filter(id => !present.has(id))
     .sort(byCodeUnit)
-    .flatMap(id => deletionDefects(id, retired.get(id), labels));
+    .flatMap(id => deletionDefects(id, retired.get(id)));
 }
 
 /**
  * Defects for one deleted scenario.
  * @param {string} id - The scenario ID that disappeared.
  * @param {object|undefined} record - Its retirement record, if any.
- * @param {readonly string[]} labels - PR labels.
  * @returns {object[]} Defects found.
  */
-function deletionDefects(id, record, labels) {
+function deletionDefects(id, record) {
   if (!record) {
     return [
       defect(
         SCENARIO_DELETED,
-        `${id} was deleted from the contract. Retiring a behavior is @superseded, not deletion — deleting it shrinks the denominator instead of the gap. A genuine removal needs a retirements record and the "${BASELINE_LABEL}" label.`
+        `${id} was deleted from the contract. Retiring a behavior is @superseded, not deletion — deleting it shrinks the denominator instead of the gap. A genuine removal needs a complete retirements record (${RETIREMENT_FIELDS.join(", ")}).`
       ),
     ];
   }
@@ -453,13 +452,5 @@ function deletionDefects(id, record, labels) {
   const defects = missing.map(field =>
     defect(SCENARIO_DELETED, `${id}: retirements record has no ${field}`)
   );
-  if (!labels.includes(BASELINE_LABEL)) {
-    defects.push(
-      defect(
-        SCENARIO_DELETED,
-        `${id}: a retirement needs the maintainer-applied "${BASELINE_LABEL}" label`
-      )
-    );
-  }
   return defects;
 }

--- a/expo/copy-overwrite/scripts/bdd/render.mjs
+++ b/expo/copy-overwrite/scripts/bdd/render.mjs
@@ -208,7 +208,7 @@ ${executionSection(report)}
 
 ## Coverage floor
 
-The committed floor is an absolute bar — "is this platform below it right now" — and nothing else. It is **not** a ratchet and nobody has to nudge it upward: what protects coverage already earned is a separate, per-obligation check. Coverage accepted at the base revision cannot disappear, and behavior that is new must arrive mapped or waived; either reduction takes a recorded route (a \`retirements\` record or a \`platformWaivers\` entry) plus the maintainer-applied \`bdd-floor-baseline\` label — two artifacts one author cannot produce alone.
+The committed floor is an absolute bar — "is this platform below it right now" — and nothing else. It is **not** a ratchet and nobody has to nudge it upward: what protects coverage already earned is a separate, per-obligation check. Coverage accepted at the base revision cannot disappear, and behavior that is new must arrive mapped or waived; either reduction takes a recorded route — a complete \`retirements\` record or a \`platformWaivers\` entry — which lands in the diff where it can be read and challenged.
 
 ${floorTable(report)}
 

--- a/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
+++ b/expo/copy-overwrite/scripts/check-bdd-coverage.mjs
@@ -312,14 +312,12 @@ function validateAll({
       baseline,
       contract,
       scenarios,
-      labels: options.labels,
     }),
     ...checkNewObligations({ baseline, contract, scenarios }),
     ...checkDeletions({
       baseIds: baseline.scenarioIds,
       scenarios,
       contract,
-      labels: options.labels,
     }),
   ];
 }
@@ -679,10 +677,6 @@ export function parseArgs(argv, env) {
     report: argv.includes("--report"),
     resultFiles,
     baseSha: env.BDD_BASE_SHA || null,
-    labels: (env.BDD_PR_LABELS ?? "")
-      .split(",")
-      .map(item => item.trim())
-      .filter(Boolean),
     today: env.BDD_TODAY || new Date().toISOString().slice(0, 10),
   };
 }

--- a/plugins/lisa-copilot/rules/reference/bdd-e2e-coverage.md
+++ b/plugins/lisa-copilot/rules/reference/bdd-e2e-coverage.md
@@ -145,9 +145,9 @@ forces it upward, and lowering it needs no ceremony.
 
 What stops coverage sliding backwards is checked directly, per obligation, against the base
 revision — **an obligation that was mapped may not stop being mapped, and new behavior arrives
-mapped or waived**. Giving coverage back is legitimate but takes two artifacts one author cannot
-produce alone: a recorded route (a `retirements` record or a `platformWaivers` entry) plus the
-maintainer-applied `bdd-floor-baseline` label. Gaps that predate the change are burndown, never a
+mapped or waived**. Giving coverage back is legitimate but takes a recorded route: a complete `retirements`
+record (for a behavior the product no longer has) or a `platformWaivers` entry (for a runner
+that cannot decide it). Gaps that predate the change are burndown, never a
 gate failure — which is what lets a brownfield project adopt `enforced` without first backfilling
 its whole history.
 

--- a/plugins/lisa-cursor/rules/bdd-e2e-coverage-reference.mdc
+++ b/plugins/lisa-cursor/rules/bdd-e2e-coverage-reference.mdc
@@ -150,9 +150,9 @@ forces it upward, and lowering it needs no ceremony.
 
 What stops coverage sliding backwards is checked directly, per obligation, against the base
 revision — **an obligation that was mapped may not stop being mapped, and new behavior arrives
-mapped or waived**. Giving coverage back is legitimate but takes two artifacts one author cannot
-produce alone: a recorded route (a `retirements` record or a `platformWaivers` entry) plus the
-maintainer-applied `bdd-floor-baseline` label. Gaps that predate the change are burndown, never a
+mapped or waived**. Giving coverage back is legitimate but takes a recorded route: a complete `retirements`
+record (for a behavior the product no longer has) or a `platformWaivers` entry (for a runner
+that cannot decide it). Gaps that predate the change are burndown, never a
 gate failure — which is what lets a brownfield project adopt `enforced` without first backfilling
 its whole history.
 

--- a/plugins/lisa/rules/reference/bdd-e2e-coverage.md
+++ b/plugins/lisa/rules/reference/bdd-e2e-coverage.md
@@ -145,9 +145,9 @@ forces it upward, and lowering it needs no ceremony.
 
 What stops coverage sliding backwards is checked directly, per obligation, against the base
 revision — **an obligation that was mapped may not stop being mapped, and new behavior arrives
-mapped or waived**. Giving coverage back is legitimate but takes two artifacts one author cannot
-produce alone: a recorded route (a `retirements` record or a `platformWaivers` entry) plus the
-maintainer-applied `bdd-floor-baseline` label. Gaps that predate the change are burndown, never a
+mapped or waived**. Giving coverage back is legitimate but takes a recorded route: a complete `retirements`
+record (for a behavior the product no longer has) or a `platformWaivers` entry (for a runner
+that cannot decide it). Gaps that predate the change are burndown, never a
 gate failure — which is what lets a brownfield project adopt `enforced` without first backfilling
 its whole history.
 

--- a/plugins/src/base/rules/reference/bdd-e2e-coverage.md
+++ b/plugins/src/base/rules/reference/bdd-e2e-coverage.md
@@ -145,9 +145,9 @@ forces it upward, and lowering it needs no ceremony.
 
 What stops coverage sliding backwards is checked directly, per obligation, against the base
 revision — **an obligation that was mapped may not stop being mapped, and new behavior arrives
-mapped or waived**. Giving coverage back is legitimate but takes two artifacts one author cannot
-produce alone: a recorded route (a `retirements` record or a `platformWaivers` entry) plus the
-maintainer-applied `bdd-floor-baseline` label. Gaps that predate the change are burndown, never a
+mapped or waived**. Giving coverage back is legitimate but takes a recorded route: a complete `retirements`
+record (for a behavior the product no longer has) or a `platformWaivers` entry (for a runner
+that cannot decide it). Gaps that predate the change are burndown, never a
 gate failure — which is what lets a brownfield project adopt `enforced` without first backfilling
 its whole history.
 

--- a/src/core/lisa-owned-hash-ledger.ts
+++ b/src/core/lisa-owned-hash-ledger.ts
@@ -22,6 +22,8 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   ]),
   "scripts/bdd/baseline.mjs": Object.freeze([
     "12503dd325bbfe95f4f4f7fc9d8284d78210d0f54fa75c9af774b42f20495fe0",
+    "1cac6b75292fb71e31289763b11497edbadcf4bd086714080ceb2fbf00914fe0",
+    "454eed958d278f97f0af8a95183e67a47e9368713bd77b3e3673aa9e79f91447",
     "46623802056b8d66e7d07515bb3e990f448d7c5c1b40971a730bdeb0f63ba760",
     "630df2cbb6613534f755d3de1efbb6390a1c1dab5694d97f0ca09b8b7422881c",
     "77394187362d95043e448dd27f28afc115dfc6580330dd2338afa7b33de3d31e",
@@ -68,6 +70,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
     "bf64e239b4218bcb83f89e2b9ce1975b5b681450c3828ec0ade620de01a387b4",
     "c3cb36a6b3cf5771f5813cdd22f8273aa367c9de663ed1724c1fb3c59f2fbae9",
     "c900d5be3b4692bc7f2252f1461b0db987d300f99817ad83466428c530da4fce",
+    "e35475f7da84abb9c3ab2c55cfaa23c0dadd6e722d0086939bbcc69fafdf6232",
     "fa4f51fbb3a0517c4813c4a0dc9edde26d402efa115420cc251aaed7b5dfd5f3",
   ]),
   "scripts/bdd/report.mjs": Object.freeze([
@@ -92,6 +95,7 @@ export const LISA_OWNED_HASH_LEDGER: Readonly<
   "scripts/check-bdd-coverage.mjs": Object.freeze([
     "13db95d2ed8bce81acfb4fdfd9adb195a60818952393268f6a269dbaa6e62d66",
     "19cbbd7d368a99457212f2e1f9b37e6352cab6d459eb7dd11adb154f0c627c84",
+    "27ed82a1f76efd40dbdf5d817f263dcef0cd9d7920e90e711016f4b60a5b1e2f",
     "36eb042310a754b67b5e4cfcd35bfb8f8fbed132e51b7daf6128ce03d987ac87",
     "98fa86e5987e7384c7fd23baa435f86830fb432424134bb7d8141c005af9167b",
     "9ef2ef274602bf49ef5346b55ec95be575e3989e5c19e5c2b566d668ce0fd3ba",

--- a/src/core/upstream-evidence-manifest.ts
+++ b/src/core/upstream-evidence-manifest.ts
@@ -197,7 +197,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/scripts/bdd-matrix.mjs":
       "d5b4bddf925290c786564e00fb699a213446e736f1cb36e54c8d1e0d7fd79927",
     "expo/copy-overwrite/scripts/bdd/baseline.mjs":
-      "956ed9e1e456356293ed0aae55c13a27589fe84b6f4d4dc55513d735f9afb50e",
+      "454eed958d278f97f0af8a95183e67a47e9368713bd77b3e3673aa9e79f91447",
     "expo/copy-overwrite/scripts/bdd/contract.mjs":
       "0cbbc0801c6d5fddf030205b18bc6b4d133b0fac7abaf7af19072e8bc83e21ad",
     "expo/copy-overwrite/scripts/bdd/discover.mjs":
@@ -209,7 +209,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/scripts/bdd/parse.mjs":
       "46584d61812fb6684cc7a5fe4a2331d8fc486c0ed44f228b5049e2b1e6034fb8",
     "expo/copy-overwrite/scripts/bdd/render.mjs":
-      "bf64e239b4218bcb83f89e2b9ce1975b5b681450c3828ec0ade620de01a387b4",
+      "e35475f7da84abb9c3ab2c55cfaa23c0dadd6e722d0086939bbcc69fafdf6232",
     "expo/copy-overwrite/scripts/bdd/report.mjs":
       "41d9b085f9b593c77d9cd1be91d55cdff2440de233dcf8a6baac5574a68e1641",
     "expo/copy-overwrite/scripts/bdd/validate.mjs":
@@ -217,7 +217,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "expo/copy-overwrite/scripts/bdd/waivers.mjs":
       "4011bcc9643b93522d2082363a2e9de3309d92f82ec054d2988860bb7cd3d16c",
     "expo/copy-overwrite/scripts/check-bdd-coverage.mjs":
-      "ec556af49f46b02441e59da66b828fb3f2a0f03b6ef16130e43e6d31d119bf5d",
+      "27ed82a1f76efd40dbdf5d817f263dcef0cd9d7920e90e711016f4b60a5b1e2f",
     "expo/copy-overwrite/scripts/check-e2e-coverage.mjs":
       "35f39f64b3d4f58d1da91b16337312a8b25354059e02017a7df2d793efb2f0d3",
     "expo/copy-overwrite/scripts/classify-maestro-failures.mjs":
@@ -849,7 +849,7 @@ export const UPSTREAM_EVIDENCE_MANIFEST: Readonly<Record<string, string>> =
     "plugins/src/base/rules/reference/base-rules.md":
       "487ea1764c4b636ca4a33b78a90e925f028bb9a54182c0795cd1bbdc437a262d",
     "plugins/src/base/rules/reference/bdd-e2e-coverage.md":
-      "4ae48d6f54f8558a7aa9b6db24db3a619c9a669aece9a61ca9e58e2e2cf2f370",
+      "c4b2bd970145451ab9f95e21f2b48d42fa4dd14e8a5077664ff391e47e13d8a6",
     "plugins/src/base/rules/reference/claim-archaeology.md":
       "fff025d47848c768d5b2c7047de744b7151eb2e44148d2df058c87310859457b",
     "plugins/src/base/rules/reference/claim-evidence-mapping.md":

--- a/tests/unit/scripts/bdd-nonregression.test.ts
+++ b/tests/unit/scripts/bdd-nonregression.test.ts
@@ -16,7 +16,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   BASELINE,
-  BASELINE_LABEL,
   COVERAGE_REGRESSION,
   ENFORCED,
   OBLIGATION_UNCOVERED,
@@ -86,21 +85,7 @@ describe("coverage the repo already accepted cannot be given back", () => {
     expect(messages(run, COVERAGE_REGRESSION)[0]).toContain(EXTRA_KEY);
   });
 
-  it("REFUSES a waiver over a previously mapped obligation without the label", () => {
-    // Waiving what used to be mapped leaves traceability at 100% — the
-    // obligation left the denominator rather than being met. A number cannot
-    // tell that from real progress; a per-obligation check does not have to.
-    const { root, base } = twoScenarioProject({
-      mappings: HOME_ONLY_MAPPINGS,
-      platformWaivers: [EXTRA_WAIVER],
-    });
-    const run = runGate(root, { BDD_MODE: ENFORCED, BDD_BASE_SHA: base });
-    expect(messages(run, COVERAGE_REGRESSION)[0]).toContain(
-      "in the same pull request that makes it is not an authorization"
-    );
-  });
-
-  it("accepts that waiver once a maintainer applies the label", () => {
+  it("accepts a waiver over a previously mapped obligation", () => {
     const { root, base } = twoScenarioProject(
       { mappings: HOME_ONLY_MAPPINGS, platformWaivers: [EXTRA_WAIVER] },
       removeExtraSpec
@@ -108,13 +93,12 @@ describe("coverage the repo already accepted cannot be given back", () => {
     const run = runGate(root, {
       BDD_MODE: ENFORCED,
       BDD_BASE_SHA: base,
-      BDD_PR_LABELS: `other-label,${BASELINE_LABEL}`,
     });
     expect(messages(run, COVERAGE_REGRESSION)).toEqual([]);
     expect(run.status).toBe(0);
   });
 
-  it("REFUSES an incomplete retirement record even with the label", () => {
+  it("REFUSES an incomplete retirement record", () => {
     const { root, base } = twoScenarioProject({
       mappings: HOME_ONLY_MAPPINGS,
       retirements: [{ ...EXTRA_RETIREMENT, ticket: undefined }],
@@ -122,12 +106,11 @@ describe("coverage the repo already accepted cannot be given back", () => {
     const run = runGate(root, {
       BDD_MODE: ENFORCED,
       BDD_BASE_SHA: base,
-      BDD_PR_LABELS: BASELINE_LABEL,
     });
     expect(messages(run, COVERAGE_REGRESSION)[0]).toContain("no ticket");
   });
 
-  it("accepts a complete retirement carrying the label", () => {
+  it("accepts a complete retirement", () => {
     const { root, base } = twoScenarioProject(
       { mappings: HOME_ONLY_MAPPINGS, retirements: [EXTRA_RETIREMENT] },
       removeExtraSpec
@@ -135,7 +118,6 @@ describe("coverage the repo already accepted cannot be given back", () => {
     const run = runGate(root, {
       BDD_MODE: ENFORCED,
       BDD_BASE_SHA: base,
-      BDD_PR_LABELS: BASELINE_LABEL,
     });
     expect(messages(run, COVERAGE_REGRESSION)).toEqual([]);
   });
@@ -238,7 +220,6 @@ describe("scenario deletion", () => {
     const run = runGate(root, {
       BDD_MODE: ENFORCED,
       BDD_BASE_SHA: base,
-      BDD_PR_LABELS: BASELINE_LABEL,
     });
     expect(codes(run)).toContain(SCENARIO_DELETED);
   });
@@ -249,7 +230,6 @@ describe("scenario deletion", () => {
     const run = runGate(root, {
       BDD_MODE: ENFORCED,
       BDD_BASE_SHA: base,
-      BDD_PR_LABELS: BASELINE_LABEL,
     });
     expect(messages(run, SCENARIO_DELETED)).toEqual([]);
   });

--- a/tests/unit/scripts/bdd-ratchet-removal.test.ts
+++ b/tests/unit/scripts/bdd-ratchet-removal.test.ts
@@ -16,7 +16,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   BASELINE,
-  BASELINE_LABEL,
   COVERAGE_REGRESSION,
   ENFORCED,
   FLOOR_INVALID,
@@ -146,7 +145,6 @@ describe("nothing became easier to regress when the ratchet was deleted", () => 
     const run = runGate(root, {
       BDD_MODE: ENFORCED,
       BDD_BASE_SHA: base,
-      BDD_PR_LABELS: BASELINE_LABEL,
     });
     expect(messages(run, COVERAGE_REGRESSION)).toEqual([]);
     expect(codes(run)).toContain(FLOOR_REGRESSION);

--- a/tests/unit/scripts/bdd-wiring.test.ts
+++ b/tests/unit/scripts/bdd-wiring.test.ts
@@ -118,10 +118,9 @@ describe("shipped wiring", () => {
     expect(workflow).toContain("absence is a FAILURE, never a skip");
   });
 
-  it("gives the non-regression checks the history and PR context they need", () => {
+  it("gives the non-regression checks the history they need", () => {
     const workflow = read(QUALITY_REL);
     expect(workflow).toContain("BDD_BASE_SHA");
-    expect(workflow).toContain("BDD_PR_LABELS");
     const job = workflow.slice(workflow.indexOf(JOB));
     expect(job.slice(0, job.indexOf(NEXT_JOB))).toContain("fetch-depth: 0");
   });

--- a/tests/unit/scripts/bdd/support.ts
+++ b/tests/unit/scripts/bdd/support.ts
@@ -27,9 +27,6 @@ export const NOT_ADOPTED = "not-adopted";
 /** Fixed evaluation date, so expiry behavior is deterministic. */
 export const TODAY = "2026-08-12";
 
-/** The maintainer-applied authorization label. */
-export const BASELINE_LABEL = "bdd-floor-baseline";
-
 /** Fixture identifiers reused across cases. */
 export const HOME_ID = "BDD-HOME-001";
 export const WEB = "web";
@@ -353,7 +350,6 @@ export function runGate(
       BDD_TODAY: TODAY,
       BDD_MODE: "",
       BDD_BASE_SHA: "",
-      BDD_PR_LABELS: "",
       BDD_EXECUTION_RESULTS: "",
       ...env,
     },
@@ -387,7 +383,6 @@ export function runReport(
       BDD_TODAY: TODAY,
       BDD_MODE: "",
       BDD_BASE_SHA: "",
-      BDD_PR_LABELS: "",
       BDD_EXECUTION_RESULTS: "",
       ...env,
     },
@@ -413,7 +408,6 @@ export function runGateWrite(
       BDD_TODAY: TODAY,
       BDD_MODE: "",
       BDD_BASE_SHA: "",
-      BDD_PR_LABELS: "",
       BDD_EXECUTION_RESULTS: "",
       ...env,
     },

--- a/wiki/decisions/2026-08-12-ratchet-policy.md
+++ b/wiki/decisions/2026-08-12-ratchet-policy.md
@@ -17,6 +17,13 @@ This conflicts with shipped Lisa behavior. Lisa ships several ratchet families:
 - BDD `coverageFloor` plus a `coverageFloorBaseline` approval path (a floor may only
   be lowered with a record naming platform/from/to/reason/ticket/approvedBy/runUrl
   **and** a maintainer-applied `bdd-floor-baseline` PR label).
+
+  *Amended 2026-08-22 (PR_PLACEHOLDER):* the label requirement is removed; the
+  complete record is the whole authorization. The label attested that a second
+  person clicked, not that the behavior was gone, and it blocked the case it was
+  most needed for — an agent retiring coverage for a feature the product genuinely
+  no longer has, with no human in the loop to apply it. Record completeness is
+  still enforced and still refused when partial.
 - The `coverage` family in `threshold-ratchet-families.mjs` (`vitest`/`jest`
   thresholds, direction `min`).
 - Stryker `thresholds.break` and the mutate-list.


### PR DESCRIPTION
## What

Giving BDD coverage back required **two** artifacts: a complete `retirements` record (or a `platformWaivers` entry) **and** a maintainer-applied `bdd-floor-baseline` PR label. This drops the label half. A complete record now authorizes a reduction on its own.

## Why

The label guarantees the wrong thing. It attests that a second person clicked — not that the behavior being retired is actually gone. And it hard-blocks the case it was most needed for: retiring coverage for a feature the product genuinely no longer has, in an autonomous lane with no human standing by to apply a label. There the gate does not slow a bad reduction down; it stops a correct one entirely, leaving only "wait for a human" or "ship a permanently-red gate".

What is kept is the half that carries information. A `retirements` record still owes `reason`, `ticket`, `approvedBy` and `recordedAt`, is still refused when any field is missing, and still lands in the diff where it can be read and challenged. The reduction stays recorded, attributable and reviewable — it just no longer waits on a second click.

## Scope

Removed end to end, so no surface still states the old contract:

- `expo/copy-overwrite/scripts/bdd/baseline.mjs` — `BASELINE_LABEL` and its checks in `isRetired` / `regressionDefect` / `routeTaken` / `deletionDefects`, plus the `labels` plumbing that became dead with them. `routeTaken` also loses `waived`: `regressionDefect` returns early for a waived key, so it was unreachable there.
- `expo/copy-overwrite/scripts/check-bdd-coverage.mjs` — the `BDD_PR_LABELS` option.
- `.github/workflows/quality.yml` — the `BDD_PR_LABELS` env, and the wiring test that pinned it there.
- `plugins/src/base/rules/reference/bdd-e2e-coverage.md` (+ the three generated copies, via `build:plugins`), `docs/bdd-coverage-schema.md`, `expo/copy-overwrite/scripts/bdd/render.mjs`.
- `wiki/decisions/2026-08-12-ratchet-policy.md` — **amended in place** per its own `*Amended …*` convention, not rewritten. It is a dated record of what was decided then.

Two mentions of `bdd-floor-baseline` survive on purpose: the historical paragraph in the schema doc explaining why the label went, and the dated amendment. Both describe the past rather than assert the present.

## Tests

The suites that encoded the label contract are retargeted at the new one. The case asserting an **incomplete** record is still refused is kept unchanged — that is the protection being retained.

One test was deleted rather than rewritten: `REFUSES a waiver over a previously mapped obligation without the label` asserted precisely the behavior being removed, and its sibling (`accepts a waiver over a previously mapped obligation`) already covers the replacement contract.

- Negative-controlled: reverting `baseline.mjs` and `check-bdd-coverage.mjs` fails 5 of the updated tests.
- `bun run test:unit` — 14,062 passed, 0 failed.
- `bun run knip:check` — clean.

## Out of scope

Record completeness. `RETIREMENT_FIELDS` is unchanged.

Work-Item: CodySwannGT/lisa#2923
