### PR TITLE
fix(ci): tell the prover which tree to scan, not just where it lives

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -4477,9 +4477,22 @@ jobs:
         # consumer-only miss here, and why the proof lives in a consumer-shaped
         # fixture (tests/unit/config/conflict-prover-consumer-layouts.test.ts).
         #
-        # No --root. The prover anchors on the working directory, so the flag
-        # would be one more thing that can be dropped without the scan getting
-        # smaller in any visible way.
+        # `--root .` is NOT redundant, and the reasoning that said it was is
+        # what turned #2951's first fix into a silent pass. Today's prover
+        # defaults its root to the working directory; the prover in releases
+        # BEFORE the move derives it from its own file location. Resolved at
+        # `node_modules/@codyswann/lisa/scripts/`, that older prover walks the
+        # PACKAGE directory: `git ls-files` there succeeds and lists nothing,
+        # because node_modules is ignored. The gate then exits 0 reporting
+        # "no leftover conflict markers in 0 tracked files" — a clean report
+        # from a scan that never ran, which is exactly what the absent-prover
+        # branch above exists to refuse. Measured against the real published
+        # tarball: 0 files scanned without the flag, 5 scanned and 1 conflict
+        # caught with it. The prover's own header predicts this failure mode.
+        #
+        # The flag is a no-op on the current prover and a correction on the
+        # older one, so one invocation is right on both — which is the same
+        # both-layouts principle as the candidate list above.
         if: steps.gate.outputs.configured == 'false'
         run: |
           set -euo pipefail
@@ -4491,7 +4504,7 @@ jobs:
             echo "::error::No conflict-marker prover found. Searched four paths, none of which exist. Two are PACKAGE-relative, inside the installed package: node_modules/@codyswann/lisa/all/copy-overwrite/scripts/check-conflict-markers.mjs (current layout) and node_modules/@codyswann/lisa/scripts/check-conflict-markers.mjs (the layout of releases before the move). Two are HOST-relative, in your own tree: scripts/check-conflict-markers.mjs (the copy 'lisa apply' installs) and all/copy-overwrite/scripts/check-conflict-markers.mjs (Lisa's own checkout). A host-relative path never matches the packaged copy. Reinstall dependencies or run 'lisa apply'. Failing rather than reporting a clean scan that never ran."
             exit 1
           fi
-          node "$PROVER"
+          node "$PROVER" --root .
         working-directory: ${{ inputs.working_directory || '.' }}
 
   sg_scan:

--- a/tests/unit/config/conflict-prover-consumer-layouts.test.ts
+++ b/tests/unit/config/conflict-prover-consumer-layouts.test.ts
@@ -102,6 +102,27 @@ const HOST_RELATIVE_CANDIDATES = [
 /** What the prover prints when it has actually walked the tracked files. */
 const SCAN_RAN = "no leftover conflict markers in";
 
+/** What it prints when it walked the WRONG directory and found it empty. */
+const SCANNED_NOTHING = "no leftover conflict markers in 0 tracked files";
+
+/** A tracked file the scan must reach, planted at the project root. */
+const CONFLICTED_FILE = "residue.md";
+
+/**
+ * A complete, ordered conflict triple — what git actually writes.
+ *
+ * Assembled from repeated characters so this very file is not flagged by the
+ * gate it tests, the same way the prover's own suite does it.
+ */
+const CONFLICT_BLOCK = [
+  `${"<".repeat(7)} HEAD`,
+  "ours",
+  "=".repeat(7),
+  "theirs",
+  `${">".repeat(7)} branch`,
+  "",
+].join("\n");
+
 /** A minimal step shape, enough to find the one under test. */
 interface WorkflowStep {
   readonly name?: string;
@@ -133,14 +154,70 @@ function fallbackShell(): string {
 }
 
 /**
- * Write the prover (and the one module it imports) at a path in a tree.
+ * The prover's source, rewritten to anchor the way a PRE-MOVE release does.
+ *
+ * The whole functional delta between the released pre-move prover and today's
+ * is the default root: it was derived from the script's own location, and is
+ * now the current working directory. Reversing that one expression reproduces
+ * the shipped artifact without vendoring three hundred lines of it, and
+ * `assertLocationAnchored` below is the positive control that the reversal
+ * actually took — a fixture that silently stopped being pre-move would make
+ * every case using it vacuous.
+ * @returns The pre-move prover's source text
+ */
+function preMoveProverSource(): string {
+  const source = readFileSync(PROVER_SOURCE, "utf8");
+  const rewritten = source
+    .replace(
+      'import { execFileSync } from "node:child_process";',
+      'import { execFileSync } from "node:child_process";\nimport { fileURLToPath } from "node:url";'
+    )
+    .replace(
+      "path.resolve(root ?? process.cwd())",
+      'path.resolve(root ?? path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."))'
+    );
+  if (rewritten === source) {
+    throw new Error(
+      "the pre-move prover fixture no longer applies; the root default moved"
+    );
+  }
+  return rewritten;
+}
+
+/** How a release lays the prover out, and how that release's prover anchors. */
+interface Layout {
+  readonly label: string;
+  readonly candidate: string;
+  readonly source: () => string;
+}
+
+/** The layout a release predating the move ships. */
+const OLD_RELEASE: Layout = {
+  candidate: PACKAGED_OLD_LAYOUT,
+  label: "a release predating the layout move",
+  source: preMoveProverSource,
+};
+
+/** The layout a release carrying the move ships. */
+const NEW_RELEASE: Layout = {
+  candidate: PACKAGED_NEW_LAYOUT,
+  label: "a release carrying the layout move",
+  source: () => readFileSync(PROVER_SOURCE, "utf8"),
+};
+
+/** Both released package layouts a consumer can be sitting on today. */
+const RELEASES = [OLD_RELEASE, NEW_RELEASE] as const;
+
+/**
+ * Write a prover (and the one module it imports) at a path in a tree.
  * @param root - Absolute tree root
  * @param relative - Where the prover goes, relative to the root
+ * @param source - The prover source to write
  */
-function installProver(root: string, relative: string): void {
+function installProver(root: string, relative: string, source: string): void {
   const target = path.join(root, relative);
   mkdirSync(path.join(path.dirname(target), "lib"), { recursive: true });
-  copyFileSync(PROVER_SOURCE, target);
+  writeFileSync(target, source, "utf8");
   copyFileSync(
     PROVER_LIB,
     path.join(path.dirname(target), "lib", path.basename(PROVER_LIB))
@@ -153,10 +230,11 @@ function installProver(root: string, relative: string): void {
  *
  * `node_modules` is deliberately left untracked, exactly as a consumer has it,
  * which also keeps the prover's own `git ls-files` walk honest.
- * @param proverPath - Candidate path to install the prover at, or undefined
+ * @param layout - The released layout to install, or undefined for none
+ * @param conflicted - Whether to commit a file carrying a real conflict block
  * @returns The absolute tree root
  */
-function consumerTree(proverPath?: string): string {
+function consumerTree(layout?: Layout, conflicted = false): string {
   const root = mkdtempSync(path.join(tmpdir(), "lisa-2951-"));
   const env = cleanGitEnv(process.env);
   const git = (...args: readonly string[]): void => {
@@ -165,12 +243,17 @@ function consumerTree(proverPath?: string): string {
   roots.push(root);
   writeFileSync(path.join(root, "README.md"), "# a consumer\n", "utf8");
   writeFileSync(path.join(root, ".gitignore"), "node_modules/\n", "utf8");
+  if (conflicted) {
+    writeFileSync(path.join(root, CONFLICTED_FILE), CONFLICT_BLOCK, "utf8");
+  }
   git("init", "-q");
   git("config", "user.email", "test@example.com");
   git("config", "user.name", "Test");
   git("add", "-A");
   git("commit", "-q", "-m", "seed");
-  if (proverPath !== undefined) installProver(root, proverPath);
+  if (layout !== undefined) {
+    installProver(root, layout.candidate, layout.source());
+  }
   return root;
 }
 
@@ -212,10 +295,26 @@ describe("the fixtures are consumer-shaped, not Lisa-shaped", () => {
   it.each(HOST_RELATIVE_CANDIDATES)(
     "leaves %s absent, so a host-relative candidate cannot carry the pass",
     (candidate: string) => {
-      const root = consumerTree(PACKAGED_OLD_LAYOUT);
+      const root = consumerTree(OLD_RELEASE);
       expect(existsSync(path.join(root, candidate))).toBe(false);
     }
   );
+
+  it("builds a genuinely PRE-MOVE prover, which anchors on its own location", () => {
+    // The positive control for `preMoveProverSource`. Without it, a fixture
+    // that quietly reverted to today's cwd-anchored prover would make the
+    // root-anchoring cases below pass while proving nothing — the exact
+    // vacuous-pass shape this file exists to avoid.
+    const root = consumerTree(OLD_RELEASE, true);
+    const prover = path.join(root, OLD_RELEASE.candidate);
+    const result = spawnSync(process.execPath, [prover, "--json"], {
+      cwd: root,
+      encoding: "utf8",
+      timeout: 60_000,
+    });
+    const report = JSON.parse(result.stdout) as { root: string };
+    expect(path.basename(report.root)).toBe("lisa");
+  });
 
   it("resolves the host-relative candidate in THIS repository, which is why Lisa never caught it", () => {
     // Stated as an assertion rather than a comment: it is the reason the tests
@@ -232,14 +331,8 @@ describe("the fixtures are consumer-shaped, not Lisa-shaped", () => {
 });
 
 describe("conflict-residue fallback resolves the prover in a consumer tree", () => {
-  it("finds the packaged prover of a release predating the layout move", () => {
-    const { code, output } = runStep(consumerTree(PACKAGED_OLD_LAYOUT));
-    expect(output).toContain(SCAN_RAN);
-    expect(code).toBe(0);
-  });
-
-  it("finds the packaged prover of a release carrying the layout move", () => {
-    const { code, output } = runStep(consumerTree(PACKAGED_NEW_LAYOUT));
+  it.each(RELEASES)("finds the packaged prover of $label", (layout: Layout) => {
+    const { code, output } = runStep(consumerTree(layout));
     expect(output).toContain(SCAN_RAN);
     expect(code).toBe(0);
   });
@@ -260,10 +353,44 @@ describe("conflict-residue fallback resolves the prover in a consumer tree", () 
   });
 });
 
+describe("the resolved prover scans the PROJECT, not the package directory", () => {
+  // Resolving the file is half the job. A released prover that anchors on its
+  // own location, invoked from `node_modules/@codyswann/lisa/`, walks THAT
+  // directory: `git ls-files` there succeeds and lists nothing, because
+  // node_modules is ignored. The gate then exits 0 saying "0 tracked files" —
+  // a clean report from a scan that never ran, which is the precise thing the
+  // absent-prover branch above refuses to do. The prover's own header predicts
+  // this failure mode in as many words.
+  it.each(RELEASES)(
+    "catches a conflict block in the project under $label",
+    (layout: Layout) => {
+      const { code, output } = runStep(consumerTree(layout, true));
+      expect(output).toContain(CONFLICTED_FILE);
+      expect(code).toBe(1);
+    }
+  );
+
+  it.each(RELEASES)(
+    "reports a non-empty scan on a clean project under $label",
+    (layout: Layout) => {
+      const { code, output } = runStep(consumerTree(layout));
+      expect(output).not.toContain(SCANNED_NOTHING);
+      expect(code).toBe(0);
+    }
+  );
+});
+
 describe("the workflow's candidate list covers both packaged layouts", () => {
   it("searches the packaged prover of both the pre- and post-move layout", () => {
     const shell = fallbackShell();
     expect(shell).toContain(PACKAGED_OLD_LAYOUT);
     expect(shell).toContain(PACKAGED_NEW_LAYOUT);
+  });
+
+  it("tells the prover which tree to scan instead of trusting its default", () => {
+    // The default differs BETWEEN released layouts, so there is no single
+    // default the step can rely on. Naming the root is what makes one
+    // invocation correct on both.
+    expect(fallbackShell()).toContain('node "$PROVER" --root .');
   });
 });


### PR DESCRIPTION
## #2959 fixed resolution. It did not fix scanning.

Adding the packaged pre-move path made the `conflict-residue` fallback **find** the prover on a
consumer running a release from before the layout move. It then ran that prover in a way that scans
nothing:

```
✓ no leftover conflict markers in 0 tracked files
exit=0
```

**That tree contained a real conflict block.**

## Why

The prover in pre-move releases derives its root from **its own file location**. Today's derives it
from the **working directory** — and that change shipped in the same commit as the move, so it
exists only in post-move packages.

Resolved at `node_modules/@codyswann/lisa/scripts/`, the older prover walks the *package* directory.
`git ls-files` there succeeds and lists nothing, because node_modules is ignored. Green gate, zero
files examined.

This is **strictly worse than the red gate it replaced.** A clean report from a scan that never ran
is the one outcome this gate exists to refuse — #2951 singles that refusal out as the thing the
incident got right. #2959 converted a loud failure into a silent pass for exactly the consumers it
was meant to help. The prover's own header predicts this failure mode in as many words:

> the failure is silent in the worst direction — `git ls-files` inside a subdirectory succeeds and
> lists only what is under it, so the gate reports "no leftover conflict markers in 40 tracked
> files" having never looked at the project.

## The change

`node "$PROVER" --root .`

A no-op on the current prover, whose default already resolves to the same directory; a correction on
the older one. One invocation, right under both released layouts — the same both-layouts principle
as the candidate list. The comment claiming the flag was redundant is replaced by the measurement
that refutes it.

## Measured against the real published tarball

Not a fixture. `npm pack @codyswann/lisa` at the pre-move release, unpacked into a consumer tree
carrying one real conflict block, running the step's shell extracted verbatim from the workflow:

| workflow | files scanned | conflict found | exit |
| --- | --- | --- | --- |
| pre-#2959 | — prover never resolved — | — | 1 (loud, correct) |
| **on `main` today** | **0** | **no** | **0 (silent pass)** |
| this branch | 5 | yes, by name | 1 |

The published package really does ship the prover only at `scripts/`, confirming #2951's premise
directly rather than by inference.

## Test

The suite asserted resolution and never asserted scanning — the gap that let this through. Both
released layouts must now catch a planted conflict block and must not report an empty scan on a
clean tree.

The pre-move prover is reproduced by reversing the single expression that changed, rather than
vendoring three hundred lines of an old file. That is only safe with a **positive control**, so
there is one: a case asserting the derived prover genuinely anchors on its own location. Without it,
a fixture drifting back to today's prover would make every new case vacuous — the post-move layout
passes either way.

**Bite control:** reverting only the `--root .` hunk fails `catches a conflict block in the project
under 'a release predating the layout move'`, `reports a non-empty scan on a clean project under 'a
release predating the layout move'`, and `tells the prover which tree to scan instead of trusting
its default` — by name, with the first reporting the real-world string `0 tracked files`.

Work-Item: CodySwannGT/lisa#2951
